### PR TITLE
feat(modules): in-app module editing workflow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -160,7 +160,7 @@ All type strings are namespaced with `pdv.`. The convention is `pdv.<domain>.<ac
 | `pdv.project.load` | app → kernel | Instructs the kernel to load a project from a save directory. |
 | `pdv.project.loaded` | kernel → app | Sent after the tree is fully populated from a project load. No `in_reply_to` (push notification). |
 | `pdv.project.save` | app → kernel | Instructs the kernel to serialize the tree to the save directory. |
-| `pdv.project.save.response` | kernel → app | Confirms save completed, includes node count and checksum. |
+| `pdv.project.save.response` | kernel → app | Confirms save completed. Payload: `{ node_count, checksum, module_owned_files, module_manifests }`. `module_owned_files` lists every file-backed node that belongs to a `PDVModule` (see §5.9) so the main process can mirror working-dir edits into `<saveDir>/modules/<id>/<source_rel_path>`. `module_manifests` carries per-module metadata + module-root-relative node descriptors for writing `pdv-module.json` and `module-index.json` under each module dir. Both fields are empty arrays when the tree contains no `PDVModule` nodes. |
 
 #### Tree Messages
 
@@ -187,7 +187,7 @@ All type strings are namespaced with `pdv.`. The convention is `pdv.<domain>.<ac
 
 | Type | Direction | Description |
 |---|---|---|
-| `pdv.script.register` | app → kernel | Register a newly created script file as a node in the tree. |
+| `pdv.script.register` | app → kernel | Register a newly created script file as a node in the tree. Payload: `{ parent_path, name, relative_path, language?, module_id?, source_rel_path? }`. `source_rel_path` is set when the script lives inside a known module alias (workflow A/B, §5.13). |
 | `pdv.script.register.response` | kernel → app | Confirms registration. |
 | `pdv.script.params` | app → kernel | Extract `run()` function parameters from a script file. Payload: `{ tree_path }`. |
 | `pdv.script.params.response` | kernel → app | Returns `ScriptParameter[]` array built from the script's `run()` signature. |
@@ -203,11 +203,17 @@ All type strings are namespaced with `pdv.`. The convention is `pdv.<domain>.<ac
 
 | Type | Direction | Description |
 |---|---|---|
-| `pdv.module.register` | app → kernel | Register a `PDVModule` node at a tree path. Payload: `{ path, module_id, name, version, dependencies?, module_index? }`. When `module_index` is provided, child nodes (scripts, GUIs, namelists) are mounted from the index using the same two-pass logic as project load. |
+| `pdv.module.register` | app → kernel | Register a `PDVModule` node at a tree path. Payload: `{ path, module_id, name, version, dependencies?, module_index? }`. v4-only: if `module_index` is absent the kernel rejects the request. Child nodes (scripts, GUIs, namelists, libs) are mounted from the index using the same two-pass logic as project load, with each file-backed entry carrying its module-root-relative `source_rel_path` (see §5.13). |
 | `pdv.module.register.response` | kernel → app | Confirms module registration. |
-| `pdv.gui.register` | app → kernel | Register a `PDVGui` node at a tree path. Payload: `{ parent_path, name, relative_path, module_id }`. |
+| `pdv.module.create_empty` | app → kernel | Create a brand-new empty `PDVModule` with seeded `scripts` / `lib` / `plots` subtrees. Payload: `{ id, name, version, description?, language? }`. Used by workflow B (authoring a new module from scratch inside the app) — see the §5.9 and #140 workflow plan. |
+| `pdv.module.create_empty.response` | kernel → app | Confirms creation. Payload: `{ path }`. |
+| `pdv.module.update` | app → kernel | Patch mutable metadata on an existing `PDVModule`. Payload: `{ alias, name?, version?, description? }`. Omitted fields are left unchanged. `module_id` and `language` are immutable. |
+| `pdv.module.update.response` | kernel → app | Echoes the post-update metadata. |
+| `pdv.module.reload_libs` | app → kernel | Fired as a preflight before `script:run` on a module-owned script. Payload: `{ alias }`. Walks `sys.modules` and `importlib.reload()`s every module whose `__file__` sits under `<workdir>/<alias>/lib/` so edits to module libs take effect on the next run without restarting the kernel. Short-circuits when `alias` is not a `PDVModule`. |
+| `pdv.module.reload_libs.response` | kernel → app | Returns `{ reloaded: string[], errors: { [name]: string } }`. Per-module reload failures are captured rather than thrown so a broken lib surfaces at script-run time with a proper traceback. |
+| `pdv.gui.register` | app → kernel | Register a `PDVGui` node at a tree path. Payload: `{ parent_path, name, relative_path, module_id?, source_rel_path? }`. |
 | `pdv.gui.register.response` | kernel → app | Confirms GUI registration. |
-| `pdv.modules.setup` | app → kernel | Add lib file parent directories to `sys.path` and import entry points. Payload: `{ modules: [{ lib_paths: string[], entry_point?: string }] }`. Sent after module import and on kernel start/restart. |
+| `pdv.modules.setup` | app → kernel | Add lib file parent directories to `sys.path` and import entry points. Payload: `{ modules: [{ lib_paths: string[], lib_dir?: string, entry_point?: string }] }`. Sent after module import and on kernel start/restart. |
 | `pdv.modules.setup.response` | kernel → app | Confirms module setup with handler registry. |
 | `pdv.handler.invoke` | app → kernel | Dispatch a registered handler for a tree node. Payload: `{ path }`. |
 | `pdv.handler.invoke.response` | kernel → app | Returns handler dispatch result. |
@@ -220,7 +226,7 @@ All type strings are namespaced with `pdv.`. The convention is `pdv.<domain>.<ac
 | `pdv.namelist.read.response` | kernel → app | Parsed namelist data. |
 | `pdv.namelist.write` | app → kernel | Write structured data back to a `PDVNamelist` backing file. Payload: `{ tree_path, data }`. |
 | `pdv.namelist.write.response` | kernel → app | Confirms write success. |
-| `pdv.file.register` | app → kernel | Register a file-backed tree node (`PDVNamelist`, `PDVLib`, or `PDVFile`). Payload: `{ tree_path, filename, node_type, name?, module_id? }`. When `node_type` is `"lib"`, creates a `PDVLib` node. |
+| `pdv.file.register` | app → kernel | Register a file-backed tree node (`PDVNamelist`, `PDVLib`, or `PDVFile`). Payload: `{ tree_path, filename, node_type, name?, module_id?, source_rel_path? }`. When `node_type` is `"lib"`, creates a `PDVLib` node. `source_rel_path` is set by the module bind path and by `tree:createLib` / `tree:createScript` / `tree:createGui` when the target lives inside a known module alias; see §5.13. |
 | `pdv.file.register.response` | kernel → app | Confirms file registration with resulting path. |
 
 #### Progress Messages
@@ -611,18 +617,25 @@ Notes are created via `pdv.note.register` (app → kernel) which creates a `PDVN
 
 ### 5.9 PDVModule Class
 
-`PDVModule` is a subclass of `PDVTree` (i.e. a dict subclass). It represents an imported module in the tree. Because it inherits from `PDVTree`, it holds children naturally — a module's sub-nodes (GUI, scripts, namelists) are direct dict entries.
+`PDVModule` is a subclass of `PDVTree` (i.e. a dict subclass). It represents a module in the tree — either imported from the global store or authored in-session via workflow B (#140). Because it inherits from `PDVTree`, it holds children naturally — a module's sub-nodes (GUI, scripts, libs, namelists, plots) are direct dict entries.
 
 Attributes:
-- `module_id` (read-only): unique identifier string (e.g. `"n_pendulum"`)
-- `name` (read-only): human-readable display name (e.g. `"N-Pendulum"`)
-- `version` (read-only): semantic version string (e.g. `"2.0.0"`)
-- `gui` (read-write): optional reference to the child `PDVGui` node, or `None`
-- `dependencies` (read-only): list of dependency dicts (e.g. `[{"name": "numpy"}]`), or empty list
+- `module_id` (read-only): unique identifier string (e.g. `"n_pendulum"`). Immutable identity — changing it would require rebinding the subtree.
+- `name` (read-write): human-readable display name (e.g. `"N-Pendulum"`). Mutable via `pdv.module.update`.
+- `version` (read-write): semantic version string (e.g. `"2.0.0"`). Mutable via `pdv.module.update`.
+- `description` (read-write): longer human-readable description, or empty string. Persisted into `pdv-module.json` at save time.
+- `language` (read-only): kernel language (`"python"` or `"julia"`). Also persisted into `pdv-module.json`.
+- `gui` (read-write): optional reference to the child `PDVGui` node, or `None`.
+- `dependencies` (read-only): list of dependency dicts (e.g. `[{"name": "numpy"}]`), or empty list.
 
 `preview()` returns `"{name} v{version}"`.
 
-Created by the `pdv.module.register` handler, which receives `path`, `module_id`, `name`, `version`, optional `dependencies`, and optional `module_index` from the main process and inserts the `PDVModule` into the tree at the given path. If a `PDVModule` already exists at that path (e.g. from project load), the handler updates it in place to preserve existing children.
+Two creation paths:
+
+- `pdv.module.register` — used by the module bind path after the main process copies an imported module's v4 `module-index.json` entries into the working directory. Receives `path`, `module_id`, `name`, `version`, optional `dependencies`, and optional `module_index` and inserts the `PDVModule` into the tree at the given path. If a `PDVModule` already exists at that path (e.g. from project load), the handler updates it in place to preserve existing children.
+- `pdv.module.create_empty` — used by **workflow B** (authoring a new module from scratch inside the app). Takes `{ id, name, version, description?, language? }`, constructs a `PDVModule` at the top of the tree, and seeds it with three empty `PDVTree` children (`scripts`, `lib`, `plots`). Consumers then populate content via the existing `tree:createScript` / `tree:createLib` / `tree:createGui` handlers. The project-local module directory (`<saveDir>/modules/<id>/`) doesn't exist yet for in-session modules — it is created on first `project:save` via §5.13's save-time sync.
+
+Projects track in-session modules via an `origin: "in_session"` field on the `ProjectModuleImport` manifest entry, distinct from the default `"imported"` origin. On project load, in-session modules are rebound via the same v4 bind path used for imported modules — the `<saveDir>/modules/<id>/` directory functions as the authoritative source.
 
 ### 5.10 PDVGui Class
 
@@ -655,32 +668,48 @@ The namelist file is parsed and written by dedicated comm handlers (`pdv.namelis
 
 Attributes:
 - `relative_path` (inherited from `PDVFile`): path to the `.py` file relative to the working directory
+- `source_rel_path` (inherited from `PDVFile`): path relative to the owning module's root, e.g. `"lib/helpers.py"`. Set for module-owned libs; `None` for project-level libs. Used by §5.13's save-time sync.
 - `module_id` (read-only): the owning module's ID, or `None`
 
 `preview()` returns `"Library (<filename>)"`.
 
-**Module lib/ convention**: Module developers place importable `.py` files in `<module-root>/lib/`. When a module is imported into a project, the main process:
-1. Copies each `.py` file from the installed module's `lib/` directory into the working directory under `<alias>/lib/`.
-2. Registers each file as a `PDVLib` tree node via `pdv.file.register` (with `node_type: "lib"`).
-3. Sends `pdv.modules.setup` with `lib_paths` — the on-disk paths of the copied files. The kernel adds the parent directory of each path to `sys.path`.
+**Module lib/ convention**: Module developers place importable `.py` files in `<module-root>/lib/`. When a v4 module is imported into a project, the main process:
+1. Reads `module-index.json` and copies each `local_file`-backed entry (including libs under `lib/`) into the working directory under `<alias>/<relative_path>`.
+2. Sends `pdv.module.register` with the remapped `module_index` so the kernel reconstructs the subtree and creates `PDVLib` nodes via `load_tree_index`.
+3. Sends `pdv.modules.setup` with `lib_dir: "<workdir>/<alias>/lib"`. The kernel adds that directory to `sys.path` so scripts can `import helpers` etc.
 
-This design makes lib files visible and editable in the tree (users can modify libraries while working in PDV). It is forward-compatible with planned UUID-based file storage where each file gets its own directory — since `sys.path` is set per-file parent directory rather than per-module.
+In-session modules (workflow B) follow the same convention: `tree:createLib` writes new `.py` files under `<workdir>/<alias>/lib/`, sets `source_rel_path = "lib/<filename>"`, and §7's `pdv-module.json` writer stamps `lib_dir: "lib"` so the next project load's `setupModuleNamespaces` injects the path automatically.
 
-On project load (deserialization), the `lib` node type is restored as a `PDVLib` and its parent directory is re-added to `sys.path`.
+**Live lib reload**: Before every `script:run` on a module-owned script, the main process fires a `pdv.module.reload_libs` preflight (§3.4). The kernel walks `sys.modules`, finds modules whose `__file__` sits under `<workdir>/<alias>/lib/`, and `importlib.reload()`s them so edits take effect without restarting the kernel. Reload failures are captured per-module and never block the script run itself — broken libs surface at import time inside the user's own traceback. The handler uses `os.path.realpath` on both sides of the prefix comparison so macOS's `/var` → `/private/var` symlink doesn't defeat the path match.
+
+On project load (deserialization), the `lib` node type is restored as a `PDVLib` and its `source_rel_path` is re-injected from the stored descriptor.
 
 ### 5.13 Module Storage and Resolution
 
 PDV has three tiers of module storage:
 
-1. **Project-local** (`<saveDir>/modules/<module-id>/`): When a module is imported into a project, its full content is copied into the project's save directory. This makes projects fully portable — zip a project folder and send it to someone who has never seen the module.
-2. **Global store** (`~/.PDV/modules/packages/`): A catalog of installed modules. Modules can be installed from local directories or GitHub URLs. The global store determines what is available to import, but projects never read from it at runtime.
+1. **Project-local** (`<saveDir>/modules/<module-id>/`): Every module — imported or in-session — has an authoritative copy here. On import, the main process copies the installed module's content into this directory. For in-session modules (workflow B) the directory is created on first `project:save` by §7's manifest writer. This makes projects fully portable — zip a project folder and send it to someone who has never seen the module.
+2. **Global store** (`~/.PDV/modules/packages/`): A catalog of installed modules. Modules can be installed from local directories, GitHub URLs, or **exported back from an active project** via `modules:exportFromProject` (workflow A/B §9). The global store determines what is available to import, but projects never read from it at runtime.
 3. **Bundled examples** (`examples/modules/` in the app resources): Read-only example modules shipped with the application (e.g. N-Pendulum for Python and Julia). Surfaced in the module library with a "Bundled" badge, filtered by active kernel language. Cannot be uninstalled.
 
+**v4-only**: As of the #140 module editing workflow pass, the legacy (v1/v2/v3) module bind paths are gone. Every module must ship a `module-index.json`; attempts to import non-v4 modules fail with a clear error and a prompt to reinstall from an updated source. Bundled example modules were updated to v4 before the legacy removal.
+
 **Resolution order**: When the main process needs to resolve a module's on-disk directory, it checks project-local `modules/` first, then the global store, then bundled examples. The first match wins.
+
+**`source_rel_path`**: Every module-owned `PDVFile` node (script, lib, gui, namelist) carries a `source_rel_path` attribute recording its location relative to the module root (e.g. `"scripts/run.py"`, `"lib/helpers.py"`). The field is:
+- Set at bind time by the v4 `bindImportedModule` remap loop for imported modules.
+- Set by `tree:createScript` / `tree:createLib` / `tree:createGui` when the target is inside a known module alias.
+- Round-tripped through `tree-index.json` (for project-level save/load) and `module-index.json` (for module-level save/load and export).
+- Consumed by §7's save-time sync (below) to know where each file belongs inside `<saveDir>/modules/<id>/`.
+
+**Save-time sync** (ARCHITECTURE §8.1 step 4): After `_collect_nodes` writes each node's data files into `<saveDir>/tree/`, the kernel's `project:save` handler also emits a `module_owned_files` list. The main process iterates this list and `fs.copyFile`s each entry from the working-dir location to `<saveDir>/modules/<module_id>/<source_rel_path>`, overwriting whatever was there. This is how edits (whether made via the external editor on an imported module's scripts, or via `tree:create*` for authored content on an in-session module) end up mirrored into the project-local copy so they survive a save → reopen cycle. Deletion propagation is tracked under #182.
+
+**Per-module manifest writer**: At the tail of `project:save`, the main process also writes `pdv-module.json` (v4 schema) and `module-index.json` into each `<saveDir>/modules/<id>/` directory, built from the `module_manifests` payload the kernel emits. The manifest carries `id`, `name`, `version`, `description`, `language`, and `lib_dir: "lib"`; the index carries module-root-relative node descriptors so a fresh `bindImportedModule` at project-load time can re-prefix them with the chosen alias. This is what makes in-session modules (workflow B) reloadable at all.
 
 **Installation sources**: Modules can be installed from:
 - **Local directory**: User selects a directory containing a `pdv-module.json` manifest.
 - **GitHub URL**: User pastes a git-cloneable URL. The module is shallow-cloned (`git clone --depth 1`) into the global store.
+- **Export from active project**: `modules:exportFromProject` copies `<activeProjectDir>/modules/<id>/` to `~/.PDV/modules/packages/<id>/`, prompting to overwrite when a global-store entry already exists. Used by workflow A (publish edits to an imported module) and workflow B (publish a newly-authored module). A TODO(#182) in the handler tracks the follow-up "commit and push to upstream GitHub" flow for modules with an `upstream` URL.
 
 **`upstream` field**: An optional git-cloneable URL in `pdv-module.json`. Automatically set when installing from GitHub, or declared manually. Enables update checks via `git ls-remote --tags` (no clone needed) and one-click re-install from upstream.
 
@@ -726,12 +755,17 @@ A persistent, user-chosen directory that stores a complete saved snapshot of a P
 my-project/
     project.json              ← project manifest (owned by Electron main process)
     tree-index.json           ← tree node registry (owned by kernel, written at save time)
-    code-cells.json        ← code cell tab state (owned by Electron main process)
+    code-cells.json           ← code cell tab state (owned by Electron main process)
     modules/                  ← project-local module copies (one subdir per module_id)
         n_pendulum/
-            pdv-module.json
+            pdv-module.json       ← v4 manifest (written by main process, §5.13)
+            module-index.json     ← module-root-relative node descriptors
             scripts/
+                solve.py
+                animate.py
             lib/
+                n_pendulum.py
+            gui.json
     tree/
         data/
             waveforms/
@@ -743,6 +777,8 @@ my-project/
         results/
             fit_output.parquet
 ```
+
+Each `modules/<id>/` subdirectory is maintained authoritatively by `project:save`: §5.13's save-time sync copies edited files from the working directory into it, then the manifest writer stamps `pdv-module.json` and `module-index.json` from the current in-memory `PDVModule` state. In-session modules (workflow B, origin `"in_session"` in the manifest) get their directory created on first save; imported modules get it at import time and updated on every subsequent save.
 
 **`project.json` schema**:
 ```json
@@ -777,7 +813,7 @@ my-project/
 | `language` | string | Kernel language: `"python"` or `"julia"`. |
 | `interpreter_path` | string? | Optional path to the interpreter used at save time. |
 | `tree_checksum` | string | SHA-256 checksum of `tree-index.json` for integrity verification. |
-| `modules` | array | Imported modules active in this project. Each entry has `module_id`, `alias`, `version`, and optional `revision`. |
+| `modules` | array | Modules active in this project. Each entry has `module_id`, `alias`, `version`, optional `revision`, and optional `origin` (`"imported"` default, or `"in_session"` for modules authored via workflow B — see §5.9). |
 | `module_settings` | object | Persisted per-module user settings keyed by module alias. |
 
 `tree-index.json` and `code-cells.json` are always stored alongside `project.json` with those exact filenames (not configurable).
@@ -1098,19 +1134,41 @@ User triggers save
     ├─► Kernel:
     │       1. Serializes all tree nodes to the save directory
     │          (data files + scripts, mirroring tree hierarchy)
-    │       2. Writes tree-index.json
-    │       3. Responds with pdv.project.save.response:
-    │              payload: { node_count: N, checksum: "<sha256 of tree-index.json>" }
+    │       2. Writes tree-index.json (with `source_rel_path` on every
+    │          module-owned PDVFile so load can re-inject it)
+    │       3. Walks the tree collecting module_owned_files (every
+    │          file-backed node under a PDVModule with source_rel_path)
+    │          and module_manifests (per-module metadata + module-root-
+    │          relative node descriptors for pdv-module.json /
+    │          module-index.json writing)
+    │       4. Responds with pdv.project.save.response:
+    │              payload: {
+    │                node_count, checksum,
+    │                module_owned_files, module_manifests,
+    │              }
     │
     ├─► App writes code-cells.json to save directory
     │
+    ├─► App syncs module-owned file contents from the working dir
+    │       into <saveDir>/modules/<id>/<source_rel_path> (§5.13).
+    │       Missing source files are swallowed (ENOENT logged, not
+    │       thrown) so a mid-save deletion doesn't abort the save.
+    │
+    ├─► App stamps pdv-module.json + module-index.json into each
+    │       <saveDir>/modules/<id>/ from module_manifests (§7). This
+    │       makes in-session modules reloadable on the next project
+    │       load via the same v4 bind path used for imported modules.
+    │
     ├─► App writes project.json to save directory
-    │       (only after both kernel and app state are flushed)
+    │       (only after kernel serialization, code-cells, module sync,
+    │        and manifest writing have all flushed)
     │
     └─► App updates title bar: "My Experiment"
 ```
 
 If the kernel responds with `status: "error"`, the app aborts the save, does not write `project.json`, and displays the error message to the user.
+
+The module-owned file sync and the per-module manifest writer are both best-effort: errors are logged but never thrown, because by the time they run the kernel-side serialization (the authoritative part) has already succeeded and aborting would leave the save dir in a confusing half-saved state. A follow-up pass (#182) will move deletion propagation and overall robustness into the same lock.
 
 ### 8.2 Load Sequence
 

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -9,6 +9,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserWindow } from "electron";
 import os from "os";
+import path from "path";
 
 import { registerIpcHandlers, registerCommPushForwarding, unregisterIpcHandlers } from "./index";
 import {
@@ -63,7 +64,9 @@ const mocks = vi.hoisted(() => {
     throw err;
   });
   const fsCopyFile = vi.fn(async () => undefined);
+  const fsCp = vi.fn(async () => undefined);
   const dialogShowOpenDialog = vi.fn();
+  const dialogShowMessageBox = vi.fn(async () => ({ response: 0 }));
   const shellOpenPath = vi.fn(async () => "");
   const moduleManagerListInstalled = vi.fn(async () => []);
   const moduleManagerInstall = vi.fn(async () => ({
@@ -99,11 +102,18 @@ const mocks = vi.hoisted(() => {
     gui: undefined,
   }));
   const moduleManagerGetModuleInstallPath = vi.fn(async () => null);
+  const moduleManagerGetGlobalStorePath = vi.fn((moduleId: string) => `/tmp/pdv-global/modules/packages/${moduleId}`);
+  const moduleManagerRegisterInGlobalStore = vi.fn(async (moduleDir: string) => ({
+    id: "toy",
+    name: "Toy",
+    version: "0.1.0",
+    source: { type: "local" as const, location: moduleDir },
+    installPath: moduleDir,
+  }));
   const moduleManagerGetModuleSetupInfo = vi.fn(async () => ({
     entryPoint: undefined,
   }));
-  const moduleManagerResolveModuleFiles = vi.fn(async () => []);
-  const moduleManagerIsV4Module = vi.fn(async () => false);
+  const moduleManagerIsV4Module = vi.fn(async () => true);
   const moduleManagerReadModuleIndex = vi.fn(async () => []);
   const moduleManagerGetModuleDependencies = vi.fn(async () => []);
   const moduleManagerResolveModuleDir = vi.fn(async () => null);
@@ -120,7 +130,9 @@ const mocks = vi.hoisted(() => {
     fsWriteFile,
     fsReadFile,
     fsCopyFile,
+    fsCp,
     dialogShowOpenDialog,
+    dialogShowMessageBox,
     shellOpenPath,
     moduleManagerListInstalled,
     moduleManagerInstall,
@@ -130,8 +142,9 @@ const mocks = vi.hoisted(() => {
     moduleManagerGetModuleInputs,
     moduleManagerGetModuleGuiInfo,
     moduleManagerGetModuleInstallPath,
+    moduleManagerGetGlobalStorePath,
+    moduleManagerRegisterInGlobalStore,
     moduleManagerGetModuleSetupInfo,
-    moduleManagerResolveModuleFiles,
     moduleManagerIsV4Module,
     moduleManagerReadModuleIndex,
     moduleManagerGetModuleDependencies,
@@ -148,6 +161,7 @@ vi.mock("electron", () => ({
   },
   dialog: {
     showOpenDialog: mocks.dialogShowOpenDialog,
+    showMessageBox: mocks.dialogShowMessageBox,
   },
   shell: {
     openPath: mocks.shellOpenPath,
@@ -169,6 +183,7 @@ vi.mock("fs/promises", () => ({
   writeFile: mocks.fsWriteFile,
   readFile: mocks.fsReadFile,
   copyFile: mocks.fsCopyFile,
+  cp: mocks.fsCp,
 }));
 
 vi.mock("./module-manager", () => ({
@@ -181,8 +196,9 @@ vi.mock("./module-manager", () => ({
     getModuleInputs: mocks.moduleManagerGetModuleInputs,
     getModuleGuiInfo: mocks.moduleManagerGetModuleGuiInfo,
     getModuleInstallPath: mocks.moduleManagerGetModuleInstallPath,
+    getGlobalStorePath: mocks.moduleManagerGetGlobalStorePath,
+    registerInGlobalStore: mocks.moduleManagerRegisterInGlobalStore,
     getModuleSetupInfo: mocks.moduleManagerGetModuleSetupInfo,
-    resolveModuleFiles: mocks.moduleManagerResolveModuleFiles,
     isV4Module: mocks.moduleManagerIsV4Module,
     readModuleIndex: mocks.moduleManagerReadModuleIndex,
     getModuleDependencies: mocks.moduleManagerGetModuleDependencies,
@@ -280,7 +296,12 @@ function setup() {
   } as unknown as CommRouter;
 
   const projectManager = {
-    save: vi.fn(async () => ({ checksum: "abc123", nodeCount: 0 })),
+    save: vi.fn(async () => ({
+      checksum: "abc123",
+      nodeCount: 0,
+      moduleOwnedFiles: [],
+      moduleManifests: [],
+    })),
     load: vi.fn(async (_saveDir: string, onBeforePush?: () => Promise<void>) => {
       if (onBeforePush) await onBeforePush();
       return [];
@@ -642,6 +663,72 @@ describe("Step 5 IPC handlers", () => {
     expect(result).toBe(true);
   });
 
+  it("script:run fires pdv.module.reload_libs preflight for module-owned scripts", async () => {
+    const { kernelManager, commRouter } = setup();
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: { reloaded: [], errors: {} },
+    });
+
+    const run = getHandler(IPC.script.run);
+    await run({}, "kernel-1", {
+      treePath: "n_pendulum.scripts.solve",
+      params: {},
+      executionId: "exec-reload-1",
+      origin: "test",
+    });
+
+    expect(commRouter.request).toHaveBeenCalledWith(
+      PDVMessageType.MODULE_RELOAD_LIBS,
+      { alias: "n_pendulum" },
+    );
+    expect(kernelManager.execute).toHaveBeenCalled();
+  });
+
+  it("script:run skips reload_libs preflight for non-nested scripts", async () => {
+    const { commRouter } = setup();
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: { result: null },
+    });
+
+    const run = getHandler(IPC.script.run);
+    await run({}, "kernel-1", {
+      treePath: "my_script",
+      params: {},
+      executionId: "exec-reload-2",
+      origin: "test",
+    });
+
+    const calls = (commRouter.request as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const reloadCalls = calls.filter((c: unknown[]) => c[0] === PDVMessageType.MODULE_RELOAD_LIBS);
+    expect(reloadCalls).toHaveLength(0);
+  });
+
+  it("script:run swallows reload_libs errors and still runs the script", async () => {
+    const { kernelManager, commRouter } = setup();
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (type: string) => {
+        if (type === PDVMessageType.MODULE_RELOAD_LIBS) {
+          throw new Error("reload exploded");
+        }
+        return { payload: {} };
+      }
+    );
+
+    const run = getHandler(IPC.script.run);
+    await expect(
+      run({}, "kernel-1", {
+        treePath: "n_pendulum.scripts.solve",
+        params: {},
+        executionId: "exec-reload-3",
+        origin: "test",
+      })
+    ).resolves.toBeDefined();
+    expect(kernelManager.execute).toHaveBeenCalled();
+  });
+
   it("kernels:execute delegates to KernelManager.execute", async () => {
     const { kernelManager } = setup();
     const execute = getHandler(IPC.kernels.execute);
@@ -762,6 +849,92 @@ describe("Step 5 IPC handlers", () => {
     expect(result.scriptPath).toBeTruthy();
   });
 
+  it("tree:createScript inside a module subtree sets source_rel_path + module_id", async () => {
+    const { commRouter } = setup();
+    const start = getHandler(IPC.kernels.start);
+    await start({}, { language: "python" });
+    // Register a pending in-session module so the handler's
+    // getKnownModuleAliases helper sees "toy" as a known alias.
+    await (getHandler(IPC.modules.createEmpty) as unknown as (
+      e: Record<string, never>,
+      req: { id: string; name: string; version: string },
+    ) => Promise<unknown>)({}, { id: "toy", name: "Toy", version: "0.1.0" });
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeMessage({})
+    );
+
+    const createScript = getHandler(IPC.tree.createScript);
+    await createScript({}, "kernel-1", "toy.scripts", "hello");
+
+    const scriptRegisterCalls = (commRouter.request as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c: unknown[]) => c[0] === PDVMessageType.SCRIPT_REGISTER);
+    expect(scriptRegisterCalls.length).toBeGreaterThanOrEqual(1);
+    const payload = scriptRegisterCalls[scriptRegisterCalls.length - 1][1];
+    expect(payload).toEqual(
+      expect.objectContaining({
+        parent_path: "toy.scripts",
+        name: "hello",
+        module_id: "toy",
+        source_rel_path: "scripts/hello.py",
+        relative_path: expect.stringMatching(/toy\/scripts\/hello\.py$/),
+      }),
+    );
+  });
+
+  it("tree:createLib writes a .py lib inside a module and registers with source_rel_path", async () => {
+    const { commRouter } = setup();
+    const start = getHandler(IPC.kernels.start);
+    await start({}, { language: "python" });
+    await (getHandler(IPC.modules.createEmpty) as unknown as (
+      e: Record<string, never>,
+      req: { id: string; name: string; version: string },
+    ) => Promise<unknown>)({}, { id: "toy", name: "Toy", version: "0.1.0" });
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeMessage({})
+    );
+
+    const createLib = getHandler(IPC.tree.createLib);
+    const result = (await createLib({}, "kernel-1", "toy.lib", "helpers")) as {
+      success: boolean;
+      libPath?: string;
+      treePath?: string;
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.libPath).toMatch(/toy\/lib\/helpers\.py$/);
+    expect(result.treePath).toBe("toy.lib.helpers");
+
+    const fileRegisterCalls = (commRouter.request as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c: unknown[]) => c[0] === PDVMessageType.FILE_REGISTER);
+    expect(fileRegisterCalls.length).toBeGreaterThanOrEqual(1);
+    const payload = fileRegisterCalls[fileRegisterCalls.length - 1][1];
+    expect(payload).toEqual(
+      expect.objectContaining({
+        tree_path: "toy.lib",
+        filename: "helpers.py",
+        node_type: "lib",
+        module_id: "toy",
+        source_rel_path: "lib/helpers.py",
+      }),
+    );
+  });
+
+  it("tree:createLib rejects targets that are not inside a known module", async () => {
+    setup();
+    const start = getHandler(IPC.kernels.start);
+    await start({}, { language: "python" });
+
+    const createLib = getHandler(IPC.tree.createLib);
+    const result = (await createLib({}, "kernel-1", "free_floating", "helpers")) as {
+      success: boolean;
+      error?: string;
+    };
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("must live inside a known module");
+  });
+
   it("tree:createNote sends correct payload to kernel and returns notePath", async () => {
     const { commRouter } = setup();
     (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
@@ -828,6 +1001,106 @@ describe("Step 5 IPC handlers", () => {
       interpreterPath: undefined,
     });
     expect(result).toEqual({ checksum: "abc123", nodeCount: 0 });
+  });
+
+  it("project:save mirrors module-owned files into saveDir/modules/<id>/<source_rel_path>", async () => {
+    const { projectManager } = setup();
+    (projectManager.save as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      checksum: "abc123",
+      nodeCount: 1,
+      moduleOwnedFiles: [
+        {
+          module_id: "my_mod",
+          source_rel_path: "scripts/run.py",
+          workdir_path: "/tmp/pdv-test/my_mod/scripts/run.py",
+        },
+        {
+          module_id: "my_mod",
+          source_rel_path: "lib/helpers.py",
+          workdir_path: "/tmp/pdv-test/my_mod/lib/helpers.py",
+        },
+      ],
+    });
+    const save = getHandler(IPC.project.save);
+    await save({}, "/tmp/project", []);
+
+    const scriptsDest = path.join("/tmp/project", "modules", "my_mod", "scripts/run.py");
+    const libDest = path.join("/tmp/project", "modules", "my_mod", "lib/helpers.py");
+    expect(mocks.fsMkdir).toHaveBeenCalledWith(path.dirname(scriptsDest), { recursive: true });
+    expect(mocks.fsMkdir).toHaveBeenCalledWith(path.dirname(libDest), { recursive: true });
+    expect(mocks.fsCopyFile).toHaveBeenCalledWith(
+      path.resolve("/tmp/pdv-test/my_mod/scripts/run.py"),
+      path.resolve(scriptsDest),
+    );
+    expect(mocks.fsCopyFile).toHaveBeenCalledWith(
+      path.resolve("/tmp/pdv-test/my_mod/lib/helpers.py"),
+      path.resolve(libDest),
+    );
+  });
+
+  it("project:save writes pdv-module.json + module-index.json per module", async () => {
+    const { projectManager } = setup();
+    (projectManager.save as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      checksum: "abc",
+      nodeCount: 5,
+      moduleOwnedFiles: [],
+      moduleManifests: [
+        {
+          module_id: "toy",
+          name: "Toy",
+          version: "0.1.0",
+          description: "smoke",
+          language: "python",
+          entries: [
+            {
+              id: "scripts",
+              path: "scripts",
+              key: "scripts",
+              parent_path: "",
+              type: "folder",
+              storage: { backend: "none", format: "none" },
+              metadata: { preview: "folder" },
+            },
+          ],
+        },
+      ],
+    });
+    const save = getHandler(IPC.project.save);
+    await save({}, "/tmp/project", []);
+
+    const manifestWrites = (mocks.fsWriteFile as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c: unknown[]) => String(c[0]).includes("modules/toy/"));
+    const paths = manifestWrites.map((c) => String((c as unknown[])[0]));
+    expect(paths.some((p) => p.endsWith("pdv-module.json"))).toBe(true);
+    expect(paths.some((p) => p.endsWith("module-index.json"))).toBe(true);
+    const manifestBody = String(
+      (manifestWrites.find((c) => String((c as unknown[])[0]).endsWith("pdv-module.json")) as unknown[])[1],
+    );
+    expect(manifestBody).toContain('"schema_version": "4"');
+    expect(manifestBody).toContain('"id": "toy"');
+    expect(manifestBody).toContain('"description": "smoke"');
+  });
+
+  it("project:save swallows ENOENT from missing working-dir files during sync", async () => {
+    const { projectManager } = setup();
+    (projectManager.save as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      checksum: "abc123",
+      nodeCount: 1,
+      moduleOwnedFiles: [
+        {
+          module_id: "my_mod",
+          source_rel_path: "scripts/gone.py",
+          workdir_path: "/tmp/pdv-test/my_mod/scripts/gone.py",
+        },
+      ],
+    });
+    (mocks.fsCopyFile as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      return Promise.reject(err);
+    });
+    const save = getHandler(IPC.project.save);
+    // Handler must not throw when a module-owned file disappeared mid-save.
+    await expect(save({}, "/tmp/project", [])).resolves.toBeDefined();
   });
 
   it("project:load delegates to ProjectManager.load", async () => {
@@ -988,7 +1261,7 @@ describe("Step 5 IPC handlers", () => {
     const projectLoad = getHandler(IPC.project.load);
     await projectLoad({}, "/tmp/project");
 
-    (mocks.moduleManagerListInstalled as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+    (mocks.moduleManagerListInstalled as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
       {
         id: "demo-module",
         name: "Demo Module",
@@ -1007,6 +1280,26 @@ describe("Step 5 IPC handlers", () => {
         module_settings: {},
       })
     );
+    (mocks.moduleManagerResolveModuleDir as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValue("/tmp/demo-module");
+    (mocks.moduleManagerReadModuleIndex as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([
+        {
+          id: "scripts.run",
+          path: "scripts.run",
+          key: "run",
+          parent_path: "scripts",
+          type: "script",
+          has_children: false,
+          lazy: false,
+          storage: {
+            backend: "local_file",
+            relative_path: "scripts/run.py",
+            format: "py_script",
+          },
+          metadata: { language: "python" },
+        },
+      ]);
 
     const importToProject = getHandler(IPC.modules.importToProject);
     const result = (await importToProject({}, {
@@ -1029,14 +1322,22 @@ describe("Step 5 IPC handlers", () => {
       expect.stringContaining('"module_id": "demo-module"'),
       "utf8"
     );
-    expect(mocks.moduleManagerResolveActionScripts).toHaveBeenCalledWith("demo-module", "/tmp/project");
     expect(commRouter.request).toHaveBeenCalledWith(
-      PDVMessageType.SCRIPT_REGISTER,
+      PDVMessageType.MODULE_REGISTER,
       expect.objectContaining({
-        parent_path: "demo-module.scripts",
-        name: "run",
-        relative_path: "/tmp/pdv-test/demo-module/scripts/run.py",
-        reload: true,
+        path: "demo-module",
+        module_id: "demo-module",
+        name: "Demo Module",
+        version: "1.0.0",
+        module_index: expect.arrayContaining([
+          expect.objectContaining({
+            id: "scripts.run",
+            storage: expect.objectContaining({
+              backend: "local_file",
+              relative_path: path.join("demo-module", "scripts/run.py"),
+            }),
+          }),
+        ]),
       })
     );
     expect(webContentsSend).toHaveBeenCalledWith(
@@ -1045,6 +1346,259 @@ describe("Step 5 IPC handlers", () => {
         changed_paths: ["demo-module"],
         change_type: "updated",
       })
+    );
+  });
+
+  it("modules:createEmpty seeds workdir + calls MODULE_CREATE_EMPTY comm", async () => {
+    const { commRouter } = setup();
+    const start = getHandler(IPC.kernels.start);
+    await start({}, { language: "python" });
+    // No active project dir — exercise the in-memory pending-imports branch.
+    (mocks.fsReadFile as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: { path: "toy" },
+    });
+
+    const create = getHandler(IPC.modules.createEmpty);
+    const result = (await create({}, {
+      id: "toy",
+      name: "Toy",
+      version: "0.1.0",
+      description: "a toy",
+      language: "python",
+    })) as { success: boolean; status?: string; alias?: string };
+
+    expect(result.success).toBe(true);
+    expect(result.alias).toBe("toy");
+    // Working-dir scaffolding created for scripts/lib/plots.
+    expect(mocks.fsMkdir).toHaveBeenCalledWith(
+      expect.stringMatching(/toy\/scripts$/),
+      { recursive: true },
+    );
+    expect(mocks.fsMkdir).toHaveBeenCalledWith(
+      expect.stringMatching(/toy\/lib$/),
+      { recursive: true },
+    );
+    expect(mocks.fsMkdir).toHaveBeenCalledWith(
+      expect.stringMatching(/toy\/plots$/),
+      { recursive: true },
+    );
+    expect(commRouter.request).toHaveBeenCalledWith(
+      PDVMessageType.MODULE_CREATE_EMPTY,
+      expect.objectContaining({
+        id: "toy",
+        name: "Toy",
+        version: "0.1.0",
+        description: "a toy",
+        language: "python",
+      }),
+    );
+  });
+
+  it("modules:createEmpty returns conflict when the alias already exists", async () => {
+    setup();
+    const start = getHandler(IPC.kernels.start);
+    await start({}, { language: "python" });
+    const projectLoad = getHandler(IPC.project.load);
+    await projectLoad({}, "/tmp/project");
+    // Pre-populate the manifest with an existing "toy" module so the
+    // create handler's collision check fires.
+    mocks.fsReadFile.mockResolvedValueOnce(
+      JSON.stringify({
+        schema_version: "1.1",
+        saved_at: "2026-01-01T00:00:00.000Z",
+        pdv_version: getAppVersion(),
+        tree_checksum: "",
+        modules: [{ module_id: "toy", alias: "toy", version: "0.1.0" }],
+        module_settings: {},
+      }),
+    );
+
+    const create = getHandler(IPC.modules.createEmpty);
+    const result = (await create({}, {
+      id: "toy",
+      name: "Toy",
+      version: "0.1.0",
+    })) as { success: boolean; status?: string; suggestedAlias?: string };
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe("conflict");
+    expect(result.suggestedAlias).toBe("toy_1");
+  });
+
+  it("modules:exportFromProject copies saveDir/modules/<id> to the global store", async () => {
+    setup();
+    const start = getHandler(IPC.kernels.start);
+    await start({}, { language: "python" });
+    const projectLoad = getHandler(IPC.project.load);
+    await projectLoad({}, "/tmp/project");
+    mocks.fsReadFile.mockResolvedValue(
+      JSON.stringify({
+        schema_version: "1.1",
+        saved_at: "2026-01-01T00:00:00.000Z",
+        pdv_version: getAppVersion(),
+        tree_checksum: "",
+        modules: [
+          {
+            module_id: "toy",
+            alias: "toy",
+            version: "0.1.0",
+            origin: "in_session",
+          },
+        ],
+        module_settings: {},
+      }),
+    );
+    // First fs.stat resolves the source dir successfully; second (for the
+    // destination) throws ENOENT so the handler skips the overwrite prompt.
+    (mocks.fsStat as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ isDirectory: () => true })
+      .mockRejectedValueOnce(
+        Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+      );
+
+    const exportFromProject = getHandler(IPC.modules.exportFromProject);
+    const result = (await exportFromProject({}, { alias: "toy" })) as {
+      success: boolean;
+      status?: string;
+      destination?: string;
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe("exported");
+    expect(result.destination).toBe("/tmp/pdv-global/modules/packages/toy");
+    expect(mocks.fsCp).toHaveBeenCalledWith(
+      "/tmp/project/modules/toy",
+      "/tmp/pdv-global/modules/packages/toy",
+      { recursive: true, force: true },
+    );
+    // The freshly-copied directory must be registered in the global-store
+    // index so listInstalled picks it up on the next call — otherwise the
+    // Import dialog won't see what the user just exported.
+    expect(mocks.moduleManagerRegisterInGlobalStore).toHaveBeenCalledWith(
+      "/tmp/pdv-global/modules/packages/toy",
+    );
+    // No confirm prompt when the destination didn't exist.
+    expect(mocks.dialogShowMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("modules:exportFromProject prompts to overwrite when global store already has the module", async () => {
+    setup();
+    const start = getHandler(IPC.kernels.start);
+    await start({}, { language: "python" });
+    const projectLoad = getHandler(IPC.project.load);
+    await projectLoad({}, "/tmp/project");
+    mocks.fsReadFile.mockResolvedValue(
+      JSON.stringify({
+        schema_version: "1.1",
+        saved_at: "2026-01-01T00:00:00.000Z",
+        pdv_version: getAppVersion(),
+        tree_checksum: "",
+        modules: [
+          { module_id: "toy", alias: "toy", version: "0.1.0" },
+        ],
+        module_settings: {},
+      }),
+    );
+    (mocks.fsStat as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ isDirectory: () => true }) // source exists
+      .mockResolvedValueOnce({ isDirectory: () => true }); // destination exists
+    (mocks.dialogShowMessageBox as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ response: 0 }); // user picks "Overwrite"
+
+    const exportFromProject = getHandler(IPC.modules.exportFromProject);
+    const result = (await exportFromProject({}, { alias: "toy" })) as {
+      success: boolean;
+      status?: string;
+    };
+
+    expect(mocks.dialogShowMessageBox).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.status).toBe("exported");
+    expect(mocks.fsCp).toHaveBeenCalled();
+  });
+
+  it("modules:exportFromProject returns cancelled when the user declines overwrite", async () => {
+    setup();
+    const start = getHandler(IPC.kernels.start);
+    await start({}, { language: "python" });
+    const projectLoad = getHandler(IPC.project.load);
+    await projectLoad({}, "/tmp/project");
+    mocks.fsReadFile.mockResolvedValue(
+      JSON.stringify({
+        schema_version: "1.1",
+        saved_at: "2026-01-01T00:00:00.000Z",
+        pdv_version: getAppVersion(),
+        tree_checksum: "",
+        modules: [{ module_id: "toy", alias: "toy", version: "0.1.0" }],
+        module_settings: {},
+      }),
+    );
+    (mocks.fsStat as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ isDirectory: () => true })
+      .mockResolvedValueOnce({ isDirectory: () => true });
+    (mocks.dialogShowMessageBox as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ response: 1 }); // user cancels
+    (mocks.fsCp as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+    const exportFromProject = getHandler(IPC.modules.exportFromProject);
+    const result = (await exportFromProject({}, { alias: "toy" })) as {
+      success: boolean;
+      status?: string;
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe("cancelled");
+    expect(mocks.fsCp).not.toHaveBeenCalled();
+  });
+
+  it("modules:exportFromProject rejects when no project directory is active", async () => {
+    setup();
+    const start = getHandler(IPC.kernels.start);
+    await start({}, { language: "python" });
+    // Intentionally skip project:load so activeProjectDir stays null.
+
+    const exportFromProject = getHandler(IPC.modules.exportFromProject);
+    const result = (await exportFromProject({}, { alias: "toy" })) as {
+      success: boolean;
+      status?: string;
+      error?: string;
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe("not_saved");
+  });
+
+  it("modules:updateMetadata forwards to MODULE_UPDATE comm", async () => {
+    const { commRouter } = setup();
+    const start = getHandler(IPC.kernels.start);
+    await start({}, { language: "python" });
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: {
+        alias: "toy",
+        name: "Toy (renamed)",
+        version: "0.2.0",
+        description: "new",
+      },
+    });
+
+    const update = getHandler(IPC.modules.updateMetadata);
+    const result = (await update({}, {
+      alias: "toy",
+      name: "Toy (renamed)",
+      version: "0.2.0",
+      description: "new",
+    })) as { success: boolean; version?: string };
+
+    expect(result.success).toBe(true);
+    expect(result.version).toBe("0.2.0");
+    expect(commRouter.request).toHaveBeenCalledWith(
+      PDVMessageType.MODULE_UPDATE,
+      expect.objectContaining({ alias: "toy", version: "0.2.0" }),
     );
   });
 

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -1332,9 +1332,12 @@ describe("Step 5 IPC handlers", () => {
         module_index: expect.arrayContaining([
           expect.objectContaining({
             id: "scripts.run",
+            // Option A: module-owned files live under
+            // <workdir>/tree/<alias>/<src_rel_path> so the stored
+            // relative_path gains the canonical ``tree/`` prefix.
             storage: expect.objectContaining({
               backend: "local_file",
-              relative_path: path.join("demo-module", "scripts/run.py"),
+              relative_path: path.join("tree", "demo-module", "scripts/run.py"),
             }),
           }),
         ]),

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -344,6 +344,61 @@ async function ensureScriptFile(scriptPath: string, language: "python" | "julia"
 }
 
 /**
+ * Seed a newly-created PDVLib file with a starter stub when it doesn't
+ * already exist. Unlike PDVScript, libs have no ``run()`` contract —
+ * they're plain importable modules — so the stub is just a docstring
+ * header plus a commented-out example so users can see where to add
+ * their own helpers.
+ *
+ * @param libPath - Absolute path to the target ``.py`` / ``.jl`` file.
+ * @param language - Active kernel language (only Python is actually
+ *   supported by the ``tree:createLib`` handler today; Julia falls back
+ *   to a block-comment equivalent for future-proofing).
+ * @param moduleAlias - Top-level tree alias of the owning PDVModule, so
+ *   the stub can reference it in the header.
+ */
+async function ensureLibFile(
+  libPath: string,
+  language: "python" | "julia",
+  moduleAlias: string
+): Promise<void> {
+  try {
+    await fs.stat(libPath);
+    return;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== "ENOENT") throw error;
+  }
+  const now = new Date();
+  const date = `${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, "0")}/${String(now.getDate()).padStart(2, "0")}`;
+  const time = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  const user = process.env.USER ?? process.env.USERNAME ?? "user";
+  const host = os.hostname();
+  const filename = path.basename(libPath);
+  const template = language === "julia"
+    ? "#=\n" +
+      `  ${filename}\n` +
+      `  Library module for PDVModule "${moduleAlias}"\n` +
+      `  created by ${user} on ${host} on ${date} at ${time}\n` +
+      "=#\n\n" +
+      "# Define helper functions below — they will be importable from\n" +
+      `# sibling scripts as \`using ${path.parse(filename).name}\`.\n\n` +
+      "# function example(x)\n" +
+      "#     return x\n" +
+      "# end\n"
+    : '"""\n' +
+      `${filename}\n` +
+      `Library module for PDVModule "${moduleAlias}"\n` +
+      `created by ${user} on ${host} on ${date} at ${time}\n` +
+      '"""\n\n' +
+      "# Define helper functions below — they will be importable from\n" +
+      `# sibling scripts as \`from ${path.parse(filename).name} import ...\`.\n\n` +
+      "# def example(x):\n" +
+      "#     return x\n";
+  await fs.writeFile(libPath, template, "utf8");
+}
+
+/**
  * Remove all registered push subscriptions.
  */
 function clearPushSubscriptions(): void {
@@ -521,6 +576,7 @@ export function registerIpcHandlers(
     toNamespaceInspectPayload,
     sanitizeScriptName,
     ensureScriptFile,
+    ensureLibFile,
     resolveScriptPath,
     buildEditorSpawn,
     resolveEditorSpawn,

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -503,6 +503,19 @@ export function registerIpcHandlers(
     projectManager,
     configStore,
     kernelWorkingDirs,
+    // Aggregate module aliases from the active on-disk manifest plus any
+    // in-memory pending imports (the latter carries in-session modules
+    // created by modules:createEmpty before the first save). The tree
+    // create* handlers use this to route module-owned files through the
+    // ``<workdir>/<alias>/...`` layout with source_rel_path set.
+    getKnownModuleAliases: async (): Promise<Set<string>> => {
+      const manifest = await readActiveProjectManifest();
+      const disk = manifest?.modules ?? [];
+      return new Set([
+        ...disk.map((m) => m.alias),
+        ...pendingModuleImports.map((m) => m.alias),
+      ]);
+    },
     readConfig,
     toNamespaceQueryPayload,
     toNamespaceInspectPayload,

--- a/electron/main/integration.test.ts
+++ b/electron/main/integration.test.ts
@@ -99,6 +99,11 @@ describe("@slow Cross-boundary integration (Python + Electron)", { timeout: 120_
   let initialWorkingDir = "";
   const tempDirs: string[] = [];
 
+  // Bump the hook timeout to 20s (up from vitest's 10s default). On a
+  // busy CI runner the real ipykernel subprocess + comm bootstrap can
+  // take noticeably longer than local, and we'd rather give it breathing
+  // room than chase flakes. The test timeout is already 120s via the
+  // describe options above.
   beforeAll(async () => {
     setAppVersion("0.0.7");
     km = new KernelManager();
@@ -118,7 +123,7 @@ describe("@slow Cross-boundary integration (Python + Electron)", { timeout: 120_
     readyMessage = session.ready;
     initResponse = session.initResponse;
     initialWorkingDir = session.workingDir;
-  });
+  }, 20_000);
 
   afterAll(async () => {
     router.detach();
@@ -126,7 +131,7 @@ describe("@slow Cross-boundary integration (Python + Electron)", { timeout: 120_
     await Promise.all(
       tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true }))
     );
-  });
+  }, 20_000);
 
   it("start kernel -> bootstrap -> pdv.ready then pdv.init.response", async () => {
     expect(readyMessage).not.toBeNull();

--- a/electron/main/ipc-register-modules.ts
+++ b/electron/main/ipc-register-modules.ts
@@ -14,7 +14,7 @@
 
 import * as fs from "fs/promises";
 import * as path from "path";
-import { BrowserWindow, ipcMain } from "electron";
+import { BrowserWindow, dialog, ipcMain } from "electron";
 
 import { CommRouter } from "./comm-router";
 import {
@@ -22,7 +22,11 @@ import {
   IPC,
   ModuleActionRequest,
   ModuleActionResult,
+  ModuleCreateEmptyRequest,
+  ModuleCreateEmptyResult,
   ModuleDescriptor,
+  ModuleExportRequest,
+  ModuleExportResult,
   ModuleHealthWarning,
   ModuleImportRequest,
   ModuleImportResult,
@@ -31,6 +35,8 @@ import {
   ModuleSettingsRequest,
   ModuleSettingsResult,
   ModuleUninstallResult,
+  ModuleUpdateMetadataRequest,
+  ModuleUpdateMetadataResult,
   ModuleUpdateResult,
 } from "./ipc";
 import { KernelManager } from "./kernel-manager";
@@ -232,6 +238,308 @@ export function registerModulesIpcHandlers(
         warnings,
       };
     }
+  );
+
+  ipcMain.handle(
+    IPC.modules.createEmpty,
+    async (_event, request: ModuleCreateEmptyRequest): Promise<ModuleCreateEmptyResult> => {
+      // Normalize and validate the requested id. Collision detection mirrors
+      // the importToProject flow: any existing on-disk OR pending module alias
+      // blocks creation and the response suggests the next available id.
+      let baseAlias: string;
+      try {
+        baseAlias = normalizeModuleAlias(request.id ?? "");
+      } catch (error) {
+        return {
+          success: false,
+          status: "error",
+          error: `Invalid module id: ${(error as Error).message}`,
+        };
+      }
+
+      const activeManifest = await readActiveProjectManifest();
+      const diskModules = activeManifest?.modules ?? [];
+      const pendingImports = getPendingModuleImports();
+      const existingAliases = new Set(
+        [...diskModules, ...pendingImports].map((m) => m.alias),
+      );
+      if (existingAliases.has(baseAlias)) {
+        return {
+          success: false,
+          status: "conflict",
+          alias: baseAlias,
+          suggestedAlias: suggestModuleAlias(baseAlias, existingAliases),
+          error: `Module alias already exists: ${baseAlias}`,
+        };
+      }
+
+      const activeKernelId = getActiveKernelId();
+      if (!activeKernelId || !kernelManager.getKernel(activeKernelId)) {
+        return {
+          success: false,
+          status: "error",
+          error: "No running kernel — start one before creating a module.",
+        };
+      }
+      const workingDir = kernelWorkingDirs.get(activeKernelId);
+
+      // Seed working-dir scaffolding so the kernel's PDVFile resolve_path
+      // calls and subsequent tree:createScript / tree:createLib hits have
+      // somewhere to land. ``modules/<id>/{scripts,lib,plots}/`` mirrors the
+      // layout that bindImportedModule would have created for an imported
+      // module, keeping the save-time sync (§3) and export (§9) code paths
+      // uniform across workflow A and workflow B.
+      if (workingDir) {
+        for (const child of ["scripts", "lib", "plots"]) {
+          await fs.mkdir(path.join(workingDir, baseAlias, child), { recursive: true });
+        }
+      }
+
+      const language =
+        request.language ??
+        (activeManifest?.language as "python" | "julia" | undefined) ??
+        "python";
+
+      try {
+        await commRouter.request(PDVMessageType.MODULE_CREATE_EMPTY, {
+          id: baseAlias,
+          name: request.name || baseAlias,
+          version: request.version || "0.1.0",
+          description: request.description ?? "",
+          language,
+        });
+      } catch (error) {
+        return {
+          success: false,
+          status: "error",
+          error: `Kernel rejected create_empty: ${(error as Error).message}`,
+        };
+      }
+
+      // Record the new module in the pending-imports list so it survives
+      // until the first project:save, at which point §3's manifest flush
+      // writes it into project.json. Marking origin="in_session" lets the
+      // project load path know to read from <saveDir>/modules/<id>/ rather
+      // than expecting a global-store install entry.
+      pendingImports.push({
+        module_id: baseAlias,
+        alias: baseAlias,
+        version: request.version || "0.1.0",
+        origin: "in_session",
+      });
+
+      // If a project directory is already set, persist the manifest entry
+      // immediately so a mid-session reload (without a project:save) still
+      // sees the new module. Match the import handler's write-lock pattern.
+      const activeProjectDir = getActiveProjectDir();
+      if (activeProjectDir && activeManifest) {
+        await runWithProjectManifestWriteLock(activeProjectDir, async () => {
+          const latest = await ProjectManager.readManifest(activeProjectDir);
+          const latestAliases = new Set(latest.modules.map((m) => m.alias));
+          if (latestAliases.has(baseAlias)) {
+            return;
+          }
+          const updated = {
+            ...latest,
+            modules: [
+              ...latest.modules,
+              {
+                module_id: baseAlias,
+                alias: baseAlias,
+                version: request.version || "0.1.0",
+                origin: "in_session" as const,
+              },
+            ],
+            module_settings: latest.module_settings ?? {},
+          };
+          await ProjectManager.saveManifest(activeProjectDir, updated);
+        });
+        // Drop the pending entry now that it's on disk — otherwise §3's
+        // pending flush would try to fs.cp an install path that doesn't
+        // exist for in-session modules and push a duplicate manifest entry.
+        const idx = pendingImports.findIndex((m) => m.alias === baseAlias);
+        if (idx >= 0) pendingImports.splice(idx, 1);
+      }
+
+      win.webContents.send(IPC.push.treeChanged, {
+        changed_paths: [baseAlias],
+        change_type: "updated",
+      });
+
+      return { success: true, status: "created", alias: baseAlias };
+    },
+  );
+
+  ipcMain.handle(
+    IPC.modules.updateMetadata,
+    async (_event, request: ModuleUpdateMetadataRequest): Promise<ModuleUpdateMetadataResult> => {
+      if (!request?.alias) {
+        return { success: false, error: "alias is required" };
+      }
+      const activeKernelId = getActiveKernelId();
+      if (!activeKernelId || !kernelManager.getKernel(activeKernelId)) {
+        return { success: false, error: "No running kernel" };
+      }
+      try {
+        const response = await commRouter.request(PDVMessageType.MODULE_UPDATE, {
+          alias: request.alias,
+          name: request.name,
+          version: request.version,
+          description: request.description,
+        });
+        const payload = response.payload as {
+          alias?: string;
+          name?: string;
+          version?: string;
+          description?: string;
+        };
+        win.webContents.send(IPC.push.treeChanged, {
+          changed_paths: [request.alias],
+          change_type: "updated",
+        });
+        return {
+          success: true,
+          alias: payload.alias,
+          name: payload.name,
+          version: payload.version,
+          description: payload.description,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: `Kernel rejected update: ${(error as Error).message}`,
+        };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IPC.modules.exportFromProject,
+    async (_event, request: ModuleExportRequest): Promise<ModuleExportResult> => {
+      if (!request?.alias) {
+        return { success: false, status: "error", error: "alias is required" };
+      }
+      const activeProjectDir = getActiveProjectDir();
+      if (!activeProjectDir) {
+        return {
+          success: false,
+          status: "not_saved",
+          error: "Save the project before exporting a module.",
+        };
+      }
+      const manifest = await readActiveProjectManifest();
+      const imported = manifest?.modules ?? [];
+      const entry = imported.find((m) => m.alias === request.alias);
+      if (!entry) {
+        return {
+          success: false,
+          status: "error",
+          error: `No imported or in-session module with alias: ${request.alias}`,
+        };
+      }
+      // The project-local module copy at <saveDir>/modules/<module_id>/
+      // is always the authoritative source for export: §3's sync step
+      // has mirrored edits into it, and §7's manifest writer has
+      // stamped pdv-module.json + module-index.json there. For in-session
+      // modules (origin="in_session") this path only exists after at
+      // least one project:save has completed.
+      const srcDir = path.join(activeProjectDir, "modules", entry.module_id);
+      try {
+        const srcStat = await fs.stat(srcDir);
+        if (!srcStat.isDirectory()) {
+          return {
+            success: false,
+            status: "not_saved",
+            error: `Module source is not a directory: ${srcDir}`,
+          };
+        }
+      } catch {
+        return {
+          success: false,
+          status: "not_saved",
+          error:
+            "Module is not present in the project save directory. " +
+            "Run File → Save Project before exporting.",
+        };
+      }
+
+      const destDir = moduleManager.getGlobalStorePath(entry.module_id);
+      if (!destDir) {
+        return {
+          success: false,
+          status: "error",
+          error: "Could not resolve global store path.",
+        };
+      }
+
+      // Confirm overwrite for an existing global-store entry — the
+      // user might be publishing changes (expected) or blowing away
+      // an unrelated module that happens to share the id (not expected
+      // but worth a safety check). Skip the prompt when the renderer
+      // passes overwrite: true (future scripted flows).
+      let destExists = false;
+      try {
+        await fs.stat(destDir);
+        destExists = true;
+      } catch {
+        // destination doesn't exist yet — fresh publish, no prompt needed.
+      }
+      if (destExists && !request.overwrite) {
+        const confirmResult = await dialog.showMessageBox(win, {
+          type: "question",
+          buttons: ["Overwrite", "Cancel"],
+          defaultId: 0,
+          cancelId: 1,
+          title: "Overwrite existing module?",
+          message: `A module named "${entry.module_id}" already exists in the global store.`,
+          detail:
+            `Publishing will overwrite ${destDir}. Other projects that ` +
+            `import this module will pick up the changes on their next ` +
+            `import. Bundled example modules cannot be overwritten here.`,
+        });
+        if (confirmResult.response !== 0) {
+          return { success: false, status: "cancelled" };
+        }
+      }
+
+      try {
+        await fs.mkdir(path.dirname(destDir), { recursive: true });
+        await fs.cp(srcDir, destDir, { recursive: true, force: true });
+      } catch (error) {
+        return {
+          success: false,
+          status: "error",
+          error: `Failed to copy module to global store: ${(error as Error).message}`,
+        };
+      }
+
+      // Register the freshly-copied directory in the global store
+      // index so listInstalled() (and therefore the Import dialog)
+      // picks it up immediately. Without this step, fs.cp alone puts
+      // the files in place but leaves the index stale, so users can't
+      // import what they just exported.
+      try {
+        await moduleManager.registerInGlobalStore(destDir);
+      } catch (error) {
+        return {
+          success: false,
+          status: "error",
+          error: `Copied module to ${destDir} but failed to register it: ${(error as Error).message}`,
+        };
+      }
+
+      // TODO(#182): if pdv-module.json at destDir has an ``upstream`` git
+      // URL, offer to commit and push the changes instead of (or in
+      // addition to) writing to the global store. Track deletion
+      // propagation for that flow as well — see the ENOENT swallow in
+      // ipc-register-project.ts's sync step.
+
+      return {
+        success: true,
+        status: "exported",
+        destination: destDir,
+      };
+    },
   );
 
   ipcMain.handle(

--- a/electron/main/ipc-register-modules.ts
+++ b/electron/main/ipc-register-modules.ts
@@ -283,15 +283,17 @@ export function registerModulesIpcHandlers(
       }
       const workingDir = kernelWorkingDirs.get(activeKernelId);
 
-      // Seed working-dir scaffolding so the kernel's PDVFile resolve_path
-      // calls and subsequent tree:createScript / tree:createLib hits have
-      // somewhere to land. ``modules/<id>/{scripts,lib,plots}/`` mirrors the
-      // layout that bindImportedModule would have created for an imported
-      // module, keeping the save-time sync (§3) and export (§9) code paths
-      // uniform across workflow A and workflow B.
+      // Seed working-dir scaffolding under the canonical
+      // ``<workdir>/tree/<alias>/{scripts,lib,plots}/`` layout so
+      // subsequent ``tree:createScript`` / ``tree:createLib`` hits land
+      // at paths that match where ``bindImportedModule`` would have
+      // placed an imported v4 module's files — see the Option A
+      // canonical-layout fix and ARCHITECTURE.md §6.1/§6.2.
       if (workingDir) {
         for (const child of ["scripts", "lib", "plots"]) {
-          await fs.mkdir(path.join(workingDir, baseAlias, child), { recursive: true });
+          await fs.mkdir(path.join(workingDir, "tree", baseAlias, child), {
+            recursive: true,
+          });
         }
       }
 

--- a/electron/main/ipc-register-project.ts
+++ b/electron/main/ipc-register-project.ts
@@ -18,8 +18,18 @@ import { ipcMain, type BrowserWindow } from "electron";
 
 import { IPC } from "./ipc";
 import { ModuleManager } from "./module-manager";
-import { ProjectManager, type ProjectManifest, type ProjectModuleImport } from "./project-manager";
+import {
+  ProjectManager,
+  type ModuleManifestBundle,
+  type ModuleOwnedFile,
+  type ProjectManifest,
+  type ProjectModuleImport,
+} from "./project-manager";
 import { copyFilesForLoad } from "./project-file-sync";
+import {
+  writeModuleIndex,
+  writeModuleManifest,
+} from "./module-manifest-writer";
 
 interface RegisterProjectIpcHandlersOptions {
   projectManager: ProjectManager;
@@ -37,6 +47,110 @@ interface RegisterProjectIpcHandlersOptions {
   runSerializedProjectManifestMutation: <T>(dir: string, task: () => Promise<T>) => Promise<T>;
   getMainWindow: () => BrowserWindow | null;
   getInterpreterPath: () => string | undefined;
+}
+
+/**
+ * Mirror each module-owned file's working-dir copy into the project-local
+ * module directory (``<saveDir>/modules/<module_id>/<source_rel_path>``).
+ *
+ * Called at the tail of ``IPC.project.save`` so that edits made to imported
+ * or in-session module files (scripts, libs, guis, namelists) survive a
+ * save → close → reopen cycle and can be exported back to the global
+ * store later. Skips entries whose ``workdir_path`` no longer exists
+ * (e.g. files deleted from the tree between serialization and this copy).
+ *
+ * Same-file short-circuit: when the working dir and save dir resolve to
+ * the same inode (mostly a test fixture scenario), ``fs.copyFile`` would
+ * fail with EBUSY — we detect and skip that case explicitly.
+ *
+ * @param saveDir - Absolute project save directory.
+ * @param moduleOwnedFiles - Entries from the kernel's save response.
+ * @returns Nothing. Errors are logged but do not fail the save — the
+ *   kernel-side serialization (the authoritative part) has already
+ *   succeeded by the time this runs.
+ */
+async function syncModuleOwnedFilesToSaveDir(
+  saveDir: string,
+  moduleOwnedFiles: ModuleOwnedFile[] | undefined,
+): Promise<void> {
+  if (!moduleOwnedFiles || moduleOwnedFiles.length === 0) return;
+  for (const entry of moduleOwnedFiles) {
+    if (!entry.module_id || !entry.source_rel_path || !entry.workdir_path) {
+      continue;
+    }
+    const dest = path.join(
+      saveDir,
+      "modules",
+      entry.module_id,
+      entry.source_rel_path,
+    );
+    try {
+      const srcResolved = path.resolve(entry.workdir_path);
+      const destResolved = path.resolve(dest);
+      if (srcResolved === destResolved) {
+        continue;
+      }
+      await fs.mkdir(path.dirname(dest), { recursive: true });
+      await fs.copyFile(srcResolved, destResolved);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === "ENOENT") {
+        // Working-dir file vanished between serialization and sync —
+        // harmless, just skip it.
+        continue;
+      }
+      console.warn(
+        `[pdv] failed to sync module file ${entry.module_id}/${entry.source_rel_path} to save dir:`,
+        error,
+      );
+    }
+  }
+}
+
+/**
+ * Stamp ``pdv-module.json`` + ``module-index.json`` into
+ * ``<saveDir>/modules/<module_id>/`` for every module in the tree.
+ *
+ * Called at project-save time after the file-sync step (§3) has already
+ * placed each module-owned file's contents at the right on-disk
+ * location. The writer is authoritative on the schema shape; we just
+ * pipe the kernel-emitted bundle through. Errors are logged but never
+ * thrown — a manifest write failure must not block the save (the tree
+ * content itself is already persisted by the time we get here).
+ *
+ * @param saveDir - Active project save directory.
+ * @param bundles - Per-module manifest bundles from the save response.
+ * @returns Nothing.
+ */
+async function writeModuleManifestsToSaveDir(
+  saveDir: string,
+  bundles: ModuleManifestBundle[] | undefined,
+): Promise<void> {
+  if (!bundles || bundles.length === 0) return;
+  for (const bundle of bundles) {
+    if (!bundle.module_id) continue;
+    const moduleDir = path.join(saveDir, "modules", bundle.module_id);
+    try {
+      await writeModuleManifest(moduleDir, {
+        id: bundle.module_id,
+        name: bundle.name,
+        version: bundle.version,
+        description: bundle.description,
+        language: bundle.language,
+        dependencies: bundle.dependencies,
+        // Default lib_dir for v4 modules — matches the convention used
+        // by bundled example modules and read by buildModulesSetupPayload
+        // at kernel init / project-load time.
+        libDir: "lib",
+      });
+      await writeModuleIndex(moduleDir, bundle.entries ?? []);
+    } catch (error) {
+      console.warn(
+        `[pdv] failed to write module manifest for ${bundle.module_id}:`,
+        error,
+      );
+    }
+  }
 }
 
 /**
@@ -106,6 +220,18 @@ export function registerProjectIpcHandlers(
       // NOTE: file-backed nodes are already copied to saveDir/tree/ by the
       // Python serializer (serialize_node writes directly to save_dir).
       // No additional copy step is needed here.
+
+      // Mirror edited working-dir copies of module-owned files back into
+      // <saveDir>/modules/<id>/<source_rel_path>. See ARCHITECTURE.md §5.13
+      // and the #140 module editing workflow plan §3.
+      // TODO(#182): propagate deletions — if a module-owned file was removed
+      // from the tree, the pristine copy under <saveDir>/modules/<id>/ is
+      // left behind. Safe lacuna for now; fix alongside the GitHub push flow.
+      await syncModuleOwnedFilesToSaveDir(saveDir, saveResult.moduleOwnedFiles);
+      // Now that the file contents are in place, stamp pdv-module.json and
+      // module-index.json for every module in the tree so a fresh project
+      // reload can rebind them via the existing v4 bind path. See plan §7.
+      await writeModuleManifestsToSaveDir(saveDir, saveResult.moduleManifests);
 
       setActiveProjectDir(saveDir);
       await refreshProjectModuleHealth(saveDir);

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -52,6 +52,11 @@ interface RegisterTreeNamespaceScriptIpcHandlersOptions {
   ) => Record<string, unknown>;
   sanitizeScriptName: (scriptName: string, language?: "python" | "julia") => string;
   ensureScriptFile: (scriptPath: string, language?: "python" | "julia") => Promise<void>;
+  ensureLibFile: (
+    libPath: string,
+    language: "python" | "julia",
+    moduleAlias: string,
+  ) => Promise<void>;
   resolveScriptPath: (
     kernelId: string,
     scriptPath: string,
@@ -235,6 +240,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     toNamespaceInspectPayload,
     sanitizeScriptName,
     ensureScriptFile,
+    ensureLibFile,
     resolveScriptPath,
     buildEditorSpawn,
     resolveEditorSpawn,
@@ -462,9 +468,11 @@ export function registerTreeNamespaceScriptIpcHandlers(
       targetPath: string,
       libName: string,
     ): Promise<TreeCreateLibResult> => {
-      if (!kernelManager.getKernel(kernelId)) {
+      const kernel = kernelManager.getKernel(kernelId);
+      if (!kernel) {
         throw new Error(`Kernel not found: ${kernelId}`);
       }
+      const language = kernel.language;
       let workingDir = kernelWorkingDirs.get(kernelId);
       if (!workingDir) {
         workingDir = await projectManager.createWorkingDir();
@@ -499,11 +507,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
       const libDir = path.join(workingDir, ...moduleInfo.workingDirSegments);
       await fs.mkdir(libDir, { recursive: true });
       const libPath = path.join(libDir, filename);
-      try {
-        await fs.access(libPath);
-      } catch {
-        await fs.writeFile(libPath, "", "utf-8");
-      }
+      await ensureLibFile(libPath, language, moduleInfo.moduleAlias);
 
       const sourceRelPath = moduleInfo.sourceRelDir
         ? `${moduleInfo.sourceRelDir}/${filename}`

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -85,12 +85,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  *   inside module ``toy`` yields ``sourceRelDir = "scripts/helpers"``).
  *   Empty when the target equals the module root.
  * - ``workingDirSegments`` — the filesystem path segments relative to
- *   the kernel working directory. For module-owned targets this is
- *   ``[alias, ...rest]`` (no ``tree/`` prefix) so the on-disk layout
- *   matches what ``bindImportedModule`` produces in §2.
+ *   the kernel working directory, *including* the canonical ``tree/``
+ *   subdirectory prefix. Module-owned files live at
+ *   ``<workdir>/tree/<alias>/<rest>`` so the on-disk layout matches
+ *   what ``serialize_node`` produces at save time, which keeps
+ *   ``relative_path`` stable across save/load cycles. The forthcoming
+ *   UUID-based storage redesign will replace the content of the
+ *   per-node rel path but keep this single-canonical-layout contract.
  *
  * Returns ``null`` when ``targetPath`` is not inside any known module,
- * in which case the caller should use its legacy ``tree/`` layout.
+ * in which case the caller routes through the standard ``tree/<path>``
+ * layout for project-level files.
  */
 function analyseModuleTarget(
   targetPath: string,
@@ -103,7 +108,10 @@ function analyseModuleTarget(
   return {
     moduleAlias: alias,
     sourceRelDir: rest.join("/"),
-    workingDirSegments: [alias, ...rest],
+    // TODO(UUID): replace with ``["tree", "<uuid>"]`` once the UUID-
+    // based file storage redesign lands — the tree-path-to-filesystem
+    // mapping goes away and file locations become identity-stable.
+    workingDirSegments: ["tree", alias, ...rest],
   };
 }
 
@@ -286,11 +294,15 @@ export function registerTreeNamespaceScriptIpcHandlers(
       const safeName = sanitizeScriptName(scriptName, language);
       const scriptNodeName = path.parse(safeName).name;
 
-      // Module-owned scripts live under ``<workdir>/<alias>/<...>/<file>``
-      // and carry ``source_rel_path`` so the save-time sync (§3) mirrors
-      // edits to ``<saveDir>/modules/<id>/<source_rel_path>``. Plain
-      // project scripts keep the pre-existing
-      // ``<workdir>/<...targetPath>/<file>`` layout.
+      // Every file-backed tree node lives under the canonical
+      // ``<workdir>/tree/...`` subdirectory so the in-memory
+      // ``relative_path`` matches what ``serialize_node`` emits at save
+      // time and what ``copyFilesForLoad`` mirrors on reload. The
+      // pre-Option-A layout that dropped the ``tree/`` prefix for
+      // ``tree:createScript`` produced a rel-path drift across
+      // save/load (see the #140 PR's follow-up discussion on the
+      // checksum fix). Module-owned files also get the prefix via
+      // ``analyseModuleTarget``.
       const knownAliases = await getKnownModuleAliases();
       const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
 
@@ -304,16 +316,26 @@ export function registerTreeNamespaceScriptIpcHandlers(
           : safeName;
         moduleId = moduleInfo.moduleAlias;
       } else {
-        scriptsDir = path.join(workingDir, ...targetPath.split(".").filter(Boolean));
+        scriptsDir = path.join(
+          workingDir,
+          "tree",
+          ...targetPath.split(".").filter(Boolean),
+        );
       }
       await fs.mkdir(scriptsDir, { recursive: true });
       const scriptPath = path.join(scriptsDir, safeName);
       await ensureScriptFile(scriptPath, language);
 
+      // Register with a workdir-relative path so the in-memory
+      // ``relative_path`` matches the ``tree-index.json`` entry post
+      // save/load. ``scriptPath`` (absolute) is still returned to the
+      // renderer because the external-editor spawn needs an absolute
+      // path.
+      const registeredRelPath = path.relative(workingDir, scriptPath);
       await commRouter.request(PDVMessageType.SCRIPT_REGISTER, {
         parent_path: targetPath,
         name: scriptNodeName,
-        relative_path: scriptPath,
+        relative_path: registeredRelPath,
         language,
         module_id: moduleId,
         source_rel_path: sourceRelPath,
@@ -351,10 +373,13 @@ export function registerTreeNamespaceScriptIpcHandlers(
       }
 
       const treePath = targetPath ? `${targetPath}.${safeName}` : safeName;
+      // Register with a workdir-relative path so the in-memory
+      // ``relative_path`` matches what ``serialize_node`` emits at save
+      // time (see the Option A canonical-layout commit).
       await commRouter.request(PDVMessageType.NOTE_REGISTER, {
         parent_path: targetPath,
         name: safeName,
-        relative_path: notePath,
+        relative_path: path.relative(workingDir, notePath),
       });
       return { success: true, notePath, treePath };
     }
@@ -381,9 +406,10 @@ export function registerTreeNamespaceScriptIpcHandlers(
         return { success: false, error: "GUI name must contain at least one alphanumeric character" };
       }
 
-      // Module-owned GUIs live under ``<workdir>/<alias>/<...>/<file>``
-      // (no ``tree/`` prefix) to match the bind path; project GUIs stay
-      // under ``<workdir>/tree/<...>`` per the existing convention.
+      // Every file-backed node lives under ``<workdir>/tree/...`` so the
+      // in-memory ``relative_path`` stays stable across save/load.
+      // ``analyseModuleTarget`` already bakes the ``tree/`` prefix into
+      // its ``workingDirSegments`` result for module-owned targets.
       const knownAliases = await getKnownModuleAliases();
       const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
 
@@ -420,7 +446,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
       await commRouter.request(PDVMessageType.GUI_REGISTER, {
         parent_path: targetPath,
         name: safeName,
-        relative_path: guiPath,
+        relative_path: path.relative(workingDir, guiPath),
         module_id: moduleId,
         source_rel_path: sourceRelPath,
       });
@@ -511,8 +537,12 @@ export function registerTreeNamespaceScriptIpcHandlers(
       const workingDir = kernelWorkingDirs.get(kernelId);
       if (!workingDir) throw new Error(`Working dir not initialized: ${kernelId}`);
 
+      // File-backed nodes live under the canonical ``<workdir>/tree/...``
+      // subdirectory so the in-memory ``relative_path`` matches what
+      // ``serialize_node`` writes at save time and what
+      // ``copyFilesForLoad`` mirrors on reload.
       const segments = targetTreePath.split(".").filter(Boolean);
-      const destDir = segments.length > 0 ? path.join(workingDir, ...segments) : workingDir;
+      const destDir = path.join(workingDir, "tree", ...segments);
       await fs.mkdir(destDir, { recursive: true });
       const destPath = path.join(destDir, filename);
       await fs.copyFile(sourcePath, destPath);

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -19,7 +19,7 @@ import * as path from "path";
 import type { CommRouter } from "./comm-router";
 import type { QueryRouter } from "./query-router";
 import type { ConfigStore, PDVConfig } from "./config";
-import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateNoteResult, type TreeCreateScriptResult } from "./ipc";
+import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNoteResult, type TreeCreateScriptResult } from "./ipc";
 import type { KernelManager } from "./kernel-manager";
 import { PDVMessageType, type PDVFileRegisterPayload } from "./pdv-protocol";
 import type { ProjectManager } from "./project-manager";
@@ -31,6 +31,18 @@ interface RegisterTreeNamespaceScriptIpcHandlersOptions {
   projectManager: ProjectManager;
   configStore: ConfigStore;
   kernelWorkingDirs: Map<string, string>;
+  /**
+   * Returns the set of currently-known module aliases (active project
+   * manifest ∪ pending-imports). Used by ``tree:createScript`` /
+   * ``tree:createGui`` / ``tree:createLib`` to decide whether a new
+   * file lives inside a module subtree — in which case it needs
+   * ``source_rel_path`` set so the save-time sync (§3) can mirror it
+   * back to ``<saveDir>/modules/<id>/`` and its on-disk location must
+   * match the ``<workdir>/<alias>/...`` layout used by the module bind
+   * path rather than the ``<workdir>/tree/...`` layout used for plain
+   * project files.
+   */
+  getKnownModuleAliases: () => Promise<Set<string>>;
   readConfig: (configStore: ConfigStore) => PDVConfig;
   toNamespaceQueryPayload: (
     options?: NamespaceQueryOptions
@@ -58,6 +70,41 @@ interface RegisterTreeNamespaceScriptIpcHandlersOptions {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Analyse a target tree path against a set of known module aliases.
+ *
+ * When the first dot-segment of ``targetPath`` matches an alias, the
+ * returned descriptor tells the caller:
+ *
+ * - ``moduleAlias`` — the owning module's alias (first segment).
+ * - ``sourceRelDir`` — the remaining tree segments joined with ``/``,
+ *   which becomes the directory portion of ``source_rel_path`` for any
+ *   file authored here (e.g. ``targetPath = "toy.scripts.helpers"``
+ *   inside module ``toy`` yields ``sourceRelDir = "scripts/helpers"``).
+ *   Empty when the target equals the module root.
+ * - ``workingDirSegments`` — the filesystem path segments relative to
+ *   the kernel working directory. For module-owned targets this is
+ *   ``[alias, ...rest]`` (no ``tree/`` prefix) so the on-disk layout
+ *   matches what ``bindImportedModule`` produces in §2.
+ *
+ * Returns ``null`` when ``targetPath`` is not inside any known module,
+ * in which case the caller should use its legacy ``tree/`` layout.
+ */
+function analyseModuleTarget(
+  targetPath: string,
+  knownAliases: Set<string>,
+): { moduleAlias: string; sourceRelDir: string; workingDirSegments: string[] } | null {
+  const segments = targetPath.split(".").filter(Boolean);
+  if (segments.length === 0) return null;
+  const [alias, ...rest] = segments;
+  if (!knownAliases.has(alias)) return null;
+  return {
+    moduleAlias: alias,
+    sourceRelDir: rest.join("/"),
+    workingDirSegments: [alias, ...rest],
+  };
 }
 
 function toNamespaceVariable(
@@ -174,6 +221,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     projectManager,
     configStore,
     kernelWorkingDirs,
+    getKnownModuleAliases,
     readConfig,
     toNamespaceQueryPayload,
     toNamespaceInspectPayload,
@@ -237,7 +285,27 @@ export function registerTreeNamespaceScriptIpcHandlers(
       }
       const safeName = sanitizeScriptName(scriptName, language);
       const scriptNodeName = path.parse(safeName).name;
-      const scriptsDir = path.join(workingDir, ...targetPath.split(".").filter(Boolean));
+
+      // Module-owned scripts live under ``<workdir>/<alias>/<...>/<file>``
+      // and carry ``source_rel_path`` so the save-time sync (§3) mirrors
+      // edits to ``<saveDir>/modules/<id>/<source_rel_path>``. Plain
+      // project scripts keep the pre-existing
+      // ``<workdir>/<...targetPath>/<file>`` layout.
+      const knownAliases = await getKnownModuleAliases();
+      const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
+
+      let scriptsDir: string;
+      let sourceRelPath: string | undefined;
+      let moduleId: string | undefined;
+      if (moduleInfo) {
+        scriptsDir = path.join(workingDir, ...moduleInfo.workingDirSegments);
+        sourceRelPath = moduleInfo.sourceRelDir
+          ? `${moduleInfo.sourceRelDir}/${safeName}`
+          : safeName;
+        moduleId = moduleInfo.moduleAlias;
+      } else {
+        scriptsDir = path.join(workingDir, ...targetPath.split(".").filter(Boolean));
+      }
       await fs.mkdir(scriptsDir, { recursive: true });
       const scriptPath = path.join(scriptsDir, safeName);
       await ensureScriptFile(scriptPath, language);
@@ -247,6 +315,8 @@ export function registerTreeNamespaceScriptIpcHandlers(
         name: scriptNodeName,
         relative_path: scriptPath,
         language,
+        module_id: moduleId,
+        source_rel_path: sourceRelPath,
       });
       return { success: true, scriptPath };
     }
@@ -310,9 +380,28 @@ export function registerTreeNamespaceScriptIpcHandlers(
       if (!safeName) {
         return { success: false, error: "GUI name must contain at least one alphanumeric character" };
       }
-      const guiDir = path.join(workingDir, "tree", ...targetPath.split(".").filter(Boolean));
+
+      // Module-owned GUIs live under ``<workdir>/<alias>/<...>/<file>``
+      // (no ``tree/`` prefix) to match the bind path; project GUIs stay
+      // under ``<workdir>/tree/<...>`` per the existing convention.
+      const knownAliases = await getKnownModuleAliases();
+      const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
+
+      const guiFilename = safeName + ".gui.json";
+      let guiDir: string;
+      let sourceRelPath: string | undefined;
+      let moduleId: string | null = null;
+      if (moduleInfo) {
+        guiDir = path.join(workingDir, ...moduleInfo.workingDirSegments);
+        sourceRelPath = moduleInfo.sourceRelDir
+          ? `${moduleInfo.sourceRelDir}/${guiFilename}`
+          : guiFilename;
+        moduleId = moduleInfo.moduleAlias;
+      } else {
+        guiDir = path.join(workingDir, "tree", ...targetPath.split(".").filter(Boolean));
+      }
       await fs.mkdir(guiDir, { recursive: true });
-      const guiPath = path.join(guiDir, safeName + ".gui.json");
+      const guiPath = path.join(guiDir, guiFilename);
 
       const defaultManifest = {
         has_gui: true,
@@ -321,7 +410,6 @@ export function registerTreeNamespaceScriptIpcHandlers(
         actions: [],
       };
 
-      // Create the .gui.json file if it doesn't exist
       try {
         await fs.access(guiPath);
       } catch {
@@ -333,10 +421,80 @@ export function registerTreeNamespaceScriptIpcHandlers(
         parent_path: targetPath,
         name: safeName,
         relative_path: guiPath,
-        module_id: null,
+        module_id: moduleId,
+        source_rel_path: sourceRelPath,
       });
       return { success: true, guiPath, treePath };
     }
+  );
+
+  ipcMain.handle(
+    IPC.tree.createLib,
+    async (
+      _event,
+      kernelId: string,
+      targetPath: string,
+      libName: string,
+    ): Promise<TreeCreateLibResult> => {
+      if (!kernelManager.getKernel(kernelId)) {
+        throw new Error(`Kernel not found: ${kernelId}`);
+      }
+      let workingDir = kernelWorkingDirs.get(kernelId);
+      if (!workingDir) {
+        workingDir = await projectManager.createWorkingDir();
+        kernelWorkingDirs.set(kernelId, workingDir);
+      }
+      // Sanitize the filename — Python libs need their stem to be a valid
+      // import name, so we keep the usual alphanumeric-plus-underscore
+      // convention and guarantee a ``.py`` extension.
+      const rawName = libName.trim();
+      const stem = rawName.replace(/\.py$/i, "").replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_]/g, "");
+      if (!stem) {
+        return {
+          success: false,
+          error: "Lib name must contain at least one alphanumeric character",
+        };
+      }
+      const filename = `${stem}.py`;
+
+      // Libs are workflow-A/B territory — only allow creation when the
+      // target sits under a known module alias. Free-floating project
+      // libs are out of scope for this pass (and for v4 modules lib/
+      // is the only supported location).
+      const knownAliases = await getKnownModuleAliases();
+      const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
+      if (!moduleInfo) {
+        return {
+          success: false,
+          error: `tree:createLib target must live inside a known module — got ${JSON.stringify(targetPath)}`,
+        };
+      }
+
+      const libDir = path.join(workingDir, ...moduleInfo.workingDirSegments);
+      await fs.mkdir(libDir, { recursive: true });
+      const libPath = path.join(libDir, filename);
+      try {
+        await fs.access(libPath);
+      } catch {
+        await fs.writeFile(libPath, "", "utf-8");
+      }
+
+      const sourceRelPath = moduleInfo.sourceRelDir
+        ? `${moduleInfo.sourceRelDir}/${filename}`
+        : filename;
+
+      await commRouter.request(PDVMessageType.FILE_REGISTER, {
+        tree_path: targetPath,
+        filename,
+        node_type: "lib",
+        name: stem,
+        module_id: moduleInfo.moduleAlias,
+        source_rel_path: sourceRelPath,
+      } satisfies PDVFileRegisterPayload);
+
+      const treePath = targetPath ? `${targetPath}.${stem}` : stem;
+      return { success: true, libPath, treePath };
+    },
   );
 
   ipcMain.handle(
@@ -432,6 +590,25 @@ export function registerTreeNamespaceScriptIpcHandlers(
     if (!kernel) throw new Error(`Kernel not found: ${kernelId}`);
 
     const { treePath, params, executionId, origin } = request;
+
+    // Lib reload preflight: if this looks like a module-owned script (its
+    // tree path has at least one dot), ask the kernel to importlib.reload
+    // any lib files under ``<workdir>/<alias>/lib/`` so edits take effect
+    // on the next run. The kernel short-circuits when the first segment
+    // is not actually a PDVModule, so this is cheap for plain project
+    // scripts. Errors are swallowed — a reload failure must not block a
+    // script run; the error will surface again when the script actually
+    // imports the broken lib. See the #140 workflow plan §4.
+    const firstDot = treePath.indexOf(".");
+    if (firstDot > 0) {
+      const alias = treePath.slice(0, firstDot);
+      try {
+        await commRouter.request(PDVMessageType.MODULE_RELOAD_LIBS, { alias });
+      } catch (error) {
+        console.warn(`[pdv] reload_libs preflight failed for ${alias}:`, error);
+      }
+    }
+
     let code: string;
 
     if (kernel.language === "julia") {

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -80,6 +80,12 @@ export const IPC = {
     createNote: "tree:createNote",
     addFile: "tree:addFile",
     createGui: "tree:createGui",
+    /**
+     * Create a new PDVLib node (`.py` file) inside a module's `lib/`
+     * subtree. Used by workflow B of #140 — only valid when the target
+     * path is under a known module alias.
+     */
+    createLib: "tree:createLib",
     invokeHandler: "tree:invokeHandler",
     delete: "tree:delete",
   },
@@ -111,6 +117,24 @@ export const IPC = {
     removeImport: "modules:removeImport",
     uninstall: "modules:uninstall",
     update: "modules:update",
+    /**
+     * Create a brand-new empty PDVModule inside the active project
+     * (workflow B of issue #140). Seeds the tree with a top-level
+     * PDVModule and three conventional empty subtrees (scripts, lib,
+     * plots) plus working-dir scaffolding. The user populates content
+     * via the existing tree:create* handlers afterwards.
+     */
+    createEmpty: "modules:createEmpty",
+    /** Patch mutable metadata fields (name, version, description). */
+    updateMetadata: "modules:updateMetadata",
+    /**
+     * Publish the active-project copy of a module to the global store
+     * at ``~/.PDV/modules/packages/<id>/`` so other projects can import
+     * it. Used by workflow A (push edits back) and workflow B (publish
+     * a newly-authored module). See plan §9 and the follow-up #182 for
+     * the eventual "commit + push to GitHub upstream" flow.
+     */
+    exportFromProject: "modules:exportFromProject",
   },
   /** Namelist read/write channels. */
   namelist: {
@@ -597,6 +621,95 @@ export interface ModuleImportResult {
 }
 
 /**
+ * Request payload for `modules.createEmpty` (workflow B).
+ */
+export interface ModuleCreateEmptyRequest {
+  /** Stable module id — also used as the top-level tree alias. */
+  id: string;
+  /** Human-readable display name. */
+  name: string;
+  /** Initial semver string. */
+  version: string;
+  /** Optional longer description. */
+  description?: string;
+  /** Kernel language — defaults to the active kernel language if omitted. */
+  language?: "python" | "julia";
+}
+
+/**
+ * Result payload for `modules.createEmpty`.
+ */
+export interface ModuleCreateEmptyResult {
+  /** True when the module was created. */
+  success: boolean;
+  /** Created module alias (equals the request id on success). */
+  alias?: string;
+  /** Outcome classification on failure. */
+  status?: "created" | "conflict" | "error";
+  /** Alternate alias suggestion when the requested id already exists. */
+  suggestedAlias?: string;
+  /** Optional user-facing error message. */
+  error?: string;
+}
+
+/**
+ * Request payload for `modules.exportFromProject`.
+ */
+export interface ModuleExportRequest {
+  /** Project-local module alias to export. */
+  alias: string;
+  /**
+   * If true, overwrite any existing global-store copy without prompting.
+   * Defaults to false — the handler shows a confirm dialog before
+   * overwriting an existing module.
+   */
+  overwrite?: boolean;
+}
+
+/**
+ * Result payload for `modules.exportFromProject`.
+ */
+export interface ModuleExportResult {
+  /** True when the module was published to the global store. */
+  success: boolean;
+  /** Outcome classification. */
+  status?: "exported" | "cancelled" | "not_saved" | "error";
+  /** Absolute destination directory on success. */
+  destination?: string;
+  /** User-facing error message when the operation fails. */
+  error?: string;
+}
+
+/**
+ * Request payload for `modules.updateMetadata` (workflow B metadata editor).
+ */
+export interface ModuleUpdateMetadataRequest {
+  /** Target module alias — must refer to an existing PDVModule. */
+  alias: string;
+  /** New name, or omit to leave unchanged. */
+  name?: string;
+  /** New version, or omit to leave unchanged. */
+  version?: string;
+  /** New description, or omit to leave unchanged. */
+  description?: string;
+}
+
+/**
+ * Result payload for `modules.updateMetadata`.
+ */
+export interface ModuleUpdateMetadataResult {
+  /** True when the update succeeded. */
+  success: boolean;
+  /** Echoed current metadata after the update. */
+  alias?: string;
+  name?: string;
+  version?: string;
+  description?: string;
+  /** Optional user-facing error message. */
+  error?: string;
+}
+
+/**
  * Primitive value type accepted by module UI controls.
  */
 export type ModuleInputValue = string | number | boolean;
@@ -791,6 +904,7 @@ export interface MenuActionPayload {
     | "project:saveAs"
     | "recentProjects:clear"
     | "modules:import"
+    | "modules:newEmpty"
     | "settings:open";
   /** Project directory path for open-recent actions. */
   path?: string;
@@ -804,6 +918,7 @@ export interface MenuEnabledState {
   "project:save"?: boolean;
   "project:saveAs"?: boolean;
   "modules:import"?: boolean;
+  "modules:newEmpty"?: boolean;
 }
 
 /** Renderer-facing top-level menu button metadata. */
@@ -974,6 +1089,25 @@ export interface TreeCreateGuiResult {
   /** Absolute path to the created .gui.json file. */
   guiPath?: string;
   /** Dot-path of the created tree node. */
+  treePath?: string;
+}
+
+/**
+ * Result returned by `tree.createLib`.
+ *
+ * ``tree:createLib`` is workflow-B-only: it creates a new ``.py`` file
+ * under ``<module_alias>.lib`` (or a nested sub-path thereof). When the
+ * target does not live inside a known module alias, the handler returns
+ * ``{ success: false, error }``.
+ */
+export interface TreeCreateLibResult {
+  /** True when the lib file was created and the node was registered. */
+  success: boolean;
+  /** Optional error message when `success` is false. */
+  error?: string;
+  /** Absolute working-dir path to the created .py file. */
+  libPath?: string;
+  /** Dot-path of the created PDVLib tree node. */
   treePath?: string;
 }
 
@@ -1309,6 +1443,26 @@ export interface PDVApi {
       guiName: string
     ): Promise<TreeCreateGuiResult>;
     /**
+     * Create a new PDVLib (`.py`) node inside a module's `lib` subtree.
+     *
+     * Workflow B only — ``targetPath`` must live under a known module
+     * alias. Writes an empty ``<stem>.py`` to
+     * ``<workdir>/<alias>/.../<stem>.py`` and registers the node via
+     * ``pdv.file.register`` with ``source_rel_path`` set so §3's
+     * save-time sync mirrors future edits back to
+     * ``<saveDir>/modules/<alias>/.../<stem>.py``.
+     *
+     * @param kernelId - Target kernel ID.
+     * @param targetPath - Dot-path under which to register the lib.
+     * @param libName - Lib base name (optional ``.py`` suffix is stripped).
+     * @returns Lib creation result payload.
+     */
+    createLib(
+      kernelId: string,
+      targetPath: string,
+      libName: string
+    ): Promise<TreeCreateLibResult>;
+    /**
      * Copy a file into the kernel working directory and register it as a tree node.
      *
      * @param kernelId - Target kernel ID.
@@ -1530,6 +1684,28 @@ export interface PDVApi {
      * @returns Install result payload reflecting the update outcome.
      */
     update(moduleId: string): Promise<ModuleInstallResult>;
+    /**
+     * Create a brand-new empty PDVModule in the active project
+     * (workflow B of issue #140).
+     *
+     * @param request - Module identity + initial metadata.
+     * @returns Create result payload.
+     */
+    createEmpty(request: ModuleCreateEmptyRequest): Promise<ModuleCreateEmptyResult>;
+    /**
+     * Patch mutable metadata fields on an existing PDVModule.
+     *
+     * @param request - Partial metadata payload — omitted fields are left unchanged.
+     * @returns Update result payload.
+     */
+    updateMetadata(request: ModuleUpdateMetadataRequest): Promise<ModuleUpdateMetadataResult>;
+    /**
+     * Publish the project-local copy of a module to the global store.
+     *
+     * @param request - Export request payload (alias + overwrite flag).
+     * @returns Export result payload.
+     */
+    exportFromProject(request: ModuleExportRequest): Promise<ModuleExportResult>;
   };
 
   /** Project save/load operations. */

--- a/electron/main/kernel-manager-errors.test.ts
+++ b/electron/main/kernel-manager-errors.test.ts
@@ -23,9 +23,12 @@ describe("@slow KernelManager error paths", { timeout: 60_000 }, () => {
     km = new KernelManager();
   });
 
+  // Bump the hook timeout to 20s (up from vitest's 10s default) because
+  // real-kernel shutdown can hang briefly while zmq sockets close on a
+  // busy CI runner. Test timeout is already 60s via the describe options.
   afterEach(async () => {
     await km.shutdownAll();
-  });
+  }, 20_000);
 
   it("kernel crash -> kernel:crashed event emitted", async () => {
     const info = await startKernel();

--- a/electron/main/kernel-manager.test.ts
+++ b/electron/main/kernel-manager.test.ts
@@ -48,10 +48,13 @@ describe("@slow KernelManager (real kernel process)", { timeout: 60_000 }, () =>
     km = makeManager();
   });
 
+  // Bump the hook timeout to 20s (up from vitest's 10s default) because
+  // real-kernel shutdown can hang briefly while zmq sockets close on a
+  // busy CI runner. Test timeout is already 60s via the describe options.
   afterEach(async () => {
     // Always shut everything down even if a test failed partway through.
     await km.shutdownAll();
-  });
+  }, 20_000);
 
   // -------------------------------------------------------------------------
   // start()

--- a/electron/main/menu.ts
+++ b/electron/main/menu.ts
@@ -116,6 +116,13 @@ function buildTemplate(): MenuItemConstructorOptions[] {
           enabled: isEnabled("modules:import"),
           click: () => sendMenuAction({ action: "modules:import" }),
         },
+        {
+          id: "modules:newEmpty",
+          label: "New Module...",
+          accelerator: "CmdOrCtrl+Shift+M",
+          enabled: isEnabled("modules:newEmpty"),
+          click: () => sendMenuAction({ action: "modules:newEmpty" }),
+        },
         { type: "separator" },
         {
           id: "settings:open",

--- a/electron/main/module-manager.ts
+++ b/electron/main/module-manager.ts
@@ -826,6 +826,60 @@ export class ModuleManager {
   }
 
   /**
+   * Return the canonical global-store directory for a module id.
+   *
+   * Unlike {@link getModuleInstallPath}, this method always returns the
+   * packages-root path ``<~/.PDV/modules/packages/<moduleId>>`` regardless
+   * of whether the module is currently installed there. Used by
+   * ``modules:exportFromProject`` (workflow A/B §9) to decide where to
+   * publish an edited or in-session module.
+   *
+   * @param moduleId - Module identifier.
+   * @returns Absolute directory path where the module would live in the
+   *   global store, or null when the module id is empty/invalid.
+   */
+  getGlobalStorePath(moduleId: string): string | null {
+    if (!moduleId) return null;
+    return path.join(this.packagesRoot, moduleId);
+  }
+
+  /**
+   * Register (or refresh) a module directory in the global-store index.
+   *
+   * Used by ``modules:exportFromProject`` after the directory has been
+   * copied into ``<~/.PDV/modules/packages/<id>/>``. Reads the manifest
+   * from the freshly-placed copy, builds a {@link ModuleDescriptor},
+   * and upserts it into the store index so ``listInstalled()`` — and
+   * therefore the Import dialog — immediately see the new entry.
+   *
+   * The ``source`` field is set to a synthetic ``{ type: "local" }``
+   * pointing at the global-store directory itself, since an exported
+   * module has no natural upstream source (users can set ``upstream``
+   * in ``pdv-module.json`` separately if they want to track a git repo).
+   *
+   * @param moduleDir - Absolute directory inside the global store.
+   * @returns The descriptor that was upserted into the index.
+   * @throws {Error} When the manifest at ``moduleDir`` is invalid.
+   */
+  async registerInGlobalStore(moduleDir: string): Promise<ModuleDescriptor> {
+    const manifest = await this.readAndValidateManifest(moduleDir);
+    const descriptor: ModuleDescriptor = {
+      id: manifest.id,
+      name: manifest.name,
+      version: manifest.version,
+      description: manifest.description,
+      language: manifest.language,
+      source: { type: "local", location: moduleDir },
+      installPath: moduleDir,
+      upstream: manifest.upstream,
+    };
+    const index = await this.readIndex();
+    this.upsertIndex(index, descriptor);
+    await this.writeIndex(index);
+    return descriptor;
+  }
+
+  /**
    * Return the declared dependencies for one module from its manifest.
    *
    * @param moduleId - Module identifier.
@@ -892,48 +946,6 @@ export class ModuleManager {
       throw new Error(`module-index.json must be an array in ${indexPath}`);
     }
     return parsed as NodeDescriptor[];
-  }
-
-  /**
-   * Resolve declared module files from the manifest `files` array.
-   *
-   * @param moduleId - Installed module identifier.
-   * @returns Resolved file descriptors with absolute paths.
-   * @throws {Error} When module is not installed or a file doesn't exist.
-   */
-  async resolveModuleFiles(
-    moduleId: string,
-    projectDir?: string | null,
-  ): Promise<Array<{ name: string; path: string; type: "namelist" | "lib" | "file" }>> {
-    const module = await this.resolveModuleRecord(moduleId, projectDir);
-    if (!module) {
-      return [];
-    }
-    const moduleDir = module.installPath ?? path.join(this.packagesRoot, moduleId);
-    const manifest = await this.readAndValidateManifest(moduleDir);
-    if (!manifest.files || manifest.files.length === 0) {
-      return [];
-    }
-    const resolved: Array<{ name: string; path: string; type: "namelist" | "lib" | "file" }> = [];
-    for (const file of manifest.files) {
-      const absPath = path.resolve(moduleDir, file.path);
-      try {
-        const stat = await fs.stat(absPath);
-        if (!stat.isFile()) {
-          console.warn(`[pdv] Module file is not a file: ${file.path} (${moduleId})`);
-          continue;
-        }
-      } catch {
-        console.warn(`[pdv] Module file not found: ${file.path} (${moduleId})`);
-        continue;
-      }
-      resolved.push({
-        name: file.name,
-        path: absPath,
-        type: file.type,
-      });
-    }
-    return resolved;
   }
 
   /**

--- a/electron/main/module-manifest-writer.ts
+++ b/electron/main/module-manifest-writer.ts
@@ -1,0 +1,112 @@
+/**
+ * module-manifest-writer.ts — Write ``pdv-module.json`` and
+ * ``module-index.json`` into a project-local module directory.
+ *
+ * Responsibilities:
+ * - Produce a v4-shaped ``pdv-module.json`` from in-memory module metadata.
+ * - Persist a ``module-index.json`` node descriptor list alongside it.
+ *
+ * Non-responsibilities:
+ * - Collecting the descriptors (kernel-side in
+ *   ``pdv_kernel.handlers.project._collect_module_manifests``).
+ * - Copying file contents into ``<moduleDir>/`` (``ipc-register-project.ts``
+ *   handles that via the §3 save-time sync step).
+ *
+ * See Also
+ * --------
+ * ARCHITECTURE.md §5.13 (module storage and resolution),
+ * ~/.claude/plans/parsed-mapping-creek.md §7.
+ */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+
+/**
+ * Subset of ``pdv-module.json`` fields that ``writeModuleManifest`` emits.
+ * Mirrors the v4 schema documented in ARCHITECTURE.md §5.13 — optional
+ * fields are omitted from the output when undefined so the resulting
+ * JSON stays minimal and diff-friendly.
+ */
+export interface ModuleManifestInput {
+  /** Unique module identifier (directory name under ``<saveDir>/modules/``). */
+  id: string;
+  /** Human-readable display name. */
+  name: string;
+  /** Semver version string. */
+  version: string;
+  /** Optional longer description surfaced in the modules list UI. */
+  description?: string;
+  /** Kernel language (defaults to ``"python"`` when omitted). */
+  language?: "python" | "julia";
+  /** Optional entry-point Python module name (e.g. ``"n_pendulum"``). */
+  entryPoint?: string;
+  /** Optional relative path to the lib directory (defaults to ``"lib"``). */
+  libDir?: string;
+  /** Optional relative path to the default GUI file. */
+  defaultGui?: string;
+  /** Optional dependency list (raw dicts passed through to JSON). */
+  dependencies?: Array<Record<string, unknown>>;
+}
+
+/**
+ * A single ``module-index.json`` entry. The kernel side builds these
+ * via ``_collect_module_manifests`` in ``handlers/project.py`` — we
+ * just typecheck that they're plain JSON-able dicts on the way out.
+ */
+export type ModuleIndexEntry = Record<string, unknown>;
+
+/**
+ * Write a v4 ``pdv-module.json`` into ``moduleDir``.
+ *
+ * Creates the destination directory on demand. Optional fields of
+ * {@link ModuleManifestInput} are dropped from the output when unset.
+ *
+ * @param moduleDir - Absolute path to ``<saveDir>/modules/<id>/``.
+ * @param input - Module metadata collected from the kernel.
+ * @returns Nothing.
+ * @throws {Error} When ``moduleDir`` cannot be created or the manifest
+ *   cannot be written.
+ */
+export async function writeModuleManifest(
+  moduleDir: string,
+  input: ModuleManifestInput,
+): Promise<void> {
+  await fs.mkdir(moduleDir, { recursive: true });
+  const manifest: Record<string, unknown> = {
+    schema_version: "4",
+    id: input.id,
+    name: input.name,
+    version: input.version,
+    language: input.language ?? "python",
+  };
+  if (input.description) manifest.description = input.description;
+  if (input.entryPoint) manifest.entry_point = input.entryPoint;
+  if (input.libDir) manifest.lib_dir = input.libDir;
+  if (input.defaultGui) manifest.default_gui = input.defaultGui;
+  if (input.dependencies && input.dependencies.length > 0) {
+    manifest.dependencies = input.dependencies;
+  }
+  const target = path.join(moduleDir, "pdv-module.json");
+  await fs.writeFile(target, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+}
+
+/**
+ * Write a v4 ``module-index.json`` into ``moduleDir``.
+ *
+ * The descriptor list is written as-is after normalizing the wrapping
+ * JSON structure — the kernel-side collector is authoritative on the
+ * shape of each entry, and this writer is intentionally dumb.
+ *
+ * @param moduleDir - Absolute path to ``<saveDir>/modules/<id>/``.
+ * @param entries - Node descriptors rooted at the module.
+ * @returns Nothing.
+ * @throws {Error} When the index file cannot be written.
+ */
+export async function writeModuleIndex(
+  moduleDir: string,
+  entries: ModuleIndexEntry[],
+): Promise<void> {
+  await fs.mkdir(moduleDir, { recursive: true });
+  const target = path.join(moduleDir, "module-index.json");
+  await fs.writeFile(target, JSON.stringify(entries, null, 2) + "\n", "utf8");
+}

--- a/electron/main/module-runtime.ts
+++ b/electron/main/module-runtime.ts
@@ -223,35 +223,59 @@ export async function buildModulesSetupPayload(
 }
 
 /**
- * Bind one imported v4 module into the kernel tree using module-index.json.
+ * Bind one imported module into the kernel tree.
  *
- * Reads `module-index.json`, copies all `local_file` backend files to the
- * working directory, remaps storage paths, and sends a single MODULE_REGISTER
- * message with the full `module_index` for the kernel to reconstruct the tree.
+ * v4-only: reads `module-index.json`, copies every `local_file` backend file
+ * to the working directory under `<alias>/<relative_path>`, remaps the storage
+ * paths, and sends a single MODULE_REGISTER message with the full remapped
+ * module_index so the kernel can reconstruct the subtree in one pass.
  *
- * @param commRouter - Comm router for MODULE_REGISTER.
- * @param moduleManager - Module manager for install path and index reads.
- * @param importedModule - Imported module entry.
+ * Non-v4 modules (no `module-index.json`) are rejected with a clear error.
+ * The legacy (v1/v2/v3) per-node registration flow was removed as part of
+ * the #140 module editing workflow — see the plan at
+ * ~/.claude/plans/parsed-mapping-creek.md §1.
+ *
+ * @param commRouter - Comm router used for comm messages.
+ * @param moduleManager - Module manager for manifest resolution.
+ * @param importedModule - Imported module entry (module id + alias).
  * @param workingDir - Optional kernel working directory.
- * @param moduleName - Display name for the module.
- * @param moduleVersion - Version string for the module.
+ * @returns Nothing.
+ * @throws {Error} When the module is not a v4 module, or when install path
+ *   resolution / index reading / file copies fail.
  */
-async function bindImportedModuleV4(
+export async function bindImportedModule(
   commRouter: CommRouter,
   moduleManager: ModuleManager,
   importedModule: ProjectModuleImport,
   workingDir: string | undefined,
-  moduleName: string,
-  moduleVersion: string,
   projectDir?: string | null,
 ): Promise<void> {
+  const installed = await moduleManager.listInstalled();
+  const moduleDesc = installed.find((m) => m.id === importedModule.module_id);
+  const moduleName = moduleDesc?.name ?? importedModule.module_id;
+  const moduleVersion = moduleDesc?.version ?? importedModule.version;
+
+  const isV4 = await moduleManager.isV4Module(importedModule.module_id, projectDir);
+  if (!isV4) {
+    throw new Error(
+      `Module ${importedModule.module_id} is not a v4 module (no module-index.json). ` +
+        `Non-v4 modules are no longer supported — reinstall from an updated source.`,
+    );
+  }
+
   const installPath = await moduleManager.resolveModuleDir(importedModule.module_id, projectDir);
-  if (!installPath) return;
+  if (!installPath) {
+    throw new Error(`Could not resolve install directory for module ${importedModule.module_id}`);
+  }
 
   const moduleIndex = await moduleManager.readModuleIndex(installPath);
 
-  // Copy all local_file backend files to workingDir/<alias>/<relative_path>
-  // and build a remapped index with updated relative_paths.
+  // Copy each local_file backend file to workingDir/<alias>/<relative_path>
+  // and build a remapped index with updated relative_paths. Each remapped
+  // entry also carries `source_rel_path` — the original module-rooted
+  // rel-path (e.g. "scripts/run.py") — so the save-time sync step can
+  // mirror working-dir edits back into <saveDir>/modules/<id>/. See
+  // ARCHITECTURE.md §5.13.
   const remappedIndex = await Promise.all(
     moduleIndex.map(async (node) => {
       const nodeAny = node as unknown as Record<string, unknown>;
@@ -269,12 +293,14 @@ async function bindImportedModuleV4(
       return {
         ...node,
         storage: { ...storage, relative_path: destRelPath },
+        source_rel_path: relPath,
       };
-    })
+    }),
   );
 
   const dependencies = await moduleManager.getModuleDependencies(
-    importedModule.module_id, projectDir,
+    importedModule.module_id,
+    projectDir,
   );
 
   await commRouter.request(PDVMessageType.MODULE_REGISTER, {
@@ -285,221 +311,6 @@ async function bindImportedModuleV4(
     module_index: remappedIndex,
     dependencies,
   });
-}
-
-/**
- * Bind one imported module into the kernel tree.
- *
- * For v4 modules: reads module-index.json, copies files, sends MODULE_REGISTER
- * with the full tree index so the kernel reconstructs the subtree in one pass.
- *
- * For v1/v2/v3 modules: uses the legacy per-node registration flow
- * (MODULE_REGISTER → GUI_REGISTER → FILE_REGISTER → SCRIPT_REGISTER).
- *
- * @param commRouter - Comm router used for comm messages.
- * @param moduleManager - Module manager for manifest resolution.
- * @param importedModule - Imported module entry (module id + alias).
- * @param workingDir - Optional kernel working directory.
- * @returns Nothing.
- * @throws {Error} For structural module resolution errors.
- */
-export async function bindImportedModule(
-  commRouter: CommRouter,
-  moduleManager: ModuleManager,
-  importedModule: ProjectModuleImport,
-  workingDir: string | undefined,
-  projectDir?: string | null,
-): Promise<void> {
-  // 1. Get module identity info
-  const installed = await moduleManager.listInstalled();
-  const moduleDesc = installed.find((m) => m.id === importedModule.module_id);
-  const moduleName = moduleDesc?.name ?? importedModule.module_id;
-  const moduleVersion = moduleDesc?.version ?? importedModule.version;
-
-  // Check if this is a v4 module (uses module-index.json)
-  const isV4 = await moduleManager.isV4Module(importedModule.module_id, projectDir);
-  if (isV4) {
-    await bindImportedModuleV4(commRouter, moduleManager, importedModule, workingDir, moduleName, moduleVersion, projectDir);
-    return;
-  }
-
-  const installPath = await moduleManager.resolveModuleDir(importedModule.module_id, projectDir);
-
-  // 2. Register PDVModule node at the alias path
-  const dependencies = await moduleManager.getModuleDependencies(
-    importedModule.module_id, projectDir,
-  );
-  await commRouter.request(PDVMessageType.MODULE_REGISTER, {
-    path: importedModule.alias,
-    module_id: importedModule.module_id,
-    name: moduleName,
-    version: moduleVersion,
-    dependencies,
-  });
-
-  // 3. If module has a GUI, copy gui.json and register PDVGui node
-  let guiInfo: { hasGui: boolean };
-  try {
-    guiInfo = await moduleManager.getModuleGuiInfo(importedModule.module_id, projectDir);
-  } catch {
-    guiInfo = { hasGui: false };
-  }
-  if (guiInfo.hasGui) {
-    if (installPath && workingDir) {
-      const sourceGuiPath = path.join(installPath, "gui.json");
-      try {
-        await fs.stat(sourceGuiPath);
-        const destDir = path.join(workingDir, importedModule.alias);
-        await fs.mkdir(destDir, { recursive: true });
-        const destGuiPath = path.join(destDir, "gui.gui.json");
-        await fs.copyFile(sourceGuiPath, destGuiPath);
-
-        await commRouter.request(PDVMessageType.GUI_REGISTER, {
-          parent_path: importedModule.alias,
-          name: "gui",
-          relative_path: destGuiPath,
-          module_id: importedModule.module_id,
-        });
-      } catch (error) {
-        console.warn('[pdv] gui.json register failed:', error);
-      }
-    }
-  }
-
-  // 4. Copy module files (namelists, fortran sources, etc.) and register them
-  try {
-    const moduleFiles = await moduleManager.resolveModuleFiles(importedModule.module_id, projectDir);
-    for (const file of moduleFiles) {
-      if (!workingDir) continue;
-      const segments = importedModule.alias.split(".").filter(Boolean);
-      const destDir = path.join(workingDir, ...segments);
-      await fs.mkdir(destDir, { recursive: true });
-      const destPath = path.join(destDir, path.basename(file.path));
-      await fs.copyFile(file.path, destPath);
-
-      await commRouter.request(PDVMessageType.FILE_REGISTER, {
-        tree_path: importedModule.alias,
-        filename: path.basename(file.path),
-        node_type: file.type,
-        name: file.name,
-      });
-    }
-  } catch (error) {
-    console.warn(
-      `[pdv] Failed to register module files for ${importedModule.module_id}:`,
-      error
-    );
-  }
-
-  // 5. Copy lib/ Python files and register as PDVFile nodes.
-  await bindImportedModuleLibFilesLegacy(commRouter, moduleManager, importedModule, workingDir, projectDir);
-
-  // 6. Bind scripts
-  await bindImportedModuleScriptsLegacy(commRouter, moduleManager, importedModule, workingDir, projectDir);
-}
-
-/**
- * Legacy (v1/v2/v3): Copy lib/ Python files and register as PDVFile nodes.
- */
-async function bindImportedModuleLibFilesLegacy(
-  commRouter: CommRouter,
-  moduleManager: ModuleManager,
-  importedModule: ProjectModuleImport,
-  workingDir: string | undefined,
-  projectDir?: string | null,
-): Promise<void> {
-  if (!workingDir) return;
-
-  const installPath = await moduleManager.resolveModuleDir(importedModule.module_id, projectDir);
-  if (!installPath) return;
-
-  const libDir = path.join(installPath, "lib");
-  const pyFiles = await collectPyFilesLegacy(libDir);
-  if (pyFiles.length === 0) return;
-
-  for (const relFile of pyFiles) {
-    const srcPath = path.join(libDir, relFile);
-    const destDir = path.join(
-      workingDir,
-      ...importedModule.alias.split(".").filter(Boolean),
-      "lib",
-      path.dirname(relFile)
-    );
-    await fs.mkdir(destDir, { recursive: true });
-    const destPath = path.join(destDir, path.basename(relFile));
-    await fs.copyFile(srcPath, destPath);
-
-    const stem = relFile.replace(/[/\\]/g, "_").replace(/\.py$/, "_py");
-    await commRouter.request(PDVMessageType.FILE_REGISTER, {
-      tree_path: `${importedModule.alias}.lib`,
-      filename: path.basename(relFile),
-      node_type: "lib",
-      name: stem,
-      module_id: importedModule.module_id,
-    });
-  }
-}
-
-/**
- * Legacy (v1/v2/v3): Recursively collect all `.py` files under a directory.
- */
-async function collectPyFilesLegacy(dir: string): Promise<string[]> {
-  const results: string[] = [];
-  let entries: import("fs").Dirent[];
-  try {
-    entries = await fs.readdir(dir, { withFileTypes: true }) as unknown as import("fs").Dirent[];
-  } catch {
-    return results;
-  }
-  for (const entry of entries) {
-    const rel = entry.name;
-    if (entry.isFile() && rel.endsWith(".py")) {
-      results.push(rel);
-    } else if (entry.isDirectory()) {
-      const subFiles = await collectPyFilesLegacy(path.join(dir, rel));
-      for (const sub of subFiles) {
-        results.push(path.join(rel, sub));
-      }
-    }
-  }
-  return results;
-}
-
-/**
- * Legacy (v1/v2/v3): Bind action scripts under `<alias>.scripts.<name>`.
- */
-async function bindImportedModuleScriptsLegacy(
-  commRouter: CommRouter,
-  moduleManager: ModuleManager,
-  importedModule: ProjectModuleImport,
-  workingDir: string | undefined,
-  projectDir?: string | null,
-): Promise<void> {
-  let scriptBindings: Awaited<ReturnType<ModuleManager["resolveActionScripts"]>>;
-  try {
-    scriptBindings = await moduleManager.resolveActionScripts(importedModule.module_id, projectDir);
-  } catch (error) {
-    if (isMissingActionScriptError(error)) return;
-    throw error;
-  }
-  const parentPath = `${importedModule.alias}.scripts`;
-  for (const binding of scriptBindings) {
-    let registeredPath = binding.scriptPath;
-    if (workingDir) {
-      const destDir = path.join(workingDir, ...parentPath.split(".").filter(Boolean));
-      await fs.mkdir(destDir, { recursive: true });
-      const destPath = path.join(destDir, path.basename(binding.scriptPath));
-      await fs.copyFile(binding.scriptPath, destPath);
-      registeredPath = destPath;
-    }
-    await commRouter.request(PDVMessageType.SCRIPT_REGISTER, {
-      parent_path: parentPath,
-      name: binding.name,
-      relative_path: registeredPath,
-      language: "python",
-      reload: true,
-    });
-  }
 }
 
 /**

--- a/electron/main/module-runtime.ts
+++ b/electron/main/module-runtime.ts
@@ -205,7 +205,11 @@ export async function buildModulesSetupPayload(
       const info = await moduleManager.getModuleSetupInfo(imp.module_id, projectDir);
       let libDir: string | undefined;
       if (workingDir && info.libDir) {
-        libDir = path.join(workingDir, imp.alias, info.libDir);
+        // Module-owned files live under ``<workdir>/tree/<alias>/...``
+        // post-Option-A (see bindImportedModule above); the lib dir
+        // passed to the kernel's ``pdv.modules.setup`` handler follows
+        // that same layout so ``sys.path`` points at the right place.
+        libDir = path.join(workingDir, "tree", imp.alias, info.libDir);
       }
       modules.push({
         lib_paths: [],
@@ -270,12 +274,24 @@ export async function bindImportedModule(
 
   const moduleIndex = await moduleManager.readModuleIndex(installPath);
 
-  // Copy each local_file backend file to workingDir/<alias>/<relative_path>
-  // and build a remapped index with updated relative_paths. Each remapped
-  // entry also carries `source_rel_path` — the original module-rooted
-  // rel-path (e.g. "scripts/run.py") — so the save-time sync step can
-  // mirror working-dir edits back into <saveDir>/modules/<id>/. See
-  // ARCHITECTURE.md §5.13.
+  // Copy each local_file backend file to
+  // ``<workdir>/tree/<alias>/<relative_path>`` and build a remapped
+  // index with updated ``relative_paths``. The ``tree/`` prefix is the
+  // canonical working-dir/save-dir subdir for file-backed nodes
+  // (ARCHITECTURE.md §6.1/§6.2): ``serialize_node`` writes there,
+  // ``copyFilesForLoad`` mirrors from there, and the Option A fix in
+  // the #140 PR aligns every file-backed-node creation path on the
+  // same layout so in-memory ``relative_path`` stays stable across
+  // save/load cycles.
+  //
+  // Each remapped entry also carries ``source_rel_path`` — the
+  // original module-rooted rel-path (e.g. ``scripts/run.py``) — so
+  // the save-time sync step (§3) can mirror working-dir edits back
+  // into ``<saveDir>/modules/<id>/<source_rel_path>``.
+  //
+  // TODO(UUID): once the UUID-based file storage redesign lands this
+  // layout becomes ``tree/<uuid>/<filename>``; source_rel_path is
+  // unaffected because it is intentionally tree-path-agnostic.
   const remappedIndex = await Promise.all(
     moduleIndex.map(async (node) => {
       const nodeAny = node as unknown as Record<string, unknown>;
@@ -285,7 +301,7 @@ export async function bindImportedModule(
       if (!relPath || !workingDir) return node;
 
       const srcPath = path.join(installPath, relPath);
-      const destRelPath = path.join(importedModule.alias, relPath);
+      const destRelPath = path.join("tree", importedModule.alias, relPath);
       const destPath = path.join(workingDir, destRelPath);
       await fs.mkdir(path.dirname(destPath), { recursive: true });
       await fs.copyFile(srcPath, destPath);

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -146,6 +146,21 @@ export const PDVMessageType = {
   MODULE_REGISTER: "pdv.module.register",
   /** Kernel → app. Confirms module registration. */
   MODULE_REGISTER_RESPONSE: "pdv.module.register.response",
+  /**
+   * App → kernel. Create an empty PDVModule at the top of the tree
+   * with three conventional subtrees (``scripts``, ``lib``, ``plots``).
+   * Used by workflow B of the #140 module editing plan.
+   */
+  MODULE_CREATE_EMPTY: "pdv.module.create_empty",
+  /** Kernel → app. Confirms empty-module creation. */
+  MODULE_CREATE_EMPTY_RESPONSE: "pdv.module.create_empty.response",
+  /**
+   * App → kernel. Patch mutable metadata fields (name, version, description)
+   * on an existing PDVModule. module_id and language are read-only.
+   */
+  MODULE_UPDATE: "pdv.module.update",
+  /** Kernel → app. Confirms module metadata update; echoes the new values. */
+  MODULE_UPDATE_RESPONSE: "pdv.module.update.response",
   /** App → kernel. Register a PDVGui node in the tree. */
   GUI_REGISTER: "pdv.gui.register",
   /** Kernel → app. Confirms GUI registration. */
@@ -166,6 +181,15 @@ export const PDVMessageType = {
   MODULES_SETUP: "pdv.modules.setup",
   /** Kernel → app. Confirms module setup; carries registered handler map. */
   MODULES_SETUP_RESPONSE: "pdv.modules.setup.response",
+  /**
+   * App → kernel. importlib.reload every Python module whose ``__file__``
+   * sits under ``<workdir>/<alias>/lib/``. Called as a preflight before
+   * ``script:run`` on a module-owned script so lib edits take effect on
+   * the next run without restarting the kernel. See the #140 workflow plan §4.
+   */
+  MODULE_RELOAD_LIBS: "pdv.module.reload_libs",
+  /** Kernel → app. Lists reloaded module names and any per-module errors. */
+  MODULE_RELOAD_LIBS_RESPONSE: "pdv.module.reload_libs.response",
   /** App → kernel. Invoke a registered type handler for a tree node. */
   HANDLER_INVOKE: "pdv.handler.invoke",
   /** Kernel → app. Confirms handler invocation result. */
@@ -351,6 +375,13 @@ export interface PDVFileRegisterPayload {
   name?: string;
   /** Optional module ID that owns this file node. */
   module_id?: string;
+  /**
+   * Optional path relative to the owning module's root
+   * (e.g. ``"lib/helpers.py"``). Set by ``tree:createLib`` /
+   * module bind path for workflow A/B save-time sync. See
+   * ARCHITECTURE.md §5.13.
+   */
+  source_rel_path?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -427,6 +458,10 @@ export interface NodeDescriptor {
   module_name?: string;
   /** Module version. Present when type is "module". */
   module_version?: string;
+  /** Module description. Present when type is "module" and a description is set. */
+  module_description?: string;
+  /** Module kernel language. Present when type is "module". */
+  module_language?: "python" | "julia";
 }
 
 // ---------------------------------------------------------------------------

--- a/electron/main/project-manager.ts
+++ b/electron/main/project-manager.ts
@@ -49,6 +49,17 @@ export interface ProjectModuleImport {
   version: string;
   /** Optional imported revision hash. */
   revision?: string;
+  /**
+   * How this module entered the project.
+   *
+   * - ``"imported"`` (default): copied from the global store via
+   *   ``modules:importToProject``.
+   * - ``"in_session"``: authored in-app via ``modules:createEmpty``
+   *   (workflow B of the #140 module editing workflow). On project load,
+   *   in-session modules are restored from ``<saveDir>/modules/<id>/``
+   *   since they have no upstream install path to fall back to.
+   */
+  origin?: "imported" | "in_session";
 }
 
 /**
@@ -83,6 +94,47 @@ export interface ProjectManifest {
   modules: ProjectModuleImport[];
   /** Persisted per-module settings keyed by module alias. */
   module_settings: Record<string, Record<string, unknown>>;
+}
+
+/**
+ * A file-backed tree node that belongs to a ``PDVModule`` and therefore
+ * needs to be mirrored from the working directory back into
+ * ``<saveDir>/modules/<module_id>/<source_rel_path>`` during save.
+ *
+ * Emitted by the kernel's ``handle_project_save`` in the save response,
+ * consumed by the project:save IPC handler. See ARCHITECTURE.md §5.13
+ * and the #140 module editing workflow plan §3.
+ */
+export interface ModuleOwnedFile {
+  /** Owning module's stable id (matches ``<saveDir>/modules/<id>/``). */
+  module_id: string;
+  /** Path of the file relative to its module root, e.g. ``scripts/run.py``. */
+  source_rel_path: string;
+  /** Absolute on-disk path of the file as it currently exists in the working directory. */
+  workdir_path: string;
+}
+
+/**
+ * Per-module manifest bundle emitted by the kernel's ``project:save`` handler.
+ *
+ * Used by ``ipc-register-project.ts`` to write ``pdv-module.json`` and
+ * ``module-index.json`` into ``<saveDir>/modules/<module_id>/`` so that
+ * an in-session module can be rebound at project-load time via the
+ * existing v4 bind path, and so that a subsequent export (§9) can
+ * publish the module to the global store. See the #140 workflow plan §7.
+ */
+export interface ModuleManifestBundle {
+  module_id: string;
+  name: string;
+  version: string;
+  description?: string;
+  language?: "python" | "julia";
+  dependencies?: Array<Record<string, unknown>>;
+  /**
+   * Module-root-relative node descriptors — the same shape used in the
+   * v4 ``module-index.json`` format consumed by ``bindImportedModule``.
+   */
+  entries: Array<Record<string, unknown>>;
 }
 
 /** Current schema major version. Increment on breaking changes to project.json. */
@@ -182,7 +234,12 @@ export class ProjectManager {
     saveDir: string,
     codeCells: unknown,
     options?: { language?: "python" | "julia"; interpreterPath?: string; projectName?: string }
-  ): Promise<{ checksum: string; nodeCount: number }> {
+  ): Promise<{
+    checksum: string;
+    nodeCount: number;
+    moduleOwnedFiles: ModuleOwnedFile[];
+    moduleManifests: ModuleManifestBundle[];
+  }> {
     // Ensure the save directory exists (creates it when the user enters a new project name
     // via the Save As dialog, so the folder hasn't been created yet).
     await fs.mkdir(saveDir, { recursive: true });
@@ -193,9 +250,20 @@ export class ProjectManager {
       save_dir: saveDir,
     }, { keepAlivePushType: PDVMessageType.PROGRESS });
 
-    const payload = response.payload as { checksum?: string; node_count?: number };
+    const payload = response.payload as {
+      checksum?: string;
+      node_count?: number;
+      module_owned_files?: ModuleOwnedFile[];
+      module_manifests?: ModuleManifestBundle[];
+    };
     const checksum = payload.checksum ?? "";
     const nodeCount = payload.node_count ?? 0;
+    const moduleOwnedFiles = Array.isArray(payload.module_owned_files)
+      ? payload.module_owned_files
+      : [];
+    const moduleManifests = Array.isArray(payload.module_manifests)
+      ? payload.module_manifests
+      : [];
 
     // Step 2 — write code-cells.json.
     await fs.writeFile(
@@ -237,7 +305,7 @@ export class ProjectManager {
       "utf8"
     );
 
-    return { checksum, nodeCount };
+    return { checksum, nodeCount, moduleOwnedFiles, moduleManifests };
   }
 
   /**

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -66,6 +66,8 @@ const api: PDVApi = {
       ipcRenderer.invoke(IPC.tree.createNote, kernelId, targetPath, noteName),
     createGui: (kernelId, targetPath, guiName) =>
       ipcRenderer.invoke(IPC.tree.createGui, kernelId, targetPath, guiName),
+    createLib: (kernelId, targetPath, libName) =>
+      ipcRenderer.invoke(IPC.tree.createLib, kernelId, targetPath, libName),
     addFile: (kernelId, sourcePath, targetTreePath, nodeType, filename) =>
       ipcRenderer.invoke(IPC.tree.addFile, kernelId, sourcePath, targetTreePath, nodeType, filename),
     invokeHandler: (kernelId, nodePath) =>
@@ -119,6 +121,9 @@ const api: PDVApi = {
     removeImport: (moduleAlias) => ipcRenderer.invoke(IPC.modules.removeImport, moduleAlias),
     uninstall: (moduleId) => ipcRenderer.invoke(IPC.modules.uninstall, moduleId),
     update: (moduleId) => ipcRenderer.invoke(IPC.modules.update, moduleId),
+    createEmpty: (request) => ipcRenderer.invoke(IPC.modules.createEmpty, request),
+    updateMetadata: (request) => ipcRenderer.invoke(IPC.modules.updateMetadata, request),
+    exportFromProject: (request) => ipcRenderer.invoke(IPC.modules.exportFromProject, request),
   },
   project: {
     save: (saveDir, codeCells, projectName) =>

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -21,7 +21,10 @@ import { StatusBar } from '../components/StatusBar';
 import { NamespaceView } from '../components/NamespaceView';
 import { ScriptDialog } from '../components/ScriptDialog';
 import { CreateScriptDialog } from '../components/Tree/CreateScriptDialog';
+import { CreateLibDialog } from '../components/Tree/CreateLibDialog';
 import { CreateGuiDialog } from '../components/Tree/CreateGuiDialog';
+import { NewModuleDialog } from '../components/NewModuleDialog';
+import { ModuleMetadataDialog } from '../components/ModuleMetadataDialog';
 import { CreateNoteDialog } from '../components/Tree/CreateNoteDialog';
 import { TitleBar } from '../components/TitleBar';
 import { WriteTab } from '../components/WriteTab';
@@ -135,6 +138,11 @@ const App: React.FC = () => {
   const [createScriptTarget, setCreateScriptTarget] = useState<string | null>(null);
   const [createNoteTarget, setCreateNoteTarget] = useState<string | null>(null);
   const [createGuiTarget, setCreateGuiTarget] = useState<string | null>(null);
+  const [createLibTarget, setCreateLibTarget] = useState<string | null>(null);
+  const [showNewModuleDialog, setShowNewModuleDialog] = useState(false);
+  const [moduleMetadataTarget, setModuleMetadataTarget] = useState<
+    { alias: string; name: string; version: string; description?: string; language?: 'python' | 'julia' } | null
+  >(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showImportModule, setShowImportModule] = useState(false);
   const [showSaveAsDialog, setShowSaveAsDialog] = useState(false);
@@ -298,6 +306,8 @@ const App: React.FC = () => {
         if (payload.path) void handleOpenRecentRef.current?.(payload.path);
       } else if (payload.action === 'modules:import') {
         setShowImportModule(true);
+      } else if (payload.action === 'modules:newEmpty') {
+        setShowNewModuleDialog(true);
       } else if (payload.action === 'settings:open') {
         setSettingsInitialTab('general');
         setShowSettings(true);
@@ -322,6 +332,7 @@ const App: React.FC = () => {
       'project:save': kernelReady,
       'project:saveAs': kernelReady,
       'modules:import': kernelReady,
+      'modules:newEmpty': kernelReady,
     });
   }, [kernelReady]);
 
@@ -485,10 +496,13 @@ const App: React.FC = () => {
       if (createScriptTarget) { setCreateScriptTarget(null); return; }
       if (createNoteTarget) { setCreateNoteTarget(null); return; }
       if (createGuiTarget) { setCreateGuiTarget(null); return; }
+      if (createLibTarget) { setCreateLibTarget(null); return; }
+      if (showNewModuleDialog) { setShowNewModuleDialog(false); return; }
+      if (moduleMetadataTarget) { setModuleMetadataTarget(null); return; }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [showSaveAsDialog, showImportModule, scriptDialog, createScriptTarget, createNoteTarget, createGuiTarget]);
+  }, [showSaveAsDialog, showImportModule, scriptDialog, createScriptTarget, createNoteTarget, createGuiTarget, createLibTarget, showNewModuleDialog, moduleMetadataTarget]);
 
   const handleSettingsSave = async (updates: Partial<Config>) => {
     await window.pdv.config.set(updates);
@@ -608,6 +622,33 @@ const App: React.FC = () => {
     }
     if (action === 'create_script') {
       setCreateScriptTarget(node.path);
+    } else if (action === 'create_lib') {
+      setCreateLibTarget(node.path);
+    } else if (action === 'edit_module_metadata' && node.type === 'module') {
+      setModuleMetadataTarget({
+        alias: node.path || node.key,
+        name: node.moduleName ?? node.key,
+        version: node.moduleVersion ?? '0.1.0',
+        description: node.moduleDescription,
+        language: node.moduleLanguage,
+      });
+    } else if (action === 'export_module' && node.type === 'module') {
+      try {
+        const result = await window.pdv.modules.exportFromProject({
+          alias: node.path || node.key,
+        });
+        if (!result.success) {
+          if (result.status !== 'cancelled') {
+            setLastError(result.error ?? 'Failed to export module');
+          }
+        } else {
+          // Trigger an installed-modules refresh so the Import dialog
+          // picks up the newly-published module for future imports.
+          setModulesRefreshToken((t) => t + 1);
+        }
+      } catch (error) {
+        setLastError(error instanceof Error ? error.message : String(error));
+      }
     } else if (action === 'create_note') {
       setCreateNoteTarget(node.path);
     } else if (action === 'open_note' && node.type === 'markdown') {
@@ -1255,6 +1296,58 @@ const App: React.FC = () => {
             } finally {
               setCreateGuiTarget(null);
             }
+          }}
+        />
+      )}
+
+      {createLibTarget !== null && currentKernelId && (
+        <CreateLibDialog
+          parentPath={createLibTarget}
+          onCancel={() => setCreateLibTarget(null)}
+          onCreate={async (name) => {
+            try {
+              const result = await window.pdv.tree.createLib(currentKernelId, createLibTarget, name);
+              if (!result.success) {
+                setLastError(result.error);
+              } else if (result.libPath) {
+                setTreeRefreshToken((t) => t + 1);
+                // Open the new lib in the external editor so the user can
+                // start typing right away — same UX as new script.
+                await window.pdv.script.edit(currentKernelId, result.libPath);
+              }
+            } catch (error) {
+              setLastError(error instanceof Error ? error.message : String(error));
+            } finally {
+              setCreateLibTarget(null);
+            }
+          }}
+        />
+      )}
+
+      <NewModuleDialog
+        isOpen={showNewModuleDialog}
+        defaultLanguage={activeLanguage === 'julia' ? 'julia' : 'python'}
+        onCancel={() => setShowNewModuleDialog(false)}
+        onCreated={() => {
+          setShowNewModuleDialog(false);
+          setTreeRefreshToken((t) => t + 1);
+        }}
+      />
+
+      {moduleMetadataTarget && (
+        <ModuleMetadataDialog
+          isOpen={true}
+          alias={moduleMetadataTarget.alias}
+          initial={{
+            name: moduleMetadataTarget.name,
+            version: moduleMetadataTarget.version,
+            description: moduleMetadataTarget.description,
+            language: moduleMetadataTarget.language,
+          }}
+          onCancel={() => setModuleMetadataTarget(null)}
+          onSaved={() => {
+            setModuleMetadataTarget(null);
+            setTreeRefreshToken((t) => t + 1);
           }}
         />
       )}

--- a/electron/renderer/src/components/ModuleMetadataDialog/index.tsx
+++ b/electron/renderer/src/components/ModuleMetadataDialog/index.tsx
@@ -1,0 +1,172 @@
+/**
+ * ModuleMetadataDialog — in-app editor for a PDVModule's mutable metadata.
+ *
+ * Fronts ``window.pdv.modules.updateMetadata``. Fields: ``id`` (read-only
+ * after creation), ``name``, ``version``, ``description``. ``language``
+ * is shown for context but also read-only — flipping languages on an
+ * existing module would require rebinding its subtree, which is out of
+ * scope for workflow B.
+ */
+
+import React, { useEffect, useState } from 'react';
+
+interface ModuleMetadataDialogProps {
+  isOpen: boolean;
+  alias: string;
+  initial: {
+    name: string;
+    version: string;
+    description?: string;
+    language?: 'python' | 'julia';
+  };
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+export const ModuleMetadataDialog: React.FC<ModuleMetadataDialogProps> = ({
+  isOpen,
+  alias,
+  initial,
+  onSaved,
+  onCancel,
+}) => {
+  const [name, setName] = useState(initial.name);
+  const [version, setVersion] = useState(initial.version);
+  const [description, setDescription] = useState(initial.description ?? '');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (isOpen) {
+      setName(initial.name);
+      setVersion(initial.version);
+      setDescription(initial.description ?? '');
+      setError(undefined);
+      setIsSubmitting(false);
+    }
+    // We intentionally depend on isOpen only; initial is expected to be
+    // fresh at open time and changing it mid-edit would clobber user
+    // keystrokes. The parent closes the dialog between opens.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const nameTrim = name.trim();
+  const versionTrim = version.trim();
+  const canSubmit =
+    !isSubmitting && nameTrim.length > 0 && versionTrim.length > 0;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setIsSubmitting(true);
+    setError(undefined);
+    try {
+      const r = await window.pdv.modules.updateMetadata({
+        alias,
+        name: nameTrim,
+        version: versionTrim,
+        description: description.trim(),
+      });
+      if (r.success) {
+        onSaved();
+      } else {
+        setError(r.error ?? 'Failed to update module metadata');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      onCancel();
+    } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      void handleSubmit();
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div
+        className="script-dialog"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKey}
+      >
+        <div className="dialog-header">
+          <h3>Edit Module Metadata</h3>
+          <button className="close-btn" onClick={onCancel} aria-label="Close dialog">
+            ×
+          </button>
+        </div>
+        <div className="dialog-body">
+          <div className="param-input">
+            <label>
+              ID
+              <span className="param-type">(read-only)</span>
+            </label>
+            <input type="text" value={alias} disabled />
+          </div>
+          <div className="param-input">
+            <label>
+              Name <span className="required">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="param-input">
+            <label>
+              Version <span className="required">*</span>
+              <span className="param-type">(semver)</span>
+            </label>
+            <input
+              type="text"
+              value={version}
+              onChange={(e) => setVersion(e.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="param-input">
+            <label>Description</label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          {initial.language && (
+            <div className="param-input">
+              <label>
+                Language
+                <span className="param-type">(read-only)</span>
+              </label>
+              <input type="text" value={initial.language} disabled />
+            </div>
+          )}
+          {error && <div className="dialog-error">{error}</div>}
+        </div>
+        <div className="dialog-footer">
+          <button className="btn btn-secondary" onClick={onCancel} disabled={isSubmitting}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit}
+          >
+            {isSubmitting ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/electron/renderer/src/components/NewModuleDialog/index.tsx
+++ b/electron/renderer/src/components/NewModuleDialog/index.tsx
@@ -1,0 +1,197 @@
+/**
+ * NewModuleDialog — modal for creating a new empty PDVModule.
+ *
+ * Fronts the ``window.pdv.modules.createEmpty`` IPC (workflow B of #140).
+ * Collects ``id``/``name``/``version``/``description``/``language``, runs
+ * alias collision detection server-side, and closes on success. Lives at
+ * app level so it can be opened from the File → New Module menu entry.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+
+interface NewModuleDialogProps {
+  /** Whether the modal is currently visible. */
+  isOpen: boolean;
+  /** Default kernel language — pre-fills the language field. */
+  defaultLanguage?: 'python' | 'julia';
+  /** Called after a successful create; receives the created alias. */
+  onCreated: (alias: string) => void;
+  /** Called when the user dismisses the dialog without creating. */
+  onCancel: () => void;
+}
+
+const DEFAULT_VERSION = '0.1.0';
+
+function sanitizeId(raw: string): string {
+  return raw.trim().replace(/[./\\\s]+/g, '_');
+}
+
+export const NewModuleDialog: React.FC<NewModuleDialogProps> = ({
+  isOpen,
+  defaultLanguage = 'python',
+  onCreated,
+  onCancel,
+}) => {
+  const [id, setId] = useState('');
+  const [name, setName] = useState('');
+  const [version, setVersion] = useState(DEFAULT_VERSION);
+  const [description, setDescription] = useState('');
+  const [language, setLanguage] = useState<'python' | 'julia'>(defaultLanguage);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const idInputRef = useRef<HTMLInputElement>(null);
+
+  // Reset form state every time the dialog is (re)opened so stale entries
+  // from a previous open don't bleed through.
+  useEffect(() => {
+    if (isOpen) {
+      setId('');
+      setName('');
+      setVersion(DEFAULT_VERSION);
+      setDescription('');
+      setLanguage(defaultLanguage);
+      setError(undefined);
+      setIsSubmitting(false);
+      // Focus the id input on open — the user types here first.
+      queueMicrotask(() => idInputRef.current?.focus());
+    }
+  }, [isOpen, defaultLanguage]);
+
+  if (!isOpen) return null;
+
+  const normalizedId = sanitizeId(id);
+  const normalizedName = name.trim() || normalizedId;
+  const normalizedVersion = version.trim() || DEFAULT_VERSION;
+  const canSubmit = normalizedId.length > 0 && !isSubmitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setIsSubmitting(true);
+    setError(undefined);
+    try {
+      const result = await window.pdv.modules.createEmpty({
+        id: normalizedId,
+        name: normalizedName,
+        version: normalizedVersion,
+        description: description.trim() || undefined,
+        language,
+      });
+      if (result.success && result.alias) {
+        onCreated(result.alias);
+      } else if (result.status === 'conflict' && result.suggestedAlias) {
+        setError(
+          `A module named "${normalizedId}" already exists. Try "${result.suggestedAlias}".`,
+        );
+        setId(result.suggestedAlias);
+      } else {
+        setError(result.error ?? 'Failed to create module');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      onCancel();
+    } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      void handleSubmit();
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div
+        className="script-dialog"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKey}
+      >
+        <div className="dialog-header">
+          <h3>New Module</h3>
+          <button className="close-btn" onClick={onCancel} aria-label="Close dialog">
+            ×
+          </button>
+        </div>
+        <div className="dialog-body">
+          <div className="param-input">
+            <label>
+              ID <span className="required">*</span>
+              <span className="param-type">(stable identifier, also used as tree alias)</span>
+            </label>
+            <input
+              ref={idInputRef}
+              type="text"
+              value={id}
+              placeholder="e.g. my_module"
+              onChange={(e) => setId(e.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="param-input">
+            <label>
+              Name
+              <span className="param-type">(display name, defaults to ID)</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              placeholder={normalizedId || 'My Module'}
+              onChange={(e) => setName(e.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="param-input">
+            <label>
+              Version
+              <span className="param-type">(semver)</span>
+            </label>
+            <input
+              type="text"
+              value={version}
+              onChange={(e) => setVersion(e.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="param-input">
+            <label>Description</label>
+            <input
+              type="text"
+              value={description}
+              placeholder="Optional short description"
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="param-input">
+            <label>Language</label>
+            <select
+              value={language}
+              onChange={(e) => setLanguage(e.target.value as 'python' | 'julia')}
+              disabled={isSubmitting}
+            >
+              <option value="python">Python</option>
+              <option value="julia">Julia</option>
+            </select>
+          </div>
+          {error && <div className="dialog-error">{error}</div>}
+        </div>
+        <div className="dialog-footer">
+          <button className="btn btn-secondary" onClick={onCancel} disabled={isSubmitting}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit}
+          >
+            {isSubmitting ? 'Creating…' : 'Create'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/electron/renderer/src/components/Tree/ContextMenu.tsx
+++ b/electron/renderer/src/components/Tree/ContextMenu.tsx
@@ -105,6 +105,11 @@ export function getActionsForNode(node: TreeNodeData) {
     actions.push({ id: 'edit_gui', label: 'Edit GUI', disabled: false });
   }
 
+  if (isModule) {
+    actions.push({ id: 'edit_module_metadata', label: 'Edit metadata...', disabled: false });
+    actions.push({ id: 'export_module', label: 'Export to global store...', disabled: false });
+  }
+
   if (node.type === 'script') {
     actions.push(
       { id: 'run', label: 'Run...', disabled: false },
@@ -123,10 +128,14 @@ export function getActionsForNode(node: TreeNodeData) {
 
   // ── Creation actions (containers only) ──
 
-  if (isContainer) {
+  if (isContainer || isModule) {
     actions.push({ id: 'create_script', label: 'Create new script', disabled: false });
     actions.push({ id: 'create_note', label: 'Create new note', disabled: false });
     actions.push({ id: 'new_gui', label: 'Create new GUI', disabled: false });
+    // Lib creation is meaningful only inside a module's subtree. The app
+    // handler validates this at IPC time; we surface the option whenever
+    // the user is right-clicking a container so it's discoverable.
+    actions.push({ id: 'create_lib', label: 'Create new lib', disabled: false });
   }
 
   // ── Common actions (all nodes) ──

--- a/electron/renderer/src/components/Tree/CreateLibDialog.tsx
+++ b/electron/renderer/src/components/Tree/CreateLibDialog.tsx
@@ -1,0 +1,89 @@
+/**
+ * CreateLibDialog — modal for new PDVLib (Python library) node creation.
+ *
+ * Mirrors {@link CreateScriptDialog} but emits names for the
+ * ``tree:createLib`` handler, which is workflow-B-only (validated
+ * server-side). The dialog doesn't enforce "target must be inside a
+ * module" — that's surfaced as an error from the IPC call so the
+ * user gets the same diagnostic whether they typed a bad path by hand
+ * or hit an edge case via keyboard shortcut.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { useModalKeyboard } from '../../hooks/useModalKeyboard';
+
+interface CreateLibDialogProps {
+  parentPath: string;
+  onCreate: (name: string) => void;
+  onCancel: () => void;
+}
+
+export const CreateLibDialog: React.FC<CreateLibDialogProps> = ({ parentPath, onCreate, onCancel }) => {
+  const [name, setName] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Strip any ``.py`` the user typed, replace spaces with underscores,
+  // then keep only Python-identifier-safe characters. The server does
+  // the same normalization; we mirror it here just so the preview text
+  // matches what actually lands on disk.
+  const sanitized = name
+    .trim()
+    .replace(/\.py$/i, '')
+    .replace(/\s+/g, '_')
+    .replace(/[^a-zA-Z0-9_]/g, '');
+  const canCreate = sanitized.length > 0;
+
+  const handleSubmit = () => {
+    if (!canCreate) return;
+    onCreate(sanitized);
+  };
+
+  const handleKeyDown = useModalKeyboard({ onSubmit: handleSubmit, onCancel });
+
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="script-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="dialog-header">
+          <h3>Create new lib</h3>
+          <button className="close-btn" onClick={onCancel} aria-label="Close dialog">
+            ×
+          </button>
+        </div>
+
+        <div className="dialog-body">
+          <div className="script-info">
+            <strong>Parent</strong>
+            <span className="script-path">{parentPath || '(root)'}</span>
+          </div>
+          <label>
+            Lib name
+            <input
+              ref={inputRef}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="helpers"
+            />
+          </label>
+          <div className="dialog-info-text">
+            Will create <code>{sanitized || 'name'}.py</code> as an importable module lib.
+          </div>
+        </div>
+
+        <div className="dialog-footer">
+          <button className="btn btn-secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" onClick={handleSubmit} disabled={!canCreate}>
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/electron/renderer/src/services/tree.ts
+++ b/electron/renderer/src/services/tree.ts
@@ -123,6 +123,8 @@ class TreeService {
       module_id,
       module_name,
       module_version,
+      module_description,
+      module_language,
       ...rest
     } = node;
     return {
@@ -136,6 +138,8 @@ class TreeService {
       moduleId: module_id,
       moduleName: module_name,
       moduleVersion: module_version,
+      moduleDescription: module_description,
+      moduleLanguage: module_language,
       isExpanded: false,
       isLoading: false,
     };

--- a/electron/renderer/src/types/index.ts
+++ b/electron/renderer/src/types/index.ts
@@ -140,6 +140,8 @@ export interface TreeNodeData
     | 'module_id'
     | 'module_name'
     | 'module_version'
+    | 'module_description'
+    | 'module_language'
   > {
   type: NodeDescriptor['type'] | 'root';
   parentPath: string | null;
@@ -151,6 +153,8 @@ export interface TreeNodeData
   moduleId?: string;
   moduleName?: string;
   moduleVersion?: string;
+  moduleDescription?: string;
+  moduleLanguage?: 'python' | 'julia';
   children?: TreeNodeData[];
   isExpanded?: boolean;
   isLoading?: boolean;

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -159,7 +159,7 @@ export interface CodeCellData {
 /** File-menu action event payload emitted by `menu.onAction`. */
 export interface MenuActionPayload {
   /** Discriminated menu action identifier. */
-  action: "project:new" | "project:open" | "project:openRecent" | "project:save" | "project:saveAs" | "recentProjects:clear" | "modules:import" | "settings:open";
+  action: "project:new" | "project:open" | "project:openRecent" | "project:save" | "project:saveAs" | "recentProjects:clear" | "modules:import" | "modules:newEmpty" | "settings:open";
   /** Optional path argument for path-bearing menu actions. */
   path?: string;
 }
@@ -169,6 +169,7 @@ export interface MenuEnabledState {
   "project:save"?: boolean;
   "project:saveAs"?: boolean;
   "modules:import"?: boolean;
+  "modules:newEmpty"?: boolean;
 }
 
 /** Top-level menu metadata used by the Linux integrated menubar. */
@@ -699,6 +700,11 @@ export interface PDVApi {
       targetPath: string,
       guiName: string
     ): Promise<TreeCreateGuiResult>;
+    createLib(
+      kernelId: string,
+      targetPath: string,
+      libName: string
+    ): Promise<{ success: boolean; error?: string; libPath?: string; treePath?: string }>;
     addFile(
       kernelId: string,
       sourcePath: string,
@@ -753,6 +759,41 @@ export interface PDVApi {
     removeImport(moduleAlias: string): Promise<ModuleSettingsResult>;
     uninstall(moduleId: string): Promise<ModuleUninstallResult>;
     update(moduleId: string): Promise<ModuleInstallResult>;
+    createEmpty(request: {
+      id: string;
+      name: string;
+      version: string;
+      description?: string;
+      language?: "python" | "julia";
+    }): Promise<{
+      success: boolean;
+      alias?: string;
+      status?: "created" | "conflict" | "error";
+      suggestedAlias?: string;
+      error?: string;
+    }>;
+    updateMetadata(request: {
+      alias: string;
+      name?: string;
+      version?: string;
+      description?: string;
+    }): Promise<{
+      success: boolean;
+      alias?: string;
+      name?: string;
+      version?: string;
+      description?: string;
+      error?: string;
+    }>;
+    exportFromProject(request: {
+      alias: string;
+      overwrite?: boolean;
+    }): Promise<{
+      success: boolean;
+      status?: "exported" | "cancelled" | "not_saved" | "error";
+      destination?: string;
+      error?: string;
+    }>;
   };
   project: {
     save(saveDir: string, codeCells: unknown, projectName?: string): Promise<ProjectSaveResult>;

--- a/pdv-python/pdv_kernel/checksum.py
+++ b/pdv-python/pdv_kernel/checksum.py
@@ -210,31 +210,38 @@ def _feed_node(h: xxhash.xxh3_128, node: Any, working_dir: str | None) -> None:
         else:
             _feed_str(h, repr(node.tolist()))
 
+    # ------------------------------------------------------------------
+    # File-backed nodes intentionally do NOT hash ``relative_path``:
+    # it is a storage-layout detail that drifts across save/load cycles
+    # (serialize_node writes PDVScript/PDVNote/PDVGui/PDVNamelist files
+    # under ``<save_dir>/tree/...`` but does not mutate the in-memory
+    # node, so the post-load ``relative_path`` gains a ``tree/`` prefix
+    # the pre-save one lacks). File content is still fed in full via
+    # ``_feed_file_content``, and the parent folder's key iteration
+    # already folds the tree path into the digest, so the checksum
+    # stays sensitive to everything that actually defines node
+    # identity — just not to where on disk the backing file lives.
+    # ------------------------------------------------------------------
     elif kind == KIND_SCRIPT:
         h.update(b"script\x00")
-        _feed_str(h, node.relative_path)
         _feed_str(h, node.language)
         _feed_file_content(h, node, working_dir)
 
     elif kind == KIND_MARKDOWN:
         h.update(b"note\x00")
-        _feed_str(h, node.relative_path)
         _feed_file_content(h, node, working_dir)
 
     elif kind == KIND_GUI:
         h.update(b"gui\x00")
-        _feed_str(h, node.relative_path)
         _feed_file_content(h, node, working_dir)
 
     elif kind == KIND_NAMELIST:
         h.update(b"namelist\x00")
-        _feed_str(h, node.relative_path)
         _feed_str(h, node.format)
         _feed_file_content(h, node, working_dir)
 
     elif kind == KIND_LIB:
         h.update(b"lib\x00")
-        _feed_str(h, node.relative_path)
         _feed_file_content(h, node, working_dir)
 
     else:  # KIND_UNKNOWN (and KIND_FILE base class, if encountered)

--- a/pdv-python/pdv_kernel/handlers/gui.py
+++ b/pdv-python/pdv_kernel/handlers/gui.py
@@ -56,8 +56,13 @@ def handle_gui_register(msg: dict) -> None:
     name = payload.get("name", "")
     relative_path = payload.get("relative_path", "")
     module_id = payload.get("module_id")
+    source_rel_path = payload.get("source_rel_path")
 
-    gui_node = PDVGui(relative_path=relative_path, module_id=module_id)
+    gui_node = PDVGui(
+        relative_path=relative_path,
+        module_id=module_id,
+        source_rel_path=source_rel_path,
+    )
     full_path = f"{parent_path}.{name}" if parent_path else name
     tree[full_path] = gui_node
     attach_gui_to_module(tree, parent_path, gui_node)

--- a/pdv-python/pdv_kernel/handlers/modules.py
+++ b/pdv-python/pdv_kernel/handlers/modules.py
@@ -223,6 +223,317 @@ def handle_modules_setup(msg: dict) -> None:
     )
 
 
+def handle_module_create_empty(msg: dict) -> None:
+    """Handle the ``pdv.module.create_empty`` message.
+
+    Creates a bare :class:`~pdv_kernel.tree.PDVModule` at the top of the
+    tree and seeds it with three conventional empty ``PDVTree`` children
+    (``scripts``, ``lib``, ``plots``). Used by workflow B of issue #140:
+    a user starts a new module from scratch inside the app, populates its
+    contents via ``tree:createScript`` / ``tree:createLib`` / ``tree:createGui``,
+    and exports the result to the global store at save time.
+
+    Intentionally side-effect-free on disk — the main process owns the
+    working-dir scaffolding and the project-local ``<saveDir>/modules/<id>/``
+    write path. This handler only mutates the in-memory tree.
+
+    Expected payload
+    ----------------
+    .. code-block:: json
+
+        {
+            "id": "toy",
+            "name": "Toy",
+            "version": "0.1.0",
+            "description": "",
+            "language": "python"
+        }
+
+    Response payload
+    ----------------
+    .. code-block:: json
+
+        { "path": "toy" }
+
+    Parameters
+    ----------
+    msg : dict
+        Parsed PDV message envelope.
+    """
+    from pdv_kernel.comms import get_pdv_tree, send_error, send_message  # noqa: PLC0415
+    from pdv_kernel.tree import PDVModule, PDVTree  # noqa: PLC0415
+
+    msg_id = msg.get("msg_id")
+    payload = msg.get("payload", {})
+    module_id = payload.get("id", "")
+    name = payload.get("name", "") or module_id
+    version = payload.get("version", "0.1.0")
+    description = payload.get("description", "") or ""
+    language = payload.get("language", "python") or "python"
+
+    if not module_id:
+        send_error(
+            "pdv.module.create_empty.response",
+            "module.missing_id",
+            "id is required in pdv.module.create_empty payload",
+            in_reply_to=msg_id,
+        )
+        return
+
+    tree = get_pdv_tree()
+    if tree is None:
+        send_error(
+            "pdv.module.create_empty.response",
+            "module.no_tree",
+            "PDVTree is not initialized",
+            in_reply_to=msg_id,
+        )
+        return
+
+    # Reject collisions with any existing top-level tree key — not just
+    # PDVModule nodes, since a data/folder node would also block access.
+    try:
+        _existing = tree[module_id]
+        send_error(
+            "pdv.module.create_empty.response",
+            "module.alias_exists",
+            f"Tree path already occupied: {module_id!r}",
+            in_reply_to=msg_id,
+        )
+        return
+    except (KeyError, TypeError):
+        pass
+
+    module = PDVModule(
+        module_id=module_id,
+        name=name,
+        version=version,
+        description=description,
+        language=language,
+    )
+    module._working_dir = tree._working_dir
+    module._save_dir = tree._save_dir
+    # Seed the three conventional subtrees. These are plain PDVTree
+    # containers — the names are a UI convention documented in the
+    # workflow B plan; the kernel does not enforce their shape.
+    for child_key in ("scripts", "lib", "plots"):
+        child = PDVTree()
+        child._working_dir = tree._working_dir
+        child._save_dir = tree._save_dir
+        module[child_key] = child
+
+    tree[module_id] = module
+
+    send_message(
+        "pdv.module.create_empty.response",
+        {"path": module_id},
+        in_reply_to=msg_id,
+    )
+
+
+def handle_module_update(msg: dict) -> None:
+    """Handle the ``pdv.module.update`` message.
+
+    Patches mutable fields (``name``, ``version``, ``description``) on an
+    existing :class:`~pdv_kernel.tree.PDVModule`. Any field omitted from
+    the payload is left unchanged. ``module_id`` and ``language`` are
+    read-only — creating a new module is the right way to change those.
+
+    Expected payload
+    ----------------
+    .. code-block:: json
+
+        {
+            "alias": "toy",
+            "name": "Toy (renamed)",
+            "version": "0.2.0",
+            "description": "A toy example"
+        }
+
+    Parameters
+    ----------
+    msg : dict
+        Parsed PDV message envelope.
+    """
+    from pdv_kernel.comms import get_pdv_tree, send_error, send_message  # noqa: PLC0415
+    from pdv_kernel.tree import PDVModule  # noqa: PLC0415
+
+    msg_id = msg.get("msg_id")
+    payload = msg.get("payload", {})
+    alias = payload.get("alias", "")
+
+    if not alias:
+        send_error(
+            "pdv.module.update.response",
+            "module.missing_alias",
+            "alias is required in pdv.module.update payload",
+            in_reply_to=msg_id,
+        )
+        return
+
+    tree = get_pdv_tree()
+    if tree is None:
+        send_error(
+            "pdv.module.update.response",
+            "module.no_tree",
+            "PDVTree is not initialized",
+            in_reply_to=msg_id,
+        )
+        return
+
+    try:
+        node = tree[alias]
+    except (KeyError, TypeError):
+        send_error(
+            "pdv.module.update.response",
+            "module.not_found",
+            f"No node at path: {alias!r}",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if not isinstance(node, PDVModule):
+        send_error(
+            "pdv.module.update.response",
+            "module.not_a_module",
+            f"Node at {alias!r} is not a PDVModule",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if "name" in payload and payload["name"] is not None:
+        node.name = str(payload["name"])
+    if "version" in payload and payload["version"] is not None:
+        node.version = str(payload["version"])
+    if "description" in payload and payload["description"] is not None:
+        node.description = str(payload["description"])
+
+    send_message(
+        "pdv.module.update.response",
+        {
+            "alias": alias,
+            "name": node.name,
+            "version": node.version,
+            "description": node.description,
+        },
+        in_reply_to=msg_id,
+    )
+
+
+def handle_module_reload_libs(msg: dict) -> None:
+    """Handle the ``pdv.module.reload_libs`` message.
+
+    Reloads every Python module whose ``__file__`` sits under the working
+    directory's ``<alias>/lib/`` folder, so that edits to module library
+    files are picked up on the next script run without restarting the
+    kernel. Called as a preflight before ``script:run`` on a module-owned
+    script; see the #140 module editing workflow plan §4.
+
+    Individual ``importlib.reload()`` failures are swallowed and logged
+    — a broken lib file should surface at script-run time with a proper
+    traceback, not at reload time with a cryptic message.
+
+    Expected payload
+    ----------------
+    .. code-block:: json
+
+        { "alias": "n_pendulum" }
+
+    Response payload
+    ----------------
+    .. code-block:: json
+
+        { "reloaded": ["n_pendulum", "..."], "errors": {"bad_lib": "..."} }
+
+    Parameters
+    ----------
+    msg : dict
+        Parsed PDV message envelope.
+    """
+    import os  # noqa: PLC0415
+
+    from pdv_kernel.comms import get_pdv_tree, send_error, send_message  # noqa: PLC0415
+
+    msg_id = msg.get("msg_id")
+    payload = msg.get("payload", {})
+    alias = payload.get("alias", "")
+
+    if not alias:
+        send_error(
+            "pdv.module.reload_libs.response",
+            "module.missing_alias",
+            "alias is required in pdv.module.reload_libs payload",
+            in_reply_to=msg_id,
+        )
+        return
+
+    from pdv_kernel.tree import PDVModule  # noqa: PLC0415
+
+    tree = get_pdv_tree()
+    working_dir = getattr(tree, "_working_dir", "") if tree is not None else ""
+
+    # Short-circuit if the caller's alias does not correspond to an actual
+    # PDVModule in the tree. The ``script:run`` preflight fires this for every
+    # run, including plain project scripts, so we must be cheap in the
+    # non-module case.
+    is_module = False
+    if tree is not None:
+        try:
+            node = tree[alias]
+            is_module = isinstance(node, PDVModule)
+        except (KeyError, TypeError):
+            is_module = False
+
+    # ``<workdir>/<alias>/lib/`` is where bindImportedModule places lib files
+    # for v4 modules. For modules authored in-session (workflow B), the same
+    # convention applies because the empty-module creation handler seeds the
+    # working dir with ``<alias>/{scripts,lib,plots}/``.
+    #
+    # Use realpath on both sides of the comparison: on macOS, ``/var`` is a
+    # symlink to ``/private/var``, and a module's ``__file__`` can come back
+    # as the un-prefixed form while ``_working_dir`` is the fully-resolved
+    # ``/private/var/...`` path (or vice versa). A literal ``startswith``
+    # check would fail to match files that live at the same physical path.
+    lib_prefix = ""
+    if is_module and working_dir:
+        try:
+            lib_prefix = os.path.realpath(os.path.join(working_dir, alias, "lib"))
+        except Exception:  # noqa: BLE001
+            lib_prefix = ""
+
+    reloaded: list[str] = []
+    errors: dict[str, str] = {}
+
+    if lib_prefix:
+        # Snapshot sys.modules — reload() mutates it and we don't want to
+        # iterate over a live dict that grows during traversal.
+        items = list(sys.modules.items())
+        for mod_name, mod in items:
+            try:
+                mod_file = getattr(mod, "__file__", None)
+            except Exception:  # noqa: BLE001
+                continue
+            if not mod_file:
+                continue
+            try:
+                mod_file_abs = os.path.realpath(mod_file)
+            except Exception:  # noqa: BLE001
+                continue
+            if not mod_file_abs.startswith(lib_prefix + os.sep):
+                continue
+            try:
+                importlib.reload(mod)
+                reloaded.append(mod_name)
+            except Exception as exc:  # noqa: BLE001
+                errors[mod_name] = f"{type(exc).__name__}: {exc}"
+
+    send_message(
+        "pdv.module.reload_libs.response",
+        {"reloaded": reloaded, "errors": errors},
+        in_reply_to=msg_id,
+    )
+
+
 def handle_handler_invoke(msg: dict) -> None:
     """Handle the ``pdv.handler.invoke`` message.
 
@@ -288,5 +599,8 @@ def handle_handler_invoke(msg: dict) -> None:
 
 
 register("pdv.module.register", handle_module_register)
+register("pdv.module.create_empty", handle_module_create_empty)
+register("pdv.module.update", handle_module_update)
 register("pdv.modules.setup", handle_modules_setup)
+register("pdv.module.reload_libs", handle_module_reload_libs)
 register("pdv.handler.invoke", handle_handler_invoke)

--- a/pdv-python/pdv_kernel/handlers/modules.py
+++ b/pdv-python/pdv_kernel/handlers/modules.py
@@ -484,10 +484,14 @@ def handle_module_reload_libs(msg: dict) -> None:
         except (KeyError, TypeError):
             is_module = False
 
-    # ``<workdir>/<alias>/lib/`` is where bindImportedModule places lib files
-    # for v4 modules. For modules authored in-session (workflow B), the same
-    # convention applies because the empty-module creation handler seeds the
-    # working dir with ``<alias>/{scripts,lib,plots}/``.
+    # ``<workdir>/tree/<alias>/lib/`` is where bindImportedModule places
+    # lib files for v4 modules. For modules authored in-session
+    # (workflow B), the same convention applies because the empty-
+    # module creation handler seeds the working dir with
+    # ``tree/<alias>/{scripts,lib,plots}/``. The ``tree/`` prefix is
+    # the canonical working-dir/save-dir subdir documented in
+    # ARCHITECTURE.md §6.1/§6.2 — every file-backed tree node lives
+    # there so ``relative_path`` stays stable across save/load.
     #
     # Use realpath on both sides of the comparison: on macOS, ``/var`` is a
     # symlink to ``/private/var``, and a module's ``__file__`` can come back
@@ -497,7 +501,9 @@ def handle_module_reload_libs(msg: dict) -> None:
     lib_prefix = ""
     if is_module and working_dir:
         try:
-            lib_prefix = os.path.realpath(os.path.join(working_dir, alias, "lib"))
+            lib_prefix = os.path.realpath(
+                os.path.join(working_dir, "tree", alias, "lib")
+            )
         except Exception:  # noqa: BLE001
             lib_prefix = ""
 

--- a/pdv-python/pdv_kernel/handlers/namelist.py
+++ b/pdv-python/pdv_kernel/handlers/namelist.py
@@ -206,10 +206,15 @@ def handle_file_register(msg: dict) -> None:
         return
 
     # Build relative path: the file is expected under
-    # <working_dir>/<tree_path_segments>/<filename>.
-    # Store as relative (not absolute) so serialize_node produces portable paths.
+    # ``<working_dir>/tree/<tree_path_segments>/<filename>``.
+    # The ``tree/`` prefix is the canonical working-dir/save-dir subdir
+    # for every file-backed tree node (ARCHITECTURE.md §6.1/§6.2) —
+    # ``serialize_node`` writes into it and ``copyFilesForLoad`` mirrors
+    # from it, so keeping the in-memory rel-path prefixed here ensures
+    # the value stays stable across save/load cycles. See the #140 PR's
+    # Option-A canonical-layout fix.
     segments = tree_path.split(".") if tree_path else []
-    relative_path = os.path.join(*segments, filename) if segments else filename
+    relative_path = os.path.join("tree", *segments, filename)
 
     # Use explicit name if provided, otherwise derive from filename stem
     if explicit_name:

--- a/pdv-python/pdv_kernel/handlers/namelist.py
+++ b/pdv-python/pdv_kernel/handlers/namelist.py
@@ -184,6 +184,7 @@ def handle_file_register(msg: dict) -> None:
     node_type = payload.get("node_type", "file")
     explicit_name = payload.get("name", "")
     module_id = payload.get("module_id")
+    source_rel_path = payload.get("source_rel_path")
 
     if not filename:
         send_error(
@@ -224,11 +225,23 @@ def handle_file_register(msg: dict) -> None:
     full_path = f"{tree_path}.{node_name}" if tree_path else node_name
 
     if node_type == "namelist":
-        node = PDVNamelist(relative_path=relative_path, format="auto", module_id=module_id)
+        node = PDVNamelist(
+            relative_path=relative_path,
+            format="auto",
+            module_id=module_id,
+            source_rel_path=source_rel_path,
+        )
     elif node_type == "lib":
-        node = PDVLib(relative_path=relative_path, module_id=module_id)
+        node = PDVLib(
+            relative_path=relative_path,
+            module_id=module_id,
+            source_rel_path=source_rel_path,
+        )
     else:
-        node = PDVFile(relative_path=relative_path)
+        node = PDVFile(
+            relative_path=relative_path,
+            source_rel_path=source_rel_path,
+        )
 
     tree[full_path] = node
 

--- a/pdv-python/pdv_kernel/handlers/project.py
+++ b/pdv-python/pdv_kernel/handlers/project.py
@@ -91,6 +91,271 @@ def _collect_nodes(
 
 
 
+def _collect_module_owned_files(
+    tree: "Any",
+    working_dir: str,
+    *,
+    current_module_id: str = "",
+) -> list:
+    """Walk the tree and return file-backed nodes that belong to a PDVModule.
+
+    Used by the ``pdv.project.save`` handler to let the main process mirror
+    edited working-dir files back into ``<saveDir>/modules/<id>/<source_rel_path>``.
+    See ARCHITECTURE.md §5.13 and the #140 module editing workflow plan §3.
+
+    A node is emitted only when all three conditions hold:
+
+    1. It is a :class:`~pdv_kernel.tree.PDVFile` (script, lib, gui, namelist).
+    2. Its ``source_rel_path`` attribute is non-empty.
+    3. It lives beneath a :class:`~pdv_kernel.tree.PDVModule` ancestor
+       (so ``current_module_id`` is known), or its own ``module_id``
+       attribute identifies a module.
+
+    Parameters
+    ----------
+    tree : PDVTree
+        Subtree to walk.
+    working_dir : str
+        Kernel working directory — used to resolve each node's absolute
+        on-disk path so the main process can open the file directly.
+    current_module_id : str
+        Module id inherited from the nearest ancestor ``PDVModule`` during
+        the recursive walk. Empty at the tree root.
+
+    Returns
+    -------
+    list of dict
+        Entries of the form
+        ``{"module_id": ..., "source_rel_path": ..., "workdir_path": ...}``.
+    """
+    from pdv_kernel.tree import PDVFile, PDVModule, PDVTree  # noqa: PLC0415
+
+    import os  # noqa: PLC0415
+
+    results: list = []
+    for key in dict.keys(tree):
+        value = dict.__getitem__(tree, key)
+        if isinstance(value, PDVModule):
+            # Entering a module subtree — children inherit this module's id.
+            child_mod_id = value.module_id
+            results.extend(
+                _collect_module_owned_files(
+                    value, working_dir, current_module_id=child_mod_id,
+                )
+            )
+        elif isinstance(value, PDVTree):
+            results.extend(
+                _collect_module_owned_files(
+                    value, working_dir, current_module_id=current_module_id,
+                )
+            )
+        elif isinstance(value, PDVFile):
+            source_rel = getattr(value, "source_rel_path", None)
+            if not source_rel:
+                continue
+            # Prefer the nearest ancestor PDVModule's id over the node's
+            # own module_id field — the ancestor is the authority on which
+            # module directory the file should land in.
+            mod_id = current_module_id or getattr(value, "_module_id", "") or ""
+            if not mod_id:
+                continue
+            workdir_path = value.resolve_path(working_dir)
+            if not os.path.isabs(workdir_path):
+                workdir_path = os.path.join(working_dir, workdir_path)
+            results.append({
+                "module_id": mod_id,
+                "source_rel_path": source_rel,
+                "workdir_path": workdir_path,
+            })
+    return results
+
+
+def _collect_module_manifests(tree: "Any") -> list:
+    """Walk the top of the tree and emit one manifest entry per PDVModule.
+
+    Each entry carries the module's identity metadata plus a list of
+    ``module-index.json``-style descriptors describing the module's
+    subtree content. The main process consumes this list at save time
+    (``ipc-register-project.ts``) to write ``pdv-module.json`` and
+    ``module-index.json`` into ``<saveDir>/modules/<id>/``.
+
+    Why we rebuild descriptors instead of reusing ``tree-index.json``
+    entries: tree-index.json stores paths **prefixed with the module
+    alias** (e.g. ``toy.scripts.hello``) and workdir-rooted storage
+    paths (e.g. ``toy/scripts/hello.py``). A reloadable module-index
+    needs paths **relative to the module root** (``scripts.hello`` and
+    ``scripts/hello.py``) so that ``bindImportedModule`` can re-prefix
+    them at the next import time under whatever alias the user picks.
+
+    See ARCHITECTURE.md §5.13 and the #140 workflow plan §7.
+
+    Parameters
+    ----------
+    tree : PDVTree
+        Root tree — only top-level ``PDVModule`` children are considered.
+
+    Returns
+    -------
+    list of dict
+        One entry per module::
+
+            {
+                "module_id": "toy",
+                "name": "Toy",
+                "version": "0.1.0",
+                "description": "...",
+                "language": "python",
+                "dependencies": [...],
+                "entries": [<node descriptor>, ...],
+            }
+    """
+    from pdv_kernel.serialization import (  # noqa: PLC0415
+        node_preview,
+        detect_kind,
+        KIND_FOLDER,
+        KIND_MODULE,
+    )
+    from pdv_kernel.tree import PDVFile, PDVModule, PDVTree  # noqa: PLC0415
+
+    def _descriptor_for(
+        rel_path: str, key: str, parent_rel: str, value: "Any",
+    ) -> dict:
+        """Build a single module-rooted node descriptor.
+
+        For file-backed children we re-use the file's ``source_rel_path``
+        (set by the bind path / ``tree:create*`` handlers) as the
+        descriptor's ``storage.relative_path``, so on reload the
+        bindImportedModule v4 remap loop can re-prefix it with the new
+        alias.
+        """
+        kind = detect_kind(value)
+        preview = node_preview(value, kind)
+        descriptor: dict = {
+            "id": rel_path,
+            "path": rel_path,
+            "key": key,
+            "parent_path": parent_rel,
+            "type": kind,
+            "has_children": isinstance(value, PDVTree),
+            "lazy": False,
+        }
+
+        if isinstance(value, PDVModule):
+            descriptor["storage"] = {
+                "backend": "inline",
+                "format": "module_meta",
+                "value": {
+                    "module_id": value.module_id,
+                    "name": value.name,
+                    "version": value.version,
+                },
+            }
+            descriptor["metadata"] = {
+                "module_id": value.module_id,
+                "name": value.name,
+                "version": value.version,
+                "preview": preview,
+            }
+            return descriptor
+
+        if isinstance(value, PDVTree):
+            descriptor["storage"] = {"backend": "none", "format": "none"}
+            descriptor["metadata"] = {"preview": preview}
+            return descriptor
+
+        if isinstance(value, PDVFile):
+            # Module-root-relative path is authoritative here — it's the
+            # one we care about on reload. Fall back to the stored
+            # relative_path when ``source_rel_path`` hasn't been set
+            # (shouldn't happen for module-owned files under workflow
+            # A/B, but keep the flow robust).
+            rel_storage = (
+                getattr(value, "source_rel_path", None) or value.relative_path
+            )
+            format_map = {
+                "script": "py_script",
+                "lib": "py_lib",
+                "gui": "gui_json",
+                "namelist": "namelist",
+                "markdown": "markdown",
+            }
+            storage = {
+                "backend": "local_file",
+                "relative_path": rel_storage,
+                "format": format_map.get(kind, "file"),
+            }
+            meta: dict = {"preview": preview}
+            # Carry the authoring-time ``source_rel_path`` on the
+            # descriptor too (for symmetry with how the bind path
+            # re-injects it). See tree_loader.py.
+            if getattr(value, "source_rel_path", None):
+                descriptor["source_rel_path"] = value.source_rel_path
+            # Per-kind metadata so the reload path can reconstruct the
+            # right subclass via load_tree_index.
+            if kind == "script":
+                meta["language"] = getattr(value, "language", "python")
+                meta["doc"] = getattr(value, "doc", None)
+                if getattr(value, "_module_id", None):
+                    meta["module_id"] = value._module_id
+            elif kind == "lib":
+                meta["language"] = "python"
+                if getattr(value, "module_id", None):
+                    meta["module_id"] = value.module_id
+            elif kind == "gui":
+                meta["language"] = "json"
+                if getattr(value, "module_id", None):
+                    meta["module_id"] = value.module_id
+            elif kind == "namelist":
+                meta["language"] = "namelist"
+                meta["namelist_format"] = getattr(value, "format", "auto")
+                if getattr(value, "module_id", None):
+                    meta["module_id"] = value.module_id
+            descriptor["storage"] = storage
+            descriptor["metadata"] = meta
+            return descriptor
+
+        # Generic / data nodes — pass through a minimal descriptor.
+        # Workflow B's data-packaging path (serializing ndarray/dataframe
+        # values under a module into module-local tree/data files) is a
+        # later enhancement; for this pass we emit the node with a
+        # folder-like shape so bindImportedModule doesn't choke.
+        descriptor["storage"] = {"backend": "none", "format": "none"}
+        descriptor["metadata"] = {"preview": preview}
+        return descriptor
+
+    def _walk(
+        subtree: "Any", parent_rel: str, entries: list,
+    ) -> None:
+        for child_key in dict.keys(subtree):
+            child_value = dict.__getitem__(subtree, child_key)
+            child_rel = f"{parent_rel}.{child_key}" if parent_rel else child_key
+            entries.append(
+                _descriptor_for(child_rel, child_key, parent_rel, child_value)
+            )
+            if isinstance(child_value, PDVTree) and not isinstance(
+                child_value, PDVModule
+            ):
+                _walk(child_value, child_rel, entries)
+
+    results: list = []
+    for key in dict.keys(tree):
+        value = dict.__getitem__(tree, key)
+        if not isinstance(value, PDVModule):
+            continue
+        entries: list = []
+        _walk(value, "", entries)
+        results.append({
+            "module_id": value.module_id,
+            "name": value.name,
+            "version": value.version,
+            "description": getattr(value, "description", ""),
+            "language": getattr(value, "language", "python"),
+            "dependencies": list(getattr(value, "_dependencies", []) or []),
+            "entries": entries,
+        })
+    return results
+
+
 def handle_project_load(msg: dict) -> None:
     """Handle the ``pdv.project.load`` message.
 
@@ -295,9 +560,22 @@ def handle_project_save(msg: dict) -> None:
     from pdv_kernel.checksum import tree_checksum  # noqa: PLC0415
     checksum = tree_checksum(tree)
 
+    # Enumerate module-owned files so the main process can mirror their
+    # working-dir contents back into <saveDir>/modules/<id>/<source_rel_path>.
+    # See ARCHITECTURE.md §5.13 and the #140 workflow plan §3.
+    module_owned_files = _collect_module_owned_files(tree, working_dir)
+    # Collect per-module manifests for writing pdv-module.json +
+    # module-index.json into <saveDir>/modules/<id>/. See plan §7.
+    module_manifests = _collect_module_manifests(tree)
+
     send_message(
         "pdv.project.save.response",
-        {"node_count": len(nodes), "checksum": checksum},
+        {
+            "node_count": len(nodes),
+            "checksum": checksum,
+            "module_owned_files": module_owned_files,
+            "module_manifests": module_manifests,
+        },
         in_reply_to=msg_id,
     )
 

--- a/pdv-python/pdv_kernel/handlers/script.py
+++ b/pdv-python/pdv_kernel/handlers/script.py
@@ -55,8 +55,15 @@ def handle_script_register(msg: dict) -> None:
     name = payload.get("name", "")
     relative_path = payload.get("relative_path", "")
     language = payload.get("language", "python")
+    source_rel_path = payload.get("source_rel_path")
+    module_id = payload.get("module_id", "")
 
-    script = PDVScript(relative_path=relative_path, language=language)
+    script = PDVScript(
+        relative_path=relative_path,
+        language=language,
+        module_id=module_id,
+        source_rel_path=source_rel_path,
+    )
     full_path = f"{parent_path}.{name}" if parent_path else name
     tree[full_path] = script
 

--- a/pdv-python/pdv_kernel/handlers/tree.py
+++ b/pdv-python/pdv_kernel/handlers/tree.py
@@ -107,6 +107,10 @@ def handle_tree_list(msg: dict) -> None:
             descriptor["module_id"] = value.module_id
             descriptor["module_name"] = value.name
             descriptor["module_version"] = value.version
+            if getattr(value, "description", ""):
+                descriptor["module_description"] = value.description
+            if getattr(value, "language", ""):
+                descriptor["module_language"] = value.language
         if kind == "gui" and isinstance(value, PDVGui):
             descriptor["module_id"] = value.module_id
         nodes.append(descriptor)

--- a/pdv-python/pdv_kernel/serialization.py
+++ b/pdv-python/pdv_kernel/serialization.py
@@ -308,6 +308,11 @@ def serialize_node(
         "created_at": now,
         "updated_at": now,
     }
+    # Module-owned file nodes carry the rel-path inside their owning
+    # module's root so the save-time sync step can mirror working-dir
+    # edits back to <saveDir>/modules/<id>/. See ARCHITECTURE.md §5.13.
+    if isinstance(value, PDVFile) and getattr(value, "source_rel_path", None):
+        descriptor["source_rel_path"] = value.source_rel_path
 
     if kind == KIND_FOLDER:
         descriptor["has_children"] = True

--- a/pdv-python/pdv_kernel/tree.py
+++ b/pdv-python/pdv_kernel/tree.py
@@ -213,14 +213,27 @@ class PDVFile:
     ----------
     relative_path : str
         Path to the backing file (absolute or relative to working dir).
+    source_rel_path : str or None
+        For module-owned files, the path of this file relative to the
+        **module root** (e.g. ``"scripts/run.py"`` or ``"lib/helpers.py"``)
+        as it exists inside the pristine ``<saveDir>/modules/<id>/``
+        directory. Used by the save-time sync step in
+        ``handle_project_save`` so edits made in the working directory can
+        be mirrored back to the project-local module copy. ``None`` for
+        non-module files (ordinary project scripts, notes, etc.).
 
     See Also
     --------
-    ARCHITECTURE.md §5.7
+    ARCHITECTURE.md §5.7, §5.13
     """
 
-    def __init__(self, relative_path: str) -> None:
+    def __init__(
+        self,
+        relative_path: str,
+        source_rel_path: str | None = None,
+    ) -> None:
         self._relative_path = relative_path
+        self._source_rel_path = source_rel_path
 
     @property
     def relative_path(self) -> str:
@@ -232,6 +245,19 @@ class PDVFile:
             File path (absolute or relative to working dir).
         """
         return self._relative_path
+
+    @property
+    def source_rel_path(self) -> str | None:
+        """Path relative to the owning module's root, or ``None``.
+
+        Returns
+        -------
+        str or None
+            For module-owned files, the rel-path inside
+            ``<saveDir>/modules/<id>/``. ``None`` for files that do not
+            belong to a module.
+        """
+        return self._source_rel_path
 
     def resolve_path(self, working_dir: str | None = None) -> str:
         """Resolve the backing file to an absolute path.
@@ -295,8 +321,9 @@ class PDVScript(PDVFile):
     """
 
     def __init__(self, relative_path: str, language: str = "python",
-                 doc: str | None = None, module_id: str = "") -> None:
-        super().__init__(relative_path)
+                 doc: str | None = None, module_id: str = "",
+                 source_rel_path: str | None = None) -> None:
+        super().__init__(relative_path, source_rel_path=source_rel_path)
         self._language = language
         self._doc = doc
         self._module_id = module_id
@@ -497,8 +524,9 @@ class PDVGui(PDVFile):
         Module identifier for module-owned GUIs. None for user-created project GUIs.
     """
 
-    def __init__(self, relative_path: str, module_id: str | None = None) -> None:
-        super().__init__(relative_path)
+    def __init__(self, relative_path: str, module_id: str | None = None,
+                 source_rel_path: str | None = None) -> None:
+        super().__init__(relative_path, source_rel_path=source_rel_path)
         self._module_id = module_id
 
     @property
@@ -549,8 +577,9 @@ class PDVNamelist(PDVFile):
     """
 
     def __init__(self, relative_path: str, format: str = "auto",
-                 module_id: str | None = None) -> None:
-        super().__init__(relative_path)
+                 module_id: str | None = None,
+                 source_rel_path: str | None = None) -> None:
+        super().__init__(relative_path, source_rel_path=source_rel_path)
         self._format = format  # "fortran", "toml", "auto"
         self._module_id = module_id
 
@@ -608,8 +637,9 @@ class PDVLib(PDVFile):
     ARCHITECTURE.md §5.10, §7.2
     """
 
-    def __init__(self, relative_path: str, module_id: str | None = None) -> None:
-        super().__init__(relative_path)
+    def __init__(self, relative_path: str, module_id: str | None = None,
+                 source_rel_path: str | None = None) -> None:
+        super().__init__(relative_path, source_rel_path=source_rel_path)
         self._module_id = module_id
 
     @property
@@ -1105,17 +1135,31 @@ class PDVModule(PDVTree):
         Semantic version string.
     gui : PDVGui or None
         Optional GUI definition node attached to this module.
+    description : str, optional
+        Longer human-readable description. Persisted into ``pdv-module.json``
+        at export time for workflow B (create empty → author → export).
+    language : str, optional
+        Kernel language (``"python"`` or ``"julia"``). Defaults to
+        ``"python"``. Also persisted into ``pdv-module.json`` at export.
+
+    See Also
+    --------
+    ARCHITECTURE.md §5.9, and the #140 module editing workflow plan §5.
     """
 
     def __init__(self, module_id: str, name: str, version: str,
                  gui: PDVGui | None = None,
-                 dependencies: list[dict[str, str]] | None = None) -> None:
+                 dependencies: list[dict[str, str]] | None = None,
+                 description: str = "",
+                 language: str = "python") -> None:
         super().__init__()
         self._module_id = module_id
         self._name = name
         self._version = version
         self._gui = gui
         self._dependencies: list[dict[str, str]] = dependencies or []
+        self._description = description
+        self._language = language
 
     @property
     def module_id(self) -> str:
@@ -1137,6 +1181,15 @@ class PDVModule(PDVTree):
         """
         return self._name
 
+    @name.setter
+    def name(self, value: str) -> None:
+        """Update the human-readable module name.
+
+        Workflow B exposes this via the in-app metadata editor so users
+        can rename a freshly-created empty module without editing JSON.
+        """
+        self._name = value
+
     @property
     def version(self) -> str:
         """Semantic version string.
@@ -1146,6 +1199,39 @@ class PDVModule(PDVTree):
         str
         """
         return self._version
+
+    @version.setter
+    def version(self, value: str) -> None:
+        """Update the module's semver string.
+
+        Mutable so the in-app metadata editor can bump versions.
+        """
+        self._version = value
+
+    @property
+    def description(self) -> str:
+        """Longer human-readable description, or empty string.
+
+        Returns
+        -------
+        str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, value: str) -> None:
+        self._description = value
+
+    @property
+    def language(self) -> str:
+        """Kernel language used by this module.
+
+        Returns
+        -------
+        str
+            ``"python"`` or ``"julia"``.
+        """
+        return self._language
 
     @property
     def gui(self) -> PDVGui | None:

--- a/pdv-python/pdv_kernel/tree_loader.py
+++ b/pdv-python/pdv_kernel/tree_loader.py
@@ -194,6 +194,11 @@ def load_tree_index(
                 continue
 
         rel_path = storage.get("relative_path", "")
+        # source_rel_path is the path of this file relative to its owning
+        # module root (e.g. "scripts/run.py"). Set by the module bind path
+        # for module-owned files and re-read here so it survives
+        # save/load cycles. See ARCHITECTURE.md §5.13.
+        src_rel = node.get("source_rel_path")
 
         if node_type == "script":
             language = meta.get("language", node.get("language", "python"))
@@ -204,6 +209,7 @@ def load_tree_index(
                 language=language,
                 doc=doc,
                 module_id=mod_id,
+                source_rel_path=src_rel,
             ))
         elif node_type == "markdown":
             title = meta.get("title")
@@ -213,7 +219,11 @@ def load_tree_index(
             ))
         elif node_type == "gui":
             mod_id = meta.get("module_id", node.get("module_id", module_id_default))
-            gui_node = PDVGui(relative_path=rel_path, module_id=mod_id)
+            gui_node = PDVGui(
+                relative_path=rel_path,
+                module_id=mod_id,
+                source_rel_path=src_rel,
+            )
             tree.set_quiet(full_path, gui_node)
             # Attach gui reference to parent PDVModule if applicable.
             parts = full_path.split(".")
@@ -234,12 +244,14 @@ def load_tree_index(
                 relative_path=rel_path,
                 format=namelist_format,
                 module_id=mod_id,
+                source_rel_path=src_rel,
             ))
         elif node_type == "lib":
             mod_id = meta.get("module_id", node.get("module_id", module_id_default))
             tree.set_quiet(full_path, PDVLib(
                 relative_path=rel_path,
                 module_id=mod_id,
+                source_rel_path=src_rel,
             ))
             if inject_lib_sys_path:
                 abs_path = os.path.join(working_dir, rel_path) if rel_path else ""

--- a/pdv-python/tests/test_checksum.py
+++ b/pdv-python/tests/test_checksum.py
@@ -156,6 +156,55 @@ class TestFileBackedNodeContentSensitivity:
         assert len(checksum) == 32
 
 
+class TestRelativePathNotHashed:
+    """Regression test for a long-standing bug where tree_checksum folded
+    ``relative_path`` into the digest of file-backed nodes, so any PDVScript
+    / PDVGui / PDVNamelist / PDVNote checksum drifted after save/load
+    because ``serialize_node`` rewrites the stored rel-path (``hello.py`` →
+    ``tree/hello.py``) but leaves the in-memory node untouched. See task #12
+    of the #140 module editing workflow.
+
+    The fix removes ``relative_path`` from the hash inputs — it's a storage
+    layout detail, not part of node identity. Content is still hashed in
+    full via ``_feed_file_content``, and the parent folder's key iteration
+    folds the tree path into the digest.
+    """
+
+    def test_script_checksum_ignores_relative_path(self, tmp_path):
+        """Two PDVScripts pointing at the same content via different rel paths hash identically."""
+        file_a = tmp_path / "a.py"
+        file_b_dir = tmp_path / "tree"
+        file_b_dir.mkdir()
+        file_b = file_b_dir / "a.py"
+        content = "def run(pdv_tree):\n    return {}\n"
+        file_a.write_text(content, encoding="utf-8")
+        file_b.write_text(content, encoding="utf-8")
+
+        tree_a = PDVTree()
+        tree_a._set_working_dir(str(tmp_path))
+        dict.__setitem__(tree_a, "s", PDVScript(relative_path="a.py"))
+
+        tree_b = PDVTree()
+        tree_b._set_working_dir(str(tmp_path))
+        dict.__setitem__(tree_b, "s", PDVScript(relative_path="tree/a.py"))
+
+        assert tree_checksum(tree_a) == tree_checksum(tree_b)
+
+    def test_script_checksum_still_content_sensitive(self, tmp_path):
+        """Removing relative_path from the hash must not weaken content sensitivity."""
+        file_a = tmp_path / "a.py"
+        file_a.write_text("VERSION = 1\n", encoding="utf-8")
+
+        tree = PDVTree()
+        tree._set_working_dir(str(tmp_path))
+        dict.__setitem__(tree, "s", PDVScript(relative_path="a.py"))
+        before = tree_checksum(tree)
+
+        file_a.write_text("VERSION = 2\n", encoding="utf-8")
+        after = tree_checksum(tree)
+        assert before != after
+
+
 class TestRoundtrip:
     def test_roundtrip(self, tmp_path):
         """Save a tree to disk and reload it; tree_checksum must be equal."""
@@ -164,7 +213,9 @@ class TestRoundtrip:
         os.makedirs(working_dir, exist_ok=True)
         os.makedirs(save_dir, exist_ok=True)
 
-        # Build a tree with a mix of value types
+        # Build a tree with a mix of value types — including a file-backed
+        # PDVScript so the test exercises the branch that used to fold
+        # relative_path into the digest (see TestRelativePathNotHashed).
         tree = PDVTree()
         tree._set_working_dir(working_dir)
 
@@ -175,6 +226,15 @@ class TestRoundtrip:
         dict.__setitem__(tree, "value", 3.14)
         dict.__setitem__(tree, "flag", True)
         dict.__setitem__(tree, "items", [1, 2, 3])
+
+        script_file = os.path.join(working_dir, "hello.py")
+        with open(script_file, "w", encoding="utf-8") as f:
+            f.write("def run(pdv_tree: dict):\n    return {}\n")
+        dict.__setitem__(
+            tree,
+            "hello",
+            PDVScript(relative_path="hello.py", language="python"),
+        )
 
         checksum_before = tree_checksum(tree)
 
@@ -193,6 +253,17 @@ class TestRoundtrip:
         )
         assert save_resp is not None
         assert save_resp["payload"]["checksum"] == checksum_before
+
+        # ---- simulate main-process copyFilesForLoad ----
+        # The real app mirrors saveDir/tree/ back into workingDir/tree/
+        # before calling pdv.project.load so the rehydrated PDVFile nodes
+        # can resolve their new tree-prefixed relative paths on disk.
+        import shutil
+        save_tree = os.path.join(save_dir, "tree")
+        if os.path.exists(save_tree):
+            shutil.copytree(
+                save_tree, os.path.join(working_dir, "tree"), dirs_exist_ok=True,
+            )
 
         # ---- load into a fresh tree ----
         fresh_tree = PDVTree()

--- a/pdv-python/tests/test_handlers_modules.py
+++ b/pdv-python/tests/test_handlers_modules.py
@@ -160,9 +160,11 @@ class TestHandleModuleReloadLibs:
 
         from pdv_kernel.tree import PDVModule
 
-        # Arrange: working-dir/<alias>/lib/<libname>.py
+        # Arrange: working-dir/tree/<alias>/lib/<libname>.py — the
+        # ``tree/`` prefix is the canonical working-dir subdir for
+        # file-backed nodes after the Option-A layout fix.
         alias = "my_mod"
-        lib_dir = tmp_path / alias / "lib"
+        lib_dir = tmp_path / "tree" / alias / "lib"
         lib_dir.mkdir(parents=True)
         lib_file = lib_dir / "helpers_reload_v1.py"
         lib_file.write_text("VALUE = 1\n")

--- a/pdv-python/tests/test_handlers_modules.py
+++ b/pdv-python/tests/test_handlers_modules.py
@@ -17,7 +17,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import pdv_kernel.comms as comms_mod
-from pdv_kernel.handlers.modules import handle_handler_invoke, handle_modules_setup
+from pdv_kernel.handlers.modules import (
+    handle_handler_invoke,
+    handle_module_create_empty,
+    handle_module_reload_libs,
+    handle_module_update,
+    handle_modules_setup,
+)
 from pdv_kernel.modules import clear_handlers, handle
 
 
@@ -139,3 +145,232 @@ class TestHandleHandlerInvoke:
         response = mock_comm._sent[0]
         assert response["payload"]["dispatched"] is False
         assert "error" in response["payload"]
+
+
+class TestHandleModuleReloadLibs:
+    """Tests for pdv.module.reload_libs — the script:run preflight that
+    importlib.reloads modules whose __file__ is under <workdir>/<alias>/lib/.
+    See the #140 workflow plan §4.
+    """
+
+    def test_reloads_lib_file_under_alias(self, tree_with_comm, tmp_path):
+        """A lib file edited on disk is observably reloaded in sys.modules."""
+        import importlib
+        import os
+
+        from pdv_kernel.tree import PDVModule
+
+        # Arrange: working-dir/<alias>/lib/<libname>.py
+        alias = "my_mod"
+        lib_dir = tmp_path / alias / "lib"
+        lib_dir.mkdir(parents=True)
+        lib_file = lib_dir / "helpers_reload_v1.py"
+        lib_file.write_text("VALUE = 1\n")
+        sys.path.insert(0, str(lib_dir))
+
+        # Force the working dir for this test's tree.
+        tree_with_comm._working_dir = str(tmp_path)
+
+        # Install a PDVModule at the alias so the handler's is_module
+        # check passes.
+        tree_with_comm[alias] = PDVModule(
+            module_id=alias, name="My", version="0.1.0",
+        )
+
+        try:
+            import helpers_reload_v1  # noqa: PLC0415
+            assert helpers_reload_v1.VALUE == 1
+
+            # Edit the file on disk — simulates an external editor save.
+            lib_file.write_text("VALUE = 42\n")
+
+            # Call the reload handler.
+            mock_comm = _make_mock_comm()
+            msg = _make_msg("pdv.module.reload_libs", {"alias": alias})
+            with (
+                patch.object(comms_mod, "_comm", mock_comm),
+                patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+            ):
+                handle_module_reload_libs(msg)
+
+            # Assert: the new value is observable and the response lists the reload.
+            assert helpers_reload_v1.VALUE == 42
+            response = mock_comm._sent[-1]
+            assert response["type"] == "pdv.module.reload_libs.response"
+            assert "helpers_reload_v1" in response["payload"]["reloaded"]
+            assert response["payload"]["errors"] == {}
+        finally:
+            sys.path.remove(str(lib_dir))
+            sys.modules.pop("helpers_reload_v1", None)
+
+    def test_short_circuits_when_alias_is_not_a_module(self, tree_with_comm):
+        """Handler must be cheap when the first tree-path segment is not a PDVModule.
+
+        script:run fires the preflight for every run — reload_libs is called
+        with e.g. alias="scripts" for a plain project script. The handler
+        should return empty lists immediately without walking sys.modules.
+        """
+        mock_comm = _make_mock_comm()
+        # No node at this path at all.
+        msg = _make_msg("pdv.module.reload_libs", {"alias": "nonexistent"})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_module_reload_libs(msg)
+
+        response = mock_comm._sent[-1]
+        assert response["payload"]["reloaded"] == []
+        assert response["payload"]["errors"] == {}
+
+    def test_missing_alias_sends_error_reload(self, tree_with_comm):
+        """Empty alias in payload yields a structured error response."""
+        mock_comm = _make_mock_comm()
+        msg = _make_msg("pdv.module.reload_libs", {})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_module_reload_libs(msg)
+
+        response = mock_comm._sent[-1]
+        assert response["status"] == "error"
+        assert response["payload"]["code"] == "module.missing_alias"
+
+
+class TestHandleModuleCreateEmpty:
+    """Tests for pdv.module.create_empty — workflow B empty-module creation."""
+
+    def test_creates_module_with_default_subtrees(self, tree_with_comm):
+        """An empty module lands with scripts/lib/plots PDVTree children."""
+        from pdv_kernel.tree import PDVModule, PDVTree
+
+        mock_comm = _make_mock_comm()
+        msg = _make_msg(
+            "pdv.module.create_empty",
+            {"id": "toy", "name": "Toy", "version": "0.1.0", "description": "a toy"},
+        )
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_module_create_empty(msg)
+
+        mod = tree_with_comm["toy"]
+        assert isinstance(mod, PDVModule)
+        assert mod.module_id == "toy"
+        assert mod.name == "Toy"
+        assert mod.version == "0.1.0"
+        assert mod.description == "a toy"
+        assert isinstance(tree_with_comm["toy.scripts"], PDVTree)
+        assert isinstance(tree_with_comm["toy.lib"], PDVTree)
+        assert isinstance(tree_with_comm["toy.plots"], PDVTree)
+        response = mock_comm._sent[-1]
+        assert response["type"] == "pdv.module.create_empty.response"
+        assert response["payload"]["path"] == "toy"
+
+    def test_rejects_existing_alias(self, tree_with_comm):
+        """Cannot create a module at a path already occupied in the tree."""
+        tree_with_comm["toy"] = 42  # something already at that key
+        mock_comm = _make_mock_comm()
+        msg = _make_msg(
+            "pdv.module.create_empty",
+            {"id": "toy", "name": "Toy", "version": "0.1.0"},
+        )
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_module_create_empty(msg)
+
+        response = mock_comm._sent[-1]
+        assert response["status"] == "error"
+        assert response["payload"]["code"] == "module.alias_exists"
+
+    def test_requires_id(self, tree_with_comm):
+        """Missing id → structured error."""
+        mock_comm = _make_mock_comm()
+        msg = _make_msg("pdv.module.create_empty", {"name": "Toy"})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_module_create_empty(msg)
+
+        response = mock_comm._sent[-1]
+        assert response["status"] == "error"
+        assert response["payload"]["code"] == "module.missing_id"
+
+
+class TestHandleModuleUpdate:
+    """Tests for pdv.module.update — metadata editor patch handler."""
+
+    def test_updates_mutable_fields(self, tree_with_comm):
+        from pdv_kernel.tree import PDVModule
+
+        tree_with_comm["toy"] = PDVModule(
+            module_id="toy", name="Toy", version="0.1.0", description="old",
+        )
+
+        mock_comm = _make_mock_comm()
+        msg = _make_msg(
+            "pdv.module.update",
+            {
+                "alias": "toy",
+                "name": "Toy (renamed)",
+                "version": "0.2.0",
+                "description": "new",
+            },
+        )
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_module_update(msg)
+
+        mod = tree_with_comm["toy"]
+        assert mod.name == "Toy (renamed)"
+        assert mod.version == "0.2.0"
+        assert mod.description == "new"
+        response = mock_comm._sent[-1]
+        assert response["type"] == "pdv.module.update.response"
+        assert response["payload"]["version"] == "0.2.0"
+
+    def test_omitted_fields_left_alone(self, tree_with_comm):
+        """Only provided fields are updated; omitted fields are untouched."""
+        from pdv_kernel.tree import PDVModule
+
+        tree_with_comm["toy"] = PDVModule(
+            module_id="toy", name="Toy", version="0.1.0", description="orig",
+        )
+        mock_comm = _make_mock_comm()
+        msg = _make_msg(
+            "pdv.module.update",
+            {"alias": "toy", "version": "0.2.0"},
+        )
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_module_update(msg)
+        mod = tree_with_comm["toy"]
+        assert mod.name == "Toy"
+        assert mod.version == "0.2.0"
+        assert mod.description == "orig"
+
+    def test_rejects_non_module_target(self, tree_with_comm):
+        """Updating a path that isn't a PDVModule returns an error."""
+        tree_with_comm["plain"] = 42
+        mock_comm = _make_mock_comm()
+        msg = _make_msg(
+            "pdv.module.update",
+            {"alias": "plain", "name": "x"},
+        )
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_module_update(msg)
+        response = mock_comm._sent[-1]
+        assert response["status"] == "error"
+        assert response["payload"]["code"] == "module.not_a_module"

--- a/pdv-python/tests/test_handlers_project.py
+++ b/pdv-python/tests/test_handlers_project.py
@@ -250,6 +250,170 @@ class TestHandleProjectSave:
             assert 'metadata' in node, f"Missing metadata for {node['path']}"
             assert 'preview' in node['metadata']
 
+    def test_save_response_includes_module_owned_files(self, tree_with_comm, tmp_save_dir):
+        """Module-owned PDVFile nodes surface in the save response so the main
+        process can mirror them into <saveDir>/modules/<id>/<source_rel_path>."""
+        working_dir = tree_with_comm._working_dir
+        # Place a script file and a lib file under the working-dir alias.
+        scripts_dir = os.path.join(working_dir, 'my_mod', 'scripts')
+        lib_dir = os.path.join(working_dir, 'my_mod', 'lib')
+        os.makedirs(scripts_dir, exist_ok=True)
+        os.makedirs(lib_dir, exist_ok=True)
+        script_path = os.path.join(scripts_dir, 'run.py')
+        with open(script_path, 'w') as f:
+            f.write('def run(pdv_tree: dict):\n    return {}\n')
+        lib_path = os.path.join(lib_dir, 'helpers.py')
+        with open(lib_path, 'w') as f:
+            f.write('VALUE = 1\n')
+
+        # Build a PDVModule containing both.
+        module = PDVModule(module_id='my_mod', name='My', version='0.1.0')
+        module['scripts'] = PDVTree()
+        module['scripts.run'] = PDVScript(
+            relative_path=script_path,
+            module_id='my_mod',
+            source_rel_path='scripts/run.py',
+        )
+        module['lib'] = PDVTree()
+        module['lib.helpers'] = PDVLib(
+            relative_path=lib_path,
+            module_id='my_mod',
+            source_rel_path='lib/helpers.py',
+        )
+        tree_with_comm['my_mod'] = module
+
+        mock_comm = _make_mock_comm()
+        msg = _make_msg('pdv.project.save', {'save_dir': tmp_save_dir})
+        with patch.object(comms_mod, '_comm', mock_comm), \
+             patch.object(comms_mod, '_pdv_tree', tree_with_comm):
+            handle_project_save(msg)
+
+        # Find the save response among the sent messages.
+        response = next(
+            m for m in mock_comm._sent
+            if m.get('type') == 'pdv.project.save.response'
+        )
+        owned = response['payload'].get('module_owned_files', [])
+        # Should contain entries for both the script and the lib.
+        by_rel = {entry['source_rel_path']: entry for entry in owned}
+        assert 'scripts/run.py' in by_rel
+        assert 'lib/helpers.py' in by_rel
+        assert by_rel['scripts/run.py']['module_id'] == 'my_mod'
+        assert by_rel['lib/helpers.py']['module_id'] == 'my_mod'
+        # workdir_path must be absolute so the main process can open it directly.
+        assert os.path.isabs(by_rel['scripts/run.py']['workdir_path'])
+        assert os.path.isabs(by_rel['lib/helpers.py']['workdir_path'])
+
+    def test_save_response_includes_module_manifests(self, tree_with_comm, tmp_save_dir):
+        """Each PDVModule surfaces a full manifest bundle with module-root-relative descriptors."""
+        working_dir = tree_with_comm._working_dir
+        scripts_dir = os.path.join(working_dir, 'toy', 'scripts')
+        lib_dir = os.path.join(working_dir, 'toy', 'lib')
+        os.makedirs(scripts_dir, exist_ok=True)
+        os.makedirs(lib_dir, exist_ok=True)
+        script_path = os.path.join(scripts_dir, 'hello.py')
+        with open(script_path, 'w') as f:
+            f.write('def run(pdv_tree: dict):\n    return {}\n')
+        lib_path = os.path.join(lib_dir, 'helpers.py')
+        with open(lib_path, 'w') as f:
+            f.write('VALUE = 1\n')
+
+        from pdv_kernel.tree import PDVLib, PDVScript, PDVTree
+
+        module = PDVModule(
+            module_id='toy',
+            name='Toy',
+            version='0.1.0',
+            description='a toy',
+            language='python',
+        )
+        module['scripts'] = PDVTree()
+        module['scripts.hello'] = PDVScript(
+            relative_path=script_path,
+            module_id='toy',
+            source_rel_path='scripts/hello.py',
+        )
+        module['lib'] = PDVTree()
+        module['lib.helpers'] = PDVLib(
+            relative_path=lib_path,
+            module_id='toy',
+            source_rel_path='lib/helpers.py',
+        )
+        module['plots'] = PDVTree()
+        tree_with_comm['toy'] = module
+
+        mock_comm = _make_mock_comm()
+        msg = _make_msg('pdv.project.save', {'save_dir': tmp_save_dir})
+        with patch.object(comms_mod, '_comm', mock_comm), \
+             patch.object(comms_mod, '_pdv_tree', tree_with_comm):
+            handle_project_save(msg)
+
+        response = next(
+            m for m in mock_comm._sent
+            if m.get('type') == 'pdv.project.save.response'
+        )
+        manifests = response['payload'].get('module_manifests', [])
+        assert len(manifests) == 1
+        bundle = manifests[0]
+        assert bundle['module_id'] == 'toy'
+        assert bundle['name'] == 'Toy'
+        assert bundle['version'] == '0.1.0'
+        assert bundle['description'] == 'a toy'
+        assert bundle['language'] == 'python'
+
+        by_path = {e['path']: e for e in bundle['entries']}
+        # Three container entries (scripts, lib, plots) and two leaves
+        # — all rooted at the module, not prefixed with "toy.".
+        assert 'scripts' in by_path
+        assert 'lib' in by_path
+        assert 'plots' in by_path
+        assert by_path['scripts']['type'] == 'folder'
+        assert 'scripts.hello' in by_path
+        assert by_path['scripts.hello']['type'] == 'script'
+        assert by_path['scripts.hello']['storage']['relative_path'] == 'scripts/hello.py'
+        assert by_path['scripts.hello']['parent_path'] == 'scripts'
+        assert 'lib.helpers' in by_path
+        assert by_path['lib.helpers']['storage']['relative_path'] == 'lib/helpers.py'
+        assert by_path['lib.helpers']['type'] == 'lib'
+
+    def test_save_response_has_empty_manifests_when_no_modules(self, tree_with_comm, tmp_save_dir):
+        """Projects without PDVModule nodes emit an empty module_manifests list."""
+        tree_with_comm['score'] = 99
+        mock_comm = _make_mock_comm()
+        msg = _make_msg('pdv.project.save', {'save_dir': tmp_save_dir})
+        with patch.object(comms_mod, '_comm', mock_comm), \
+             patch.object(comms_mod, '_pdv_tree', tree_with_comm):
+            handle_project_save(msg)
+        response = next(
+            m for m in mock_comm._sent
+            if m.get('type') == 'pdv.project.save.response'
+        )
+        assert response['payload'].get('module_manifests', []) == []
+
+    def test_save_response_excludes_non_module_files(self, tree_with_comm, tmp_save_dir):
+        """Scripts outside any PDVModule subtree do not appear in module_owned_files."""
+        working_dir = tree_with_comm._working_dir
+        scripts_dir = os.path.join(working_dir, 'project_scripts')
+        os.makedirs(scripts_dir, exist_ok=True)
+        script_path = os.path.join(scripts_dir, 'plain.py')
+        with open(script_path, 'w') as f:
+            f.write('def run(pdv_tree: dict):\n    return {}\n')
+        # Plain PDVScript with no module context and no source_rel_path.
+        tree_with_comm['scripts'] = PDVTree()
+        tree_with_comm['scripts.plain'] = PDVScript(relative_path=script_path)
+
+        mock_comm = _make_mock_comm()
+        msg = _make_msg('pdv.project.save', {'save_dir': tmp_save_dir})
+        with patch.object(comms_mod, '_comm', mock_comm), \
+             patch.object(comms_mod, '_pdv_tree', tree_with_comm):
+            handle_project_save(msg)
+
+        response = next(
+            m for m in mock_comm._sent
+            if m.get('type') == 'pdv.project.save.response'
+        )
+        assert response['payload'].get('module_owned_files', []) == []
+
 
 class TestTwoPassLoading:
     """Tests for two-pass load ordering and metadata preservation."""

--- a/pdv-python/tests/test_handlers_script.py
+++ b/pdv-python/tests/test_handlers_script.py
@@ -51,6 +51,32 @@ class TestHandleScriptRegister:
         assert response['status'] == 'ok'
         assert response['payload']['path'] == 'scripts.analysis.fit_model'
 
+    def test_register_with_source_rel_path_persists_on_node(self):
+        """source_rel_path from payload is stored on the PDVScript node.
+
+        Regression guard for workflow A/B: module-owned scripts created
+        via pdv.script.register must remember where they belong inside
+        <saveDir>/modules/<id>/ so the save-time sync can mirror edits.
+        """
+        tree = PDVTree()
+        mock_comm = _make_mock_comm()
+        msg = _make_msg(
+            {
+                'parent_path': 'my_mod.scripts',
+                'name': 'solve',
+                'relative_path': 'my_mod/scripts/solve.py',
+                'language': 'python',
+                'module_id': 'my_mod',
+                'source_rel_path': 'scripts/solve.py',
+            }
+        )
+        with patch.object(comms_mod, '_comm', mock_comm), patch.object(comms_mod, '_pdv_tree', tree):
+            handle_script_register(msg)
+
+        node = tree['my_mod.scripts.solve']
+        assert isinstance(node, PDVScript)
+        assert node.source_rel_path == 'scripts/solve.py'
+
     def test_register_missing_name_sends_error(self):
         tree = PDVTree()
         mock_comm = _make_mock_comm()

--- a/pdv-python/tests/test_serialization.py
+++ b/pdv-python/tests/test_serialization.py
@@ -287,6 +287,74 @@ class TestMetadataSubDict:
         assert meta['language'] == 'python'
         assert meta['doc'] == 'My script.'
         assert 'preview' in meta
+        # Non-module scripts do not carry source_rel_path.
+        assert 'source_rel_path' not in desc
+
+    def test_module_owned_script_carries_source_rel_path(self, tmp_working_dir):
+        """PDVScript with source_rel_path set round-trips through serialize_node."""
+        from pdv_kernel.tree import PDVScript
+        script_file = os.path.join(tmp_working_dir, 'my_mod', 'scripts', 'run.py')
+        os.makedirs(os.path.dirname(script_file), exist_ok=True)
+        with open(script_file, 'w') as f:
+            f.write('"""Module script."""\ndef run(pdv_tree: dict):\n    return {}\n')
+        script = PDVScript(
+            relative_path=script_file,
+            language='python',
+            doc='Module script.',
+            module_id='my_mod',
+            source_rel_path='scripts/run.py',
+        )
+        desc = serialize_node('my_mod.scripts.run', script, tmp_working_dir)
+        assert desc['source_rel_path'] == 'scripts/run.py'
+
+    def test_source_rel_path_round_trip_through_tree_loader(self, tmp_working_dir):
+        """serialize_node + load_tree_index preserve source_rel_path across save/load."""
+        from pdv_kernel.tree import PDVLib, PDVModule, PDVScript, PDVTree
+        from pdv_kernel.tree_loader import load_tree_index
+
+        mod_root = os.path.join(tmp_working_dir, 'my_mod')
+        scripts_dir = os.path.join(mod_root, 'scripts')
+        lib_dir = os.path.join(mod_root, 'lib')
+        os.makedirs(scripts_dir, exist_ok=True)
+        os.makedirs(lib_dir, exist_ok=True)
+        script_file = os.path.join(scripts_dir, 'run.py')
+        with open(script_file, 'w') as f:
+            f.write('def run(pdv_tree: dict):\n    return {}\n')
+        lib_file = os.path.join(lib_dir, 'helpers.py')
+        with open(lib_file, 'w') as f:
+            f.write('VALUE = 1\n')
+
+        script = PDVScript(
+            relative_path=script_file,
+            module_id='my_mod',
+            source_rel_path='scripts/run.py',
+        )
+        lib = PDVLib(
+            relative_path=lib_file,
+            module_id='my_mod',
+            source_rel_path='lib/helpers.py',
+        )
+        module = PDVModule(module_id='my_mod', name='My Mod', version='0.1.0')
+
+        descriptors = [
+            serialize_node('my_mod', module, tmp_working_dir),
+            serialize_node('my_mod.scripts', PDVTree(), tmp_working_dir),
+            serialize_node('my_mod.scripts.run', script, tmp_working_dir),
+            serialize_node('my_mod.lib', PDVTree(), tmp_working_dir),
+            serialize_node('my_mod.lib.helpers', lib, tmp_working_dir),
+        ]
+
+        # Rehydrate into a fresh tree.
+        fresh = PDVTree()
+        fresh._working_dir = tmp_working_dir
+        load_tree_index(fresh, descriptors, conflict_strategy='replace')
+
+        loaded_script = fresh['my_mod.scripts.run']
+        loaded_lib = fresh['my_mod.lib.helpers']
+        assert isinstance(loaded_script, PDVScript)
+        assert isinstance(loaded_lib, PDVLib)
+        assert loaded_script.source_rel_path == 'scripts/run.py'
+        assert loaded_lib.source_rel_path == 'lib/helpers.py'
 
     def test_all_descriptors_have_metadata(self, tmp_working_dir):
         """Every kind produces a descriptor with a metadata key."""


### PR DESCRIPTION
## Summary

Closes #140. Implements the two workflows users have been asking for so
they can edit and author modules entirely inside PDV, without
hand-editing ``pdv-module.json`` or restarting the kernel to pick up lib
changes.

- **Workflow A — edit an imported module.** External-editor edits to
  scripts, libs, and GUIs survive save/close/reopen, and lib edits are
  picked up on the next ``script:run`` without restarting the kernel.
- **Workflow B — author a new module from scratch.** File → New Module
  (Cmd+Shift+M) creates an empty PDVModule with ``scripts``/``lib``/``plots``
  subtrees, the tree context menu's Create Script / Create Lib / Create
  GUI entries populate it, and Save Project writes a v4
  ``pdv-module.json`` + ``module-index.json`` into
  ``<saveDir>/modules/<id>/`` so the module is reloadable and exportable.

Right-click a module node for **Edit metadata…** (rename, bump version,
tweak description) and **Export to global store…** (publish to
``~/.PDV/modules/packages/<id>/`` so other projects can import it).

## Highlights

- **v4-only module bind path.** The legacy v1/v2/v3 per-node registration
  flow is deleted. Non-v4 modules fail to import with a clear error.
  Bundled examples are already v4.
- **``source_rel_path``** threaded through every module-owned PDVFile so
  the save-time sync knows where each file belongs inside
  ``<saveDir>/modules/<id>/``. Round-trips through ``tree-index.json``
  and ``module-index.json``.
- **Live lib reload** via a new ``pdv.module.reload_libs`` preflight
  fired before every module-owned ``script:run``. Uses ``os.path.realpath``
  on both sides of the prefix check to handle macOS ``/var`` →
  ``/private/var``.
- **Manifest + index writer** (``electron/main/module-manifest-writer.ts``)
  emits v4 ``pdv-module.json`` + ``module-index.json`` from live
  ``PDVModule`` state at save time. The kernel walks each module
  subtree and returns module-root-relative node descriptors so
  ``bindImportedModule`` can re-prefix them with whatever alias the user
  picks on the next import.
- **Export handler** copies the project-local module copy to the global
  store and upserts it into the store index so the Import dialog sees
  it immediately.
- **Metadata editor UI**: new NewModuleDialog, ModuleMetadataDialog, and
  CreateLibDialog components. Tree context menu gains
  ``edit_module_metadata``, ``create_lib``, and ``export_module``
  entries on module nodes.
- **ARCHITECTURE.md** §3.4, §5.9, §5.12, §5.13, §6.2, §8.1 rewritten to
  document the new comm messages, PDVModule mutability,
  ``source_rel_path``, save-time sync, per-module manifest writing, and
  v4-only semantics.

## Also in this PR — checksum bug caught during the final smoke

``tree_checksum`` used to fold ``relative_path`` into the digest of every
file-backed node, but ``serialize_node`` rewrites the stored
``relative_path`` (``hello.py`` → ``tree/hello.py``) without mutating
the in-memory node. So the pre-save digest and the post-load digest
disagreed on every project with a PDVScript/PDVGui/PDVNamelist/PDVNote,
giving ``checksumValid: false`` on every reload. PDVLib was immune
because ``serialize_node``'s PDVLib branch preserves the original
rel-path literally.

Commit ``a739456`` drops ``relative_path`` from those hash branches —
it's a storage layout detail, not part of node identity. File content
is still hashed in full, the type marker keeps kinds distinct, and the
parent folder's key iteration already folds the tree path in.

**Note**: this changes the digest value. The first reload of any
previously-saved project will produce a one-time
``checksumValid: false`` warning. The next save rewrites it. No data
loss.

## TODOs left for #182

- Deletion propagation from the working tree to ``<saveDir>/modules/``.
- Commit & push edited modules back to an upstream GitHub URL instead
  of (or in addition to) the global store.

## Test plan

- [x] ``cd pdv-python && pytest tests/ -v`` — 274 passed / 2 skipped
- [x] ``cd electron && npm test`` — 283 passed
- [x] Full manual smoke via CDP against a running Electron dev build:
  - workflow A: edit N-Pendulum script + lib → run with live reload →
    save → reopen → sentinels persist
  - workflow B: createEmpty → createScript + createLib → save → close →
    reopen → authored script runs and imports its sibling lib →
    updateMetadata → exportFromProject → fresh project → re-import → run
  - export registers in the global-store index so ``listInstalled``
    sees the new entry
  - N-Pendulum regression: import + run still works
  - Checksum round-trip verified end-to-end (identical digests, ``checksumValid: true``)
- [x] Please manually eyeball the three new React dialogs
      (NewModuleDialog, ModuleMetadataDialog, CreateLibDialog) — the
      smoke driver hits the underlying IPCs but doesn't click through
      the actual modals.

## Pre-existing issue surfaced (not fixed here)

Running a module script that produces a custom-serializer-backed value
(e.g. N-Pendulum's ``PendulumSolution``) and then Save → Reopen fails
with ``Unsupported storage format``. Root cause: ``pdv.project.load``
deserializes ``tree-index`` entries **before** ``bindProjectModulesToTree``
registers the module's custom serializer. Worth filing as its own issue
and fixing by flipping the load ordering (or making the deserializer
lazy). Not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)