### PR TITLE
fix(ui): theme script GUI inputs in dark mode

### DIFF
--- a/electron/renderer/src/styles/editor.css
+++ b/electron/renderer/src/styles/editor.css
@@ -278,7 +278,7 @@
 }
 
 .log-stderr {
-  color: #ff9d88;
+  color: var(--error);
 }
 
 .log-result {
@@ -306,5 +306,5 @@
   align-self: flex-start;
   border: 1px solid var(--border-color);
   border-radius: 4px;
-  background-color: #111;
+  background-color: var(--bg-primary);
 }

--- a/electron/renderer/src/styles/gui-editor.css
+++ b/electron/renderer/src/styles/gui-editor.css
@@ -216,7 +216,7 @@
 }
 
 .canvas-node-row.selected {
-  background: rgba(0, 122, 204, 0.2);
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
   outline: 1px solid var(--accent, #007acc);
 }
 

--- a/electron/renderer/src/styles/modules.css
+++ b/electron/renderer/src/styles/modules.css
@@ -148,6 +148,47 @@
   min-width: 0;
 }
 
+select.modules-input-field,
+input.modules-input-field:not([type="range"]) {
+  padding: 2px 4px;
+  font-size: 12px;
+  border: 1px solid var(--border-color, #474747);
+  border-radius: 3px;
+  background: var(--bg-secondary, #252526);
+  color: var(--text-primary, #d4d4d4);
+  box-sizing: border-box;
+}
+
+select.modules-input-field option {
+  background: var(--bg-secondary, #252526);
+  color: var(--text-primary, #d4d4d4);
+}
+
+input.modules-input-field[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  background: var(--border-color, #474747);
+  border-radius: 2px;
+  outline: none;
+  padding: 0;
+}
+
+input.modules-input-field[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent, #0e639c);
+  border: none;
+  cursor: pointer;
+}
+
+input.modules-input-field[type="range"]::-webkit-slider-thumb:hover {
+  background: var(--accent-hover, #1177bb);
+}
+
 .modules-input-checkbox {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
## Summary
- Script GUI text inputs, dropdowns, and range sliders now use theme CSS variables instead of browser defaults, so they render correctly in dark themes (previously white-on-black).
- Range slider track and thumb themed via `--border-color` / `--accent`.
- Replaced a few lingering hardcoded colors with theme variables: `.log-stderr` → `--error`, `.log-image` background → `--bg-primary`, `.canvas-node-row.selected` highlight → `color-mix` of `--accent`.

## Test plan
- [x] Open a script GUI module (e.g. N-Pendulum) in a dark theme and verify inputs, selects, and sliders match the theme
- [x] Switch to a light theme and verify the same widgets look correct
- [x] Check stderr output color in the console log
- [x] Select a node in the GUI editor canvas and confirm the selected-row highlight uses the accent color

🤖 Generated with [Claude Code](https://claude.com/claude-code)