### PR TITLE
Runtime selection UI fix

### DIFF
--- a/electron/main/environment-detector.ts
+++ b/electron/main/environment-detector.ts
@@ -222,9 +222,10 @@ export class EnvironmentDetector {
       }
     };
 
-    // 1. User-configured path.
+    // 1. User-configured path — infer the real kind so it gets the correct
+    //    badge and label instead of always showing "Configured *".
     if (configuredPath) {
-      const env = await _probeEnv(configuredPath, "configured");
+      const env = await _probeEnv(configuredPath, _inferKind(configuredPath));
       if (env) add(env);
     }
 
@@ -579,7 +580,7 @@ export class EnvironmentDetector {
   static async checkEnvironment(
     pythonPath: string
   ): Promise<EnvironmentInfo | null> {
-    const env = await _probeEnv(pythonPath, "configured");
+    const env = await _probeEnv(pythonPath, _inferKind(pythonPath));
     if (!env) return null;
     return EnvironmentDetector.enrichEnvironment(env);
   }
@@ -689,6 +690,32 @@ function _pythonInPrefix(prefix: string): string {
   return process.platform === "win32"
     ? path.join(prefix, "python.exe")
     : path.join(prefix, "bin", "python");
+}
+
+/**
+ * Infer the environment kind from a Python executable path by checking whether
+ * it lives inside a conda prefix, virtualenv, pyenv version directory, etc.
+ *
+ * Falls back to ``"configured"`` when no known layout matches.
+ *
+ * @param pythonPath - Absolute path to a Python executable.
+ * @returns The inferred {@link EnvironmentKind}.
+ */
+function _inferKind(pythonPath: string): EnvironmentKind {
+  const resolved = path.resolve(pythonPath);
+
+  // pyenv: ~/.pyenv/versions/<name>/bin/python
+  const pyenvRoot = path.join(os.homedir(), ".pyenv", "versions");
+  if (resolved.startsWith(pyenvRoot + path.sep)) return "pyenv";
+
+  // conda: check if the prefix contains conda-meta/
+  const prefix = path.dirname(path.dirname(resolved)); // strip bin/python
+  if (fs.existsSync(path.join(prefix, "conda-meta"))) return "conda";
+
+  // venv: check for pyvenv.cfg in the prefix
+  if (fs.existsSync(path.join(prefix, "pyvenv.cfg"))) return "venv";
+
+  return "configured";
 }
 
 /**

--- a/electron/renderer/src/components/EnvironmentSelector/index.tsx
+++ b/electron/renderer/src/components/EnvironmentSelector/index.tsx
@@ -46,6 +46,14 @@ const KIND_ICONS: Record<string, string> = {
   configured: '*',
 };
 
+const KIND_TOOLTIPS: Record<string, string> = {
+  conda: 'Conda environment',
+  venv: 'Virtual environment',
+  pyenv: 'pyenv environment',
+  system: 'System Python',
+  configured: 'Manually configured',
+};
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -279,7 +287,7 @@ export const EnvironmentSelector: React.FC<EnvironmentSelectorProps> = ({
             onClick={() => handleSelect(env)}
             type="button"
           >
-            <span className={`env-kind-badge env-kind-badge--${env.kind}`}>
+            <span className={`env-kind-badge env-kind-badge--${env.kind}`} title={KIND_TOOLTIPS[env.kind] ?? 'Unknown'}>
               {KIND_ICONS[env.kind] ?? '?'}
             </span>
             <span className="env-row-info">


### PR DESCRIPTION
fix: infer environment kind from filesystem instead of hardcoding "configured".

Both checkEnvironment() and detectEnvironments() hardcoded kind:"configured" when probing a Python path, causing conda/venv/pyenv environments to display as "Configured *" instead of their real type (e.g. "conda: env_name"). This happened on initial load (for the saved path) and whenever the user clicked an environment row to re-probe it. Added _inferKind() which checks filesystem markers (conda-meta/, pyvenv.cfg, ~/.pyenv/versions/) to classify correctly.

Also adds tooltips to the environment kind badges in the selector UI.

Closes #155