### PR TITLE
kernel start race fix

### DIFF
--- a/electron/main/comm-router.ts
+++ b/electron/main/comm-router.ts
@@ -435,6 +435,11 @@ export class CommRouter {
     this.pending.clear();
   }
 
+  /** Return the current comm_id (for diagnostics). */
+  getCommId(): string | null {
+    return this.commId;
+  }
+
   /**
    * Reject all pending request promises and clear push handlers.
    *

--- a/electron/main/kernel-manager.ts
+++ b/electron/main/kernel-manager.ts
@@ -1093,6 +1093,22 @@ export class KernelManager extends EventEmitter {
   }
 
   /**
+   * Send a kernel_info_request and wait for the reply.
+   *
+   * Drains any stale replies from the shell socket in the process.
+   * Used to confirm the shell channel is responsive before sending
+   * comm messages.
+   *
+   * @param id - Kernel ID.
+   * @param timeoutMs - Maximum wait time (default 5 s).
+   */
+  async ping(id: string, timeoutMs = 5_000): Promise<void> {
+    const managed = this.kernels.get(id);
+    if (!managed) throw new Error(`Kernel not found: ${id}`);
+    await this.sendShellRequest(managed, "kernel_info_request", {}, timeoutMs);
+  }
+
+  /**
    * Send a shell-channel request and wait for the correlated shell reply.
    *
    * @param managed - Target running kernel.

--- a/electron/main/kernel-session.ts
+++ b/electron/main/kernel-session.ts
@@ -111,6 +111,14 @@ export async function initializeKernelSession(
     throw new Error(bootstrapResult.error);
   }
   await readyPromise;
+  // Ping the shell channel before sending pdv.init.  The bootstrap
+  // execute leaves unread kernel_info_reply / execute_reply frames in the
+  // DEALER socket's receive buffer.  Sending a kernel_info_request and
+  // reading the correlated reply drains those stale frames and confirms
+  // the kernel's shell thread is ready to accept the next message.
+  // Without this, pdv.init (a comm_msg) can be silently lost on the
+  // ROUTER socket under ipykernel ≥ 7.
+  await kernelManager.ping(kernelId);
   const workingDir = await projectManager.createWorkingDir();
   await commRouter.request(PDVMessageType.INIT, {
     working_dir: workingDir,


### PR DESCRIPTION
## Summary
- Fix intermittent `PDVCommTimeoutError: PDV request timed out: pdv.init` on kernel restart
- After bootstrap execution, unread reply frames (`kernel_info_reply`, `execute_reply`) accumulate in the ZMQ DEALER socket's receive buffer, which can cause the kernel's ROUTER socket to silently drop subsequent `comm_msg` frames under ipykernel 7
- Added `KernelManager.ping()` that sends a `kernel_info_request` round-trip before `pdv.init` to drain stale frames and confirm the shell thread is responsive

## Test plan
- [x] Start app, open a project, select a new environment — kernel starts without timeout
- [x] Repeat environment selection multiple times in succession — no hangs
- [x] Cold start (no prior kernel) still works normally
- [x] Kernel restart via Runtime menu works normally