### PR TITLE
Disable Autocomplete on Enter.

### DIFF
--- a/electron/renderer/src/components/CodeCell/index.tsx
+++ b/electron/renderer/src/components/CodeCell/index.tsx
@@ -448,6 +448,7 @@ export const CodeCell: React.FC<CodeCellProps> = ({
             // Suggestions — kernel-backed completions (PLANNED_FEATURES §5)
             quickSuggestions: { other: true, comments: false, strings: false },
             suggestOnTriggerCharacters: true,
+            acceptSuggestionOnEnter: 'off',
             wordBasedSuggestions: 'off',
             parameterHints: { enabled: false },
 


### PR DESCRIPTION
disable the auto complete on enter to improve the user experence and make it more inline with standared editor keybinds. Fixes #101 
