### PR TITLE
Various pre-beta fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1278,7 +1278,7 @@ The API surface:
 - `window.pdv.config.*` — app config: `get`, `set`
 - `window.pdv.about.*` — app metadata: `getVersion`
 - `window.pdv.themes.*` — theme persistence: `get`, `save`, `openDir` (open `~/.PDV/themes/` in OS file manager)
-- `window.pdv.codeCells.*` — tab persistence: `load`, `save` (stored under `~/.PDV/state/code-cells.json`)
+- `window.pdv.codeCells.*` — tab persistence: `load`, `save` (stored under `<kernelWorkingDir>/code-cells.json`; kernel-lifetime scope, mirrored into the project save dir on `project.save` and back out on `project.load`)
 - `window.pdv.files.*` — native OS dialogs: `pickExecutable() → string | null` (wraps Electron `dialog.showOpenDialog` for executables); `pickFile() → string | null` (general file picker); `pickDirectory() → string | null` (wraps `dialog.showOpenDialog` with `properties: ['openDirectory', 'createDirectory']`, used for Save/Open project)
 - `window.pdv.modules.*` — module management: `listInstalled`, `install`, `importToProject`, `listImported`, `removeImport`, `saveSettings`, `runAction`, `checkUpdates`, `uninstall`, `update`
 - `window.pdv.moduleWindows.*` — module GUI windows: `open`, `close`, `context`, `executeInMain`; push: `onExecuteRequest(cb) → unsub`

--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -1,3 +1,29 @@
-# projects
+# Projects
 
 <!-- TODO -->
+
+## The working directory
+
+PDV keeps all of a session's on-disk content (scripts, files, notes) under a
+single working directory. This is a per-session temp directory until you save
+the project, and it stays stable for the lifetime of the kernel.
+
+The kernel's own current working directory (`os.getcwd()`) defaults to your
+home directory and PDV will **not** change it behind your back. That means a
+plain `np.loadtxt("data.csv")` in a code cell or script resolves against
+`~`, not against your project. To load a file that lives alongside your
+project, use `pdv.working_dir`:
+
+```python
+import numpy as np
+data = np.loadtxt(pdv.working_dir / "data.csv")
+```
+
+`pdv.working_dir` is a `pathlib.Path` pointing at the current session's
+working directory.
+
+**Persistence.** The tree is the only persistent surface in PDV. Files you
+drop under `pdv.working_dir` directly are scratch — they are not copied into
+the project save directory when you save. To make a file part of the saved
+project, attach it to the tree as a `PDVFile` node. Everything in the tree
+is serialized on save; everything else is not.

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -995,8 +995,9 @@ describe("Step 5 IPC handlers", () => {
   it("project:save delegates to ProjectManager.save", async () => {
     const { projectManager } = setup();
     const save = getHandler(IPC.project.save);
-    const result = await save({}, "/tmp/project", []);
-    expect(projectManager.save).toHaveBeenCalledWith("/tmp/project", [], {
+    const cells = { tabs: [], activeTabId: 1 };
+    const result = await save({}, "/tmp/project", cells);
+    expect(projectManager.save).toHaveBeenCalledWith("/tmp/project", cells, {
       language: "python",
       interpreterPath: undefined,
     });
@@ -1022,7 +1023,7 @@ describe("Step 5 IPC handlers", () => {
       ],
     });
     const save = getHandler(IPC.project.save);
-    await save({}, "/tmp/project", []);
+    await save({}, "/tmp/project", { tabs: [], activeTabId: 1 });
 
     const scriptsDest = path.join("/tmp/project", "modules", "my_mod", "scripts/run.py");
     const libDest = path.join("/tmp/project", "modules", "my_mod", "lib/helpers.py");
@@ -1066,7 +1067,7 @@ describe("Step 5 IPC handlers", () => {
       ],
     });
     const save = getHandler(IPC.project.save);
-    await save({}, "/tmp/project", []);
+    await save({}, "/tmp/project", { tabs: [], activeTabId: 1 });
 
     const manifestWrites = (mocks.fsWriteFile as unknown as ReturnType<typeof vi.fn>).mock.calls
       .filter((c: unknown[]) => String(c[0]).includes("modules/toy/"));
@@ -1100,7 +1101,7 @@ describe("Step 5 IPC handlers", () => {
     });
     const save = getHandler(IPC.project.save);
     // Handler must not throw when a module-owned file disappeared mid-save.
-    await expect(save({}, "/tmp/project", [])).resolves.toBeDefined();
+    await expect(save({}, "/tmp/project", { tabs: [], activeTabId: 1 })).resolves.toBeDefined();
   });
 
   it("project:load delegates to ProjectManager.load", async () => {
@@ -1171,16 +1172,14 @@ describe("Step 5 IPC handlers", () => {
     });
   });
 
-  it("codeCells:load returns null initially, codeCells:save persists", async () => {
+  it("codeCells:load returns null when no active kernel", async () => {
+    // As of audit #5, code-cell persistence is scoped to the active
+    // kernel's working directory rather than a global ~/.PDV/state file.
+    // With no kernel started in this test harness, load must return null
+    // (no file to read) and the handler must not throw.
     setup();
     const load = getHandler(IPC.codeCells.load);
     expect(await load({})).toBeNull();
-
-    const save = getHandler(IPC.codeCells.save);
-    await save({}, { boxes: [{ id: "b1" }] });
-
-    const afterSave = await load({});
-    expect(afterSave).toEqual({ boxes: [{ id: "b1" }] });
   });
 
   it("modules:listInstalled delegates to ModuleManager.listInstalled", async () => {

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -1399,6 +1399,23 @@ describe("Step 5 IPC handlers", () => {
         language: "python",
       }),
     );
+    // A MODULES_SETUP must follow MODULE_CREATE_EMPTY so the kernel walker
+    // establishes sys.path for the fresh in-session module. The payload
+    // must identify the module by alias only — no pre-computed lib_dir.
+    const requestCalls = (
+      commRouter.request as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls;
+    const createIdx = requestCalls.findIndex(
+      ([type]) => type === PDVMessageType.MODULE_CREATE_EMPTY,
+    );
+    const setupIdx = requestCalls.findIndex(
+      ([type]) => type === PDVMessageType.MODULES_SETUP,
+    );
+    expect(createIdx).toBeGreaterThanOrEqual(0);
+    expect(setupIdx).toBeGreaterThan(createIdx);
+    expect(requestCalls[setupIdx][1]).toEqual({
+      modules: [{ alias: "toy" }],
+    });
   });
 
   it("modules:createEmpty returns conflict when the alias already exists", async () => {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -438,7 +438,6 @@ export function registerIpcHandlers(
   // Derive per-purpose sub-directories within ~/.PDV
   const themesDir = path.join(pdvDir, "themes");
   const stateDir  = path.join(pdvDir, "state");
-  const codeCellsPath = path.join(stateDir, "code-cells.json");
   const moduleManager = new ModuleManager(pdvDir);
   let activeProjectDir: string | null = null;
   let activeKernelId: string | null = null;
@@ -636,7 +635,6 @@ export function registerIpcHandlers(
     readConfig,
     themesDir,
     stateDir,
-    codeCellsPath,
     setAllowClose,
   });
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -602,6 +602,7 @@ export function registerIpcHandlers(
   registerProjectIpcHandlers({
     projectManager,
     moduleManager,
+    commRouter,
     kernelWorkingDirs,
     getActiveKernelId: () => activeKernelId,
     getActiveKernelLanguage: () => {

--- a/electron/main/ipc-register-app-state.ts
+++ b/electron/main/ipc-register-app-state.ts
@@ -16,13 +16,12 @@ import * as fsSync from "fs";
 import * as path from "path";
 
 import type { ConfigStore, PDVConfig } from "./config";
-import type { CodeCellData, Theme, WindowChromeInfo, WindowChromePlatform } from "./ipc";
+import type { Theme, WindowChromeInfo, WindowChromePlatform } from "./ipc";
 import { IPC } from "./ipc";
 import { getTopLevelMenuModel, popupTopLevelMenu, updateMenuEnabled, updateRecentProjectsMenu } from "./menu";
 import { initAutoUpdater, checkForUpdates, downloadUpdate, installUpdate, openReleasesPage } from "./auto-updater";
 
 let savedThemes: Theme[] = [];
-let savedCodeCells: CodeCellData | null = null;
 
 interface RegisterAppStateIpcHandlersOptions {
   win: BrowserWindow;
@@ -30,7 +29,6 @@ interface RegisterAppStateIpcHandlersOptions {
   readConfig: (configStore: ConfigStore) => PDVConfig;
   themesDir: string;
   stateDir: string;
-  codeCellsPath: string;
   /** Flips the close-guard flag in `app.ts` so the next `win.close()` proceeds. */
   setAllowClose: (allow: boolean) => void;
 }
@@ -93,24 +91,6 @@ function loadThemesFromDisk(themesDir: string): void {
   }
 }
 
-function loadCodeCellsFromDisk(codeCellsPath: string): void {
-  if (savedCodeCells !== null) {
-    return;
-  }
-  try {
-    const raw = fsSync.readFileSync(codeCellsPath, "utf8");
-    savedCodeCells = JSON.parse(raw) as CodeCellData;
-  } catch (error) {
-    const err = error as NodeJS.ErrnoException;
-    if (err.code !== "ENOENT") {
-      console.warn(
-        `[ipc-register-app-state] Unable to read code cells from ${codeCellsPath}`,
-        error
-      );
-    }
-  }
-}
-
 /**
  * Register app-state IPC handlers (config/themes/code-cells/menu/files).
  *
@@ -121,7 +101,7 @@ function loadCodeCellsFromDisk(codeCellsPath: string): void {
 export function registerAppStateIpcHandlers(
   options: RegisterAppStateIpcHandlersOptions
 ): void {
-  const { win, configStore, readConfig, themesDir, stateDir, codeCellsPath, setAllowClose } = options;
+  const { win, configStore, readConfig, themesDir, stateDir, setAllowClose } = options;
 
   fs.mkdir(themesDir, { recursive: true }).catch((error) => {
     console.warn(
@@ -136,7 +116,6 @@ export function registerAppStateIpcHandlers(
     );
   });
   loadThemesFromDisk(themesDir);
-  loadCodeCellsFromDisk(codeCellsPath);
 
   const pushWindowChromeState = (): void => {
     if (win.isDestroyed()) {
@@ -190,14 +169,6 @@ export function registerAppStateIpcHandlers(
   ipcMain.handle(IPC.themes.openDir, async () => {
     await fs.mkdir(themesDir, { recursive: true });
     return shell.openPath(themesDir);
-  });
-
-  ipcMain.handle(IPC.codeCells.load, async () => savedCodeCells);
-
-  ipcMain.handle(IPC.codeCells.save, async (_event, data: CodeCellData) => {
-    savedCodeCells = data;
-    await fs.writeFile(codeCellsPath, JSON.stringify(data, null, 2), "utf8");
-    return true;
   });
 
   ipcMain.handle(IPC.menu.updateRecentProjects, async (_event, paths: string[]) => {

--- a/electron/main/ipc-register-kernels.ts
+++ b/electron/main/ipc-register-kernels.ts
@@ -22,8 +22,7 @@ import { IPC } from "./ipc";
 import { KernelManager, type KernelInfo } from "./kernel-manager";
 import { initializeKernelSession } from "./kernel-session";
 import type { ModuleManager } from "./module-manager";
-import { buildModulesSetupPayload } from "./module-runtime";
-import { PDVMessageType } from "./pdv-protocol";
+import { setupProjectModuleNamespaces } from "./module-runtime";
 import { copyFilesForLoad } from "./project-file-sync";
 import { ProjectManager } from "./project-manager";
 
@@ -100,24 +99,12 @@ export function registerKernelIpcHandlers(
   } = options;
 
   /**
-   * Send pdv.modules.setup to the kernel so lib file paths are added to
-   * sys.path and entry points are executed.
+   * Send `pdv.modules.setup` to the kernel so PDVLib parent dirs in the
+   * active project's modules are wired into `sys.path`. Reads the manifest
+   * at call time via {@link setupProjectModuleNamespaces}.
    */
-  async function setupModuleNamespaces(kernelId: string): Promise<void> {
-    const projectDir = getActiveProjectDir();
-    if (!projectDir) return;
-    let manifest: Awaited<ReturnType<typeof ProjectManager.readManifest>>;
-    try {
-      manifest = await ProjectManager.readManifest(projectDir);
-    } catch {
-      return;
-    }
-    if (!manifest.modules || manifest.modules.length === 0) return;
-    const workingDir = kernelWorkingDirs.get(kernelId);
-    const payload = await buildModulesSetupPayload(moduleManager, manifest.modules, workingDir, projectDir);
-    if (payload.modules.length > 0) {
-      await commRouter.request(PDVMessageType.MODULES_SETUP, payload);
-    }
+  async function setupModuleNamespaces(_kernelId: string): Promise<void> {
+    await setupProjectModuleNamespaces(commRouter, moduleManager, getActiveProjectDir());
   }
 
   // Serialize kernel start/restart so concurrent calls cannot race on

--- a/electron/main/ipc-register-modules.ts
+++ b/electron/main/ipc-register-modules.ts
@@ -215,12 +215,11 @@ export function registerModulesIpcHandlers(
           kernelWorkingDirs.get(activeKernelId),
           activeProjectDir,
         );
-        // Send pdv.modules.setup so the kernel adds lib paths to sys.path
-        // and imports entry points for the newly imported module.
+        // Send pdv.modules.setup so the kernel walks the newly-registered
+        // PDVModule subtree and wires its PDVLib parent dirs into sys.path.
         const setupPayload = await buildModulesSetupPayload(
           moduleManager,
           [importedModule],
-          kernelWorkingDirs.get(activeKernelId),
           activeProjectDir,
         );
         if (setupPayload.modules.length > 0) {
@@ -316,6 +315,30 @@ export function registerModulesIpcHandlers(
           status: "error",
           error: `Kernel rejected create_empty: ${(error as Error).message}`,
         };
+      }
+
+      // Wire sys.path for the fresh module. Symmetric with the import
+      // path above: the kernel walks the PDVModule subtree (seeded by
+      // MODULE_CREATE_EMPTY) and adds parent dirs of any PDVLib nodes
+      // to sys.path. For a freshly created module the subtree has no
+      // libs yet, but this call establishes the invariant that every
+      // in-session module has been registered with the setup handler,
+      // so subsequent tree:createLib hits land in a directory that is
+      // already on sys.path.
+      const inSessionSetupPayload = await buildModulesSetupPayload(
+        moduleManager,
+        [
+          {
+            module_id: baseAlias,
+            alias: baseAlias,
+            version: request.version || "0.1.0",
+            origin: "in_session",
+          },
+        ],
+        getActiveProjectDir(),
+      );
+      if (inSessionSetupPayload.modules.length > 0) {
+        await commRouter.request(PDVMessageType.MODULES_SETUP, inSessionSetupPayload);
       }
 
       // Record the new module in the pending-imports list so it survives

--- a/electron/main/ipc-register-project.ts
+++ b/electron/main/ipc-register-project.ts
@@ -17,11 +17,13 @@ import * as path from "path";
 import { ipcMain, type BrowserWindow } from "electron";
 
 import type { CommRouter } from "./comm-router";
+import type { CodeCellData } from "./ipc";
 import { IPC } from "./ipc";
 import { ModuleManager } from "./module-manager";
 import { setupProjectModuleNamespaces } from "./module-runtime";
 import {
   ProjectManager,
+  assertCodeCellData,
   type ModuleManifestBundle,
   type ModuleOwnedFile,
   type ProjectManifest,
@@ -190,6 +192,9 @@ export function registerProjectIpcHandlers(
   ipcMain.handle(
     IPC.project.save,
     async (_event, saveDir: string, codeCells: unknown, projectName?: string) => {
+      // Validate at the IPC boundary so the error path is reported to the
+      // renderer with a clean stack, rather than a mid-save filesystem error.
+      assertCodeCellData(codeCells);
       const saveResult = await projectManager.save(saveDir, codeCells, {
         language: getActiveKernelLanguage(),
         interpreterPath: getInterpreterPath(),
@@ -293,6 +298,26 @@ export function registerProjectIpcHandlers(
 
     const { codeCells, postLoadChecksum } = await projectManager.load(saveDir);
 
+    // Mirror the project's code-cells.json into the active kernel's working
+    // directory so the per-session autosave file is in sync with the loaded
+    // project state. The working-dir file is the single source of truth for
+    // the UI autosave loop during a session; the saveDir copy is the durable
+    // snapshot bundled with the project.
+    if (activeKernelId) {
+      const workingDir = kernelWorkingDirs.get(activeKernelId);
+      if (workingDir && codeCells != null) {
+        try {
+          await fs.writeFile(
+            path.join(workingDir, "code-cells.json"),
+            JSON.stringify(codeCells, null, 2),
+            "utf8"
+          );
+        } catch (err) {
+          console.warn("[ipc-register-project] mirror code-cells to working dir failed", err);
+        }
+      }
+    }
+
     // Now that the kernel tree has been repopulated from tree-index.json,
     // wire each module's lib parent dirs into sys.path. The kernel walker
     // in handle_modules_setup is the sole owner of this, so project load
@@ -324,6 +349,40 @@ export function registerProjectIpcHandlers(
     }
 
     return { codeCells, checksum, checksumValid, nodeCount, savedPdvVersion, projectName };
+  });
+
+  // Kernel-working-dir scoped code-cell autosave. Replaces the previous
+  // global ~/.PDV/state/code-cells.json file (audit #5): tying cells to the
+  // kernel lifetime eliminates cross-project contamination and aligns with
+  // "the tree/working dir is the only persistent surface" from ARCHITECTURE.md.
+  const codeCellsFilePath = (): string | null => {
+    const kernelId = getActiveKernelId();
+    if (!kernelId) return null;
+    const workingDir = kernelWorkingDirs.get(kernelId);
+    if (!workingDir) return null;
+    return path.join(workingDir, "code-cells.json");
+  };
+
+  ipcMain.handle(IPC.codeCells.load, async (): Promise<CodeCellData | null> => {
+    const filePath = codeCellsFilePath();
+    if (!filePath) return null;
+    try {
+      const raw = await fs.readFile(filePath, "utf8");
+      return JSON.parse(raw) as CodeCellData;
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code === "ENOENT") return null;
+      console.warn("[ipc-register-project] codeCells.load failed", err);
+      return null;
+    }
+  });
+
+  ipcMain.handle(IPC.codeCells.save, async (_event, data: unknown): Promise<boolean> => {
+    assertCodeCellData(data);
+    const filePath = codeCellsFilePath();
+    if (!filePath) return false;
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2), "utf8");
+    return true;
   });
 
   ipcMain.handle(IPC.project.new, async () => {

--- a/electron/main/ipc-register-project.ts
+++ b/electron/main/ipc-register-project.ts
@@ -16,8 +16,10 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { ipcMain, type BrowserWindow } from "electron";
 
+import type { CommRouter } from "./comm-router";
 import { IPC } from "./ipc";
 import { ModuleManager } from "./module-manager";
+import { setupProjectModuleNamespaces } from "./module-runtime";
 import {
   ProjectManager,
   type ModuleManifestBundle,
@@ -34,6 +36,7 @@ import {
 interface RegisterProjectIpcHandlersOptions {
   projectManager: ProjectManager;
   moduleManager: ModuleManager;
+  commRouter: CommRouter;
   kernelWorkingDirs: Map<string, string>;
   getActiveKernelId: () => string | null;
   getActiveKernelLanguage: () => "python" | "julia";
@@ -138,9 +141,11 @@ async function writeModuleManifestsToSaveDir(
         description: bundle.description,
         language: bundle.language,
         dependencies: bundle.dependencies,
-        // Default lib_dir for v4 modules — matches the convention used
-        // by bundled example modules and read by buildModulesSetupPayload
-        // at kernel init / project-load time.
+        // Default lib_dir for the v4 manifest. Kept for external tooling
+        // that reads the on-disk manifest; the TS/kernel setup path no
+        // longer consumes this field — the kernel walker in
+        // handle_modules_setup derives sys.path entries directly from
+        // the live PDVModule subtree.
         libDir: "lib",
       });
       await writeModuleIndex(moduleDir, bundle.entries ?? []);
@@ -166,6 +171,7 @@ export function registerProjectIpcHandlers(
   const {
     projectManager,
     moduleManager,
+    commRouter,
     kernelWorkingDirs,
     getActiveKernelId,
     getActiveKernelLanguage,
@@ -286,6 +292,12 @@ export function registerProjectIpcHandlers(
     }
 
     const { codeCells, postLoadChecksum } = await projectManager.load(saveDir);
+
+    // Now that the kernel tree has been repopulated from tree-index.json,
+    // wire each module's lib parent dirs into sys.path. The kernel walker
+    // in handle_modules_setup is the sole owner of this, so project load
+    // must trigger a setup pass whenever it repopulates the tree.
+    await setupProjectModuleNamespaces(commRouter, moduleManager, saveDir);
 
     // Validate: compare the kernel's post-load checksum against the stored one.
     const checksumValid =

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -522,6 +522,17 @@ export function registerTreeNamespaceScriptIpcHandlers(
         source_rel_path: sourceRelPath,
       } satisfies PDVFileRegisterPayload);
 
+      // Wire sys.path for the newly-created lib. The kernel walker in
+      // handle_modules_setup is the sole owner of sys.path for module
+      // libs — we re-run it for the affected module whenever a new
+      // PDVLib is added to the tree so its parent directory lands on
+      // sys.path. Entry point is intentionally omitted: create_empty
+      // modules do not have one, and imported-module entry points have
+      // already been imported at import time.
+      await commRouter.request(PDVMessageType.MODULES_SETUP, {
+        modules: [{ alias: moduleInfo.moduleAlias }],
+      });
+
       const treePath = targetPath ? `${targetPath}.${stem}` : stem;
       return { success: true, libPath, treePath };
     },

--- a/electron/main/module-manager.ts
+++ b/electron/main/module-manager.ts
@@ -959,7 +959,6 @@ export class ModuleManager {
     installPath: string;
     pythonPackage?: string;
     entryPoint?: string;
-    libDir?: string;
   }> {
     const module = await this.resolveModuleRecord(moduleId, projectDir);
     if (!module) {
@@ -971,7 +970,6 @@ export class ModuleManager {
       installPath: moduleDir,
       pythonPackage: manifest.python_package,
       entryPoint: manifest.entry_point,
-      libDir: manifest.lib_dir,
     };
   }
 

--- a/electron/main/module-runtime.test.ts
+++ b/electron/main/module-runtime.test.ts
@@ -2,9 +2,11 @@
  * module-runtime.test.ts — Unit tests for module runtime helpers.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { toPythonArgumentValue } from "./module-runtime";
+import type { ModuleManager } from "./module-manager";
+import type { ProjectModuleImport } from "./project-manager";
+import { buildModulesSetupPayload, toPythonArgumentValue } from "./module-runtime";
 
 describe("toPythonArgumentValue", () => {
   it("preserves numeric literals for numeric text inputs", () => {
@@ -41,5 +43,101 @@ describe("toPythonArgumentValue", () => {
 
   it("returns null for empty string input", () => {
     expect(toPythonArgumentValue("   ")).toBeNull();
+  });
+});
+
+describe("buildModulesSetupPayload", () => {
+  function makeMockModuleManager(
+    overrides: Partial<Record<string, ReturnType<typeof vi.fn>>> = {},
+  ): { moduleManager: ModuleManager; getModuleSetupInfo: ReturnType<typeof vi.fn> } {
+    const getModuleSetupInfo = overrides.getModuleSetupInfo ?? vi.fn();
+    const moduleManager = { getModuleSetupInfo } as unknown as ModuleManager;
+    return { moduleManager, getModuleSetupInfo };
+  }
+
+  it("emits { alias } for in-session modules and never reads the installed manifest", async () => {
+    const { moduleManager, getModuleSetupInfo } = makeMockModuleManager();
+    const modules: ProjectModuleImport[] = [
+      { module_id: "toy", alias: "toy", version: "0.1.0", origin: "in_session" },
+    ];
+
+    const payload = await buildModulesSetupPayload(moduleManager, modules, "/tmp/proj");
+
+    expect(payload).toEqual({ modules: [{ alias: "toy" }] });
+    expect(getModuleSetupInfo).not.toHaveBeenCalled();
+  });
+
+  it("emits { alias, entry_point } for imported modules via getModuleSetupInfo", async () => {
+    const getModuleSetupInfo = vi.fn().mockResolvedValue({
+      installPath: "/store/n_pendulum",
+      entryPoint: "n_pendulum",
+    });
+    const { moduleManager } = makeMockModuleManager({ getModuleSetupInfo });
+    const modules: ProjectModuleImport[] = [
+      {
+        module_id: "n_pendulum",
+        alias: "n_pendulum",
+        version: "2.0.0",
+        origin: "imported",
+      },
+    ];
+
+    const payload = await buildModulesSetupPayload(moduleManager, modules, "/tmp/proj");
+
+    expect(payload).toEqual({
+      modules: [{ alias: "n_pendulum", entry_point: "n_pendulum" }],
+    });
+    expect(getModuleSetupInfo).toHaveBeenCalledTimes(1);
+    expect(getModuleSetupInfo).toHaveBeenCalledWith("n_pendulum", "/tmp/proj");
+  });
+
+  it("omits entry_point when the imported module has none", async () => {
+    const getModuleSetupInfo = vi
+      .fn()
+      .mockResolvedValue({ installPath: "/store/x" });
+    const { moduleManager } = makeMockModuleManager({ getModuleSetupInfo });
+    const modules: ProjectModuleImport[] = [
+      { module_id: "x", alias: "x", version: "0.1.0", origin: "imported" },
+    ];
+
+    const payload = await buildModulesSetupPayload(moduleManager, modules, null);
+
+    expect(payload.modules).toHaveLength(1);
+    expect(payload.modules[0]).toEqual({ alias: "x" });
+  });
+
+  it("falls back to { alias } when getModuleSetupInfo throws — walker still wires from the live tree", async () => {
+    const getModuleSetupInfo = vi
+      .fn()
+      .mockRejectedValue(new Error("manifest missing"));
+    const { moduleManager } = makeMockModuleManager({ getModuleSetupInfo });
+    const modules: ProjectModuleImport[] = [
+      { module_id: "broken", alias: "broken", version: "0.1.0", origin: "imported" },
+    ];
+
+    const payload = await buildModulesSetupPayload(moduleManager, modules, null);
+
+    expect(payload).toEqual({ modules: [{ alias: "broken" }] });
+  });
+
+  it("handles a mix of origins in one call", async () => {
+    const getModuleSetupInfo = vi
+      .fn()
+      .mockResolvedValue({ installPath: "/store/imp", entryPoint: "imp" });
+    const { moduleManager } = makeMockModuleManager({ getModuleSetupInfo });
+    const modules: ProjectModuleImport[] = [
+      { module_id: "imp", alias: "imp", version: "1.0.0", origin: "imported" },
+      { module_id: "sess", alias: "sess", version: "0.1.0", origin: "in_session" },
+    ];
+
+    const payload = await buildModulesSetupPayload(moduleManager, modules, null);
+
+    expect(payload).toEqual({
+      modules: [
+        { alias: "imp", entry_point: "imp" },
+        { alias: "sess" },
+      ],
+    });
+    expect(getModuleSetupInfo).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/main/module-runtime.ts
+++ b/electron/main/module-runtime.ts
@@ -171,59 +171,89 @@ export function buildModuleActionCode(
 /**
  * Build the payload for the `pdv.modules.setup` comm message.
  *
- * For each imported module, resolves the lib directory path (already copied
- * to the working directory by {@link bindImportedModule}) and includes the
- * optional entry_point from the manifest.
+ * Per module, emits `{ alias, entry_point? }`. The kernel is the sole owner
+ * of `sys.path` wiring for module libraries: it walks each `PDVModule` in
+ * the live tree, collects the parent directory of every `PDVLib` descendant,
+ * and inserts the dedup'd set into `sys.path`. Main process code therefore
+ * does not touch on-disk module layout here — keeping the contract stable
+ * across storage-layout redesigns.
  *
- * The kernel adds the lib_dir directly to `sys.path`/`LOAD_PATH`, making the
- * module importable without enumerating individual files.
+ * For imported modules, `entry_point` is read from the installed manifest
+ * via {@link ModuleManager.getModuleSetupInfo}. In-session modules have no
+ * entry point and skip the manifest lookup entirely — which also means
+ * they work correctly before the first `project:save` (when no on-disk
+ * manifest exists yet). Manifest-read failures for imported modules
+ * degrade to emitting `{ alias }` so the kernel walker can still wire up
+ * libs from the live tree state.
  *
- * @param moduleManager - Module manager for manifest reads.
- * @param importedModules - List of project-imported modules.
- * @param workingDir - Kernel working directory where module files were copied.
+ * @param moduleManager - Module manager for imported-module manifest reads.
+ * @param modules - Project module imports (imported or in-session).
+ * @param projectDir - Active project directory (optional).
  * @returns Payload object for pdv.modules.setup.
  */
 export async function buildModulesSetupPayload(
   moduleManager: ModuleManager,
-  importedModules: ProjectModuleImport[],
-  workingDir?: string,
+  modules: ProjectModuleImport[],
   projectDir?: string | null,
 ): Promise<{
   modules: Array<{
-    lib_paths: string[];
-    lib_dir?: string;
+    alias: string;
     entry_point?: string;
   }>;
 }> {
-  const modules: Array<{
-    lib_paths: string[];
-    lib_dir?: string;
-    entry_point?: string;
-  }> = [];
-  for (const imp of importedModules) {
+  const out: Array<{ alias: string; entry_point?: string }> = [];
+  for (const imp of modules) {
+    if (imp.origin === "in_session") {
+      out.push({ alias: imp.alias });
+      continue;
+    }
     try {
       const info = await moduleManager.getModuleSetupInfo(imp.module_id, projectDir);
-      let libDir: string | undefined;
-      if (workingDir && info.libDir) {
-        // Module-owned files live under ``<workdir>/tree/<alias>/...``
-        // post-Option-A (see bindImportedModule above); the lib dir
-        // passed to the kernel's ``pdv.modules.setup`` handler follows
-        // that same layout so ``sys.path`` points at the right place.
-        libDir = path.join(workingDir, "tree", imp.alias, info.libDir);
-      }
-      modules.push({
-        lib_paths: [],
-        lib_dir: libDir,
-        entry_point: info.entryPoint,
-      });
+      const entry: { alias: string; entry_point?: string } = { alias: imp.alias };
+      if (info.entryPoint) entry.entry_point = info.entryPoint;
+      out.push(entry);
     } catch (error) {
       console.warn(
-        `[pdv] Failed to get module setup info for ${imp.module_id}:`,
-        error
+        `[pdv] Failed to read setup info for module ${imp.module_id}; kernel walker will still wire libs from the live tree:`,
+        error,
       );
+      out.push({ alias: imp.alias });
     }
   }
-  return { modules };
+  return { modules: out };
+}
+
+/**
+ * Send `pdv.modules.setup` to the kernel for every module in the active
+ * project manifest. Reads the manifest at call time so it sees whatever
+ * the latest save wrote. A no-op when there is no active project or when
+ * the manifest has no modules.
+ *
+ * Call this after any operation that populates or repopulates the kernel
+ * tree with module subtrees (project load, kernel restart-with-project),
+ * so the walker in `handle_modules_setup` has PDVModule nodes to traverse.
+ *
+ * @param commRouter - Comm router used to send the comm message.
+ * @param moduleManager - Module manager for imported-module manifest reads.
+ * @param projectDir - Active project directory, or null.
+ */
+export async function setupProjectModuleNamespaces(
+  commRouter: CommRouter,
+  moduleManager: ModuleManager,
+  projectDir: string | null,
+): Promise<void> {
+  if (!projectDir) return;
+  let manifest: Awaited<ReturnType<typeof ProjectManager.readManifest>>;
+  try {
+    manifest = await ProjectManager.readManifest(projectDir);
+  } catch {
+    return;
+  }
+  if (!manifest.modules || manifest.modules.length === 0) return;
+  const payload = await buildModulesSetupPayload(moduleManager, manifest.modules, projectDir);
+  if (payload.modules.length > 0) {
+    await commRouter.request(PDVMessageType.MODULES_SETUP, payload);
+  }
 }
 
 /**

--- a/electron/main/project-manager.test.ts
+++ b/electron/main/project-manager.test.ts
@@ -27,6 +27,9 @@ import * as path from "path";
 import type { CommRouter } from "./comm-router";
 import { PDVCommError } from "./comm-router";
 import { ProjectManager, PDVSchemaVersionError } from "./project-manager";
+import type { CodeCellData } from "./ipc";
+
+const EMPTY_CELLS: CodeCellData = { tabs: [], activeTabId: 1 };
 import { PDVMessageType, getAppVersion, setAppVersion } from "./pdv-protocol";
 
 // ---------------------------------------------------------------------------
@@ -136,7 +139,7 @@ describe("ProjectManager", () => {
       requestMock.mockResolvedValue(makeOkResponse({ checksum: "abc123" }));
 
       const pm = new ProjectManager(router);
-      await pm.save(tmpDir, []);
+      await pm.save(tmpDir, EMPTY_CELLS);
 
       expect(requestMock).toHaveBeenCalledOnce();
       expect(requestMock).toHaveBeenCalledWith(PDVMessageType.PROJECT_SAVE, {
@@ -154,8 +157,11 @@ describe("ProjectManager", () => {
       });
 
       const pm = new ProjectManager(router);
-      const boxes = [{ id: 1, code: "print('hi')" }];
-      await pm.save(tmpDir, boxes);
+      const cells: CodeCellData = {
+        tabs: [{ id: 1, code: "print('hi')" }],
+        activeTabId: 1,
+      };
+      await pm.save(tmpDir, cells);
       callOrder.push("files-written");
 
       // Verify comm was called before file writes.
@@ -165,7 +171,7 @@ describe("ProjectManager", () => {
         path.join(tmpDir, "code-cells.json"),
         "utf8"
       );
-      expect(JSON.parse(cbContent)).toEqual(boxes);
+      expect(JSON.parse(cbContent)).toEqual(cells);
     });
 
     it("writes project.json with checksum from kernel", async () => {
@@ -175,7 +181,7 @@ describe("ProjectManager", () => {
       );
 
       const pm = new ProjectManager(router);
-      await pm.save(tmpDir, []);
+      await pm.save(tmpDir, EMPTY_CELLS);
 
       const raw = await fs.readFile(
         path.join(tmpDir, "project.json"),
@@ -193,12 +199,46 @@ describe("ProjectManager", () => {
       requestMock.mockRejectedValue(makeCommError("save.failed"));
 
       const pm = new ProjectManager(router);
-      await expect(pm.save(tmpDir, [])).rejects.toThrow();
+      await expect(pm.save(tmpDir, EMPTY_CELLS)).rejects.toThrow();
 
       // project.json must NOT exist.
       await expect(
         fs.stat(path.join(tmpDir, "project.json"))
       ).rejects.toMatchObject({ code: "ENOENT" });
+    });
+
+    it("refuses nullish codeCells payloads before any disk write", async () => {
+      const { router, requestMock } = makeMockRouter();
+      requestMock.mockResolvedValue(makeOkResponse({ checksum: "c1" }));
+
+      const pm = new ProjectManager(router);
+      await expect(
+        pm.save(tmpDir, null as unknown as CodeCellData)
+      ).rejects.toThrow(/CodeCellData/);
+      await expect(
+        pm.save(tmpDir, undefined as unknown as CodeCellData)
+      ).rejects.toThrow(/CodeCellData/);
+      expect(requestMock).not.toHaveBeenCalled();
+      await expect(
+        fs.stat(path.join(tmpDir, "code-cells.json"))
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    });
+
+    it("refuses malformed cells shapes", async () => {
+      const { router } = makeMockRouter();
+      const pm = new ProjectManager(router);
+      await expect(
+        pm.save(tmpDir, { tabs: "not-an-array" } as unknown as CodeCellData)
+      ).rejects.toThrow(/tabs/);
+      await expect(
+        pm.save(tmpDir, { tabs: [], activeTabId: "one" } as unknown as CodeCellData)
+      ).rejects.toThrow(/activeTabId/);
+      await expect(
+        pm.save(
+          tmpDir,
+          { tabs: [{ id: "x", code: "" }], activeTabId: 1 } as unknown as CodeCellData
+        )
+      ).rejects.toThrow(/numeric id/);
     });
 
     it("writes comm, then code-cells.json, then project.json — in that order", async () => {
@@ -216,7 +256,7 @@ describe("ProjectManager", () => {
       });
 
       const pm = new ProjectManager(router);
-      await pm.save(tmpDir, []);
+      await pm.save(tmpDir, EMPTY_CELLS);
 
       // After save both files must exist.
       await expect(

--- a/electron/main/project-manager.ts
+++ b/electron/main/project-manager.ts
@@ -26,6 +26,7 @@
 
 import { CommRouter } from "./comm-router";
 import { PDVMessageType, getAppVersion, type PDVProjectLoadResponsePayload } from "./pdv-protocol";
+import type { CodeCellData } from "./ipc";
 import * as fs from "fs/promises";
 import * as path from "path";
 import * as os from "os";
@@ -178,6 +179,44 @@ export class PDVSchemaVersionError extends Error {
   }
 }
 
+/**
+ * Validate that a value conforms to the {@link CodeCellData} shape.
+ *
+ * Used by {@link ProjectManager.save} to refuse nullish or malformed
+ * payloads before they are serialized into ``code-cells.json``. A prior
+ * bug (audit item #5) allowed ``undefined`` cells to silently clobber a
+ * project's saved tabs — this validator is the boundary check.
+ *
+ * @param value - Unknown payload from an IPC caller.
+ * @throws {Error} If the value is not a well-formed CodeCellData object.
+ */
+export function assertCodeCellData(value: unknown): asserts value is CodeCellData {
+  if (value == null || typeof value !== "object") {
+    throw new Error(
+      "project.save: codeCells payload must be a CodeCellData object, got " +
+        (value === null ? "null" : typeof value)
+    );
+  }
+  const obj = value as Record<string, unknown>;
+  if (!Array.isArray(obj.tabs)) {
+    throw new Error("project.save: codeCells.tabs must be an array");
+  }
+  if (typeof obj.activeTabId !== "number") {
+    throw new Error("project.save: codeCells.activeTabId must be a number");
+  }
+  for (const [i, tab] of obj.tabs.entries()) {
+    if (!tab || typeof tab !== "object") {
+      throw new Error(`project.save: codeCells.tabs[${i}] must be an object`);
+    }
+    const t = tab as Record<string, unknown>;
+    if (typeof t.id !== "number" || typeof t.code !== "string") {
+      throw new Error(
+        `project.save: codeCells.tabs[${i}] must have numeric id and string code`
+      );
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // ProjectManager
 // ---------------------------------------------------------------------------
@@ -232,7 +271,7 @@ export class ProjectManager {
    */
   async save(
     saveDir: string,
-    codeCells: unknown,
+    codeCells: CodeCellData,
     options?: { language?: "python" | "julia"; interpreterPath?: string; projectName?: string }
   ): Promise<{
     checksum: string;
@@ -240,6 +279,10 @@ export class ProjectManager {
     moduleOwnedFiles: ModuleOwnedFile[];
     moduleManifests: ModuleManifestBundle[];
   }> {
+    // Validate before any on-disk mutation: a nullish or malformed payload
+    // here used to clobber a project's saved tabs (audit #5).
+    assertCodeCellData(codeCells);
+
     // Ensure the save directory exists (creates it when the user enters a new project name
     // via the Save As dialog, so the folder hasn't been created yet).
     await fs.mkdir(saveDir, { recursive: true });

--- a/electron/renderer/src/app/HOOKS.md
+++ b/electron/renderer/src/app/HOOKS.md
@@ -9,7 +9,7 @@ App (index.tsx)
  ├── 21 useState declarations (grouped by domain — see §State Groups below)
  ├── useLayoutState()           — sidebar/pane geometry (localStorage)
  ├── useThemeManager()          — theme colors + Monaco theme
- ├── useCodeCellsPersistence()  — load/save code tabs to ~/.PDV/state/
+ ├── useCodeCellsPersistence()  — autosave code tabs to <kernelWorkingDir>/code-cells.json
  ├── useKernelSubscriptions()   — push-subscription lifecycle
  ├── useKernelLifecycle()       — start / restart / env-save
  ├── useKeyboardShortcuts()     — global keydown listener
@@ -68,15 +68,15 @@ Several hooks bump integer "refresh tokens" (e.g. `setTreeRefreshToken(t => t + 
 
 ---
 
-### `useCodeCellsPersistence({ cellTabs, activeCellTab, setCellTabs, setActiveCellTab })`
+### `useCodeCellsPersistence({ cellTabs, activeCellTab, currentKernelId })`
 
-**Purpose**: Loads persisted code cell tabs from `~/.PDV/state/code-cells.json` on mount and saves them back on every change (debounced by `CODE_CELL_SAVE_DEBOUNCE_MS`).
+**Purpose**: Debounced autosave of code cell tab state to `<kernelWorkingDir>/code-cells.json` whenever a kernel is running. Cells are scoped to the kernel lifetime — a new kernel starts empty, and project open/save mirrors the file in/out of the project save directory via `useProjectWorkflow`. There is no global `~/.PDV/state/` persistence.
 
-**Takes**: Code editor state and setters.
+**Takes**: `cellTabs`, `activeCellTab`, and the active `currentKernelId` (autosave is disabled when null).
 
 **Returns**: Nothing (void).
 
-**Dependencies**: None — independent read/write to filesystem.
+**Dependencies**: None — independent write to the kernel working dir via IPC.
 
 ---
 

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -1236,6 +1236,7 @@ const App: React.FC = () => {
               if (!result.success) {
                 setLastError(result.error);
               } else if (result.scriptPath) {
+                setTreeRefreshToken((t) => t + 1);
                 await window.pdv.script.edit(currentKernelId, result.scriptPath);
               }
             } catch (error) {

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -203,9 +203,7 @@ const App: React.FC = () => {
   useCodeCellsPersistence({
     cellTabs: cellTabs,
     activeCellTab,
-    setCellTabs,
-    setActiveCellTab,
-    currentProjectDir,
+    currentKernelId,
   });
 
   useEffect(() => {

--- a/electron/renderer/src/app/useCodeCellsPersistence.ts
+++ b/electron/renderer/src/app/useCodeCellsPersistence.ts
@@ -1,54 +1,38 @@
-import { useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
+import { useEffect, useRef } from 'react';
 import type { CellTab } from '../types';
 import { CODE_CELL_SAVE_DEBOUNCE_MS } from './constants';
 
-/** Options for {@link useCodeCellsPersistence}. Reads/writes code cell state to ~/.PDV/state/. */
+/**
+ * Options for {@link useCodeCellsPersistence}.
+ *
+ * Writes the current code-cell tab state to the active kernel's working
+ * directory (``<workingDir>/code-cells.json``) on a debounce. Cells are
+ * scoped to the kernel lifetime: a fresh kernel starts with an empty tab
+ * set, and project load restores tabs via {@link useProjectWorkflow}, not
+ * via this hook. There is no global ``~/.PDV/state/`` persistence.
+ */
 interface UseCodeCellsPersistenceOptions {
   /** The current array of code editor tabs (code, title, id). */
   cellTabs: CellTab[];
   /** The ID of the currently active editor tab. */
   activeCellTab: number;
-  /** Setter to restore persisted tabs on mount. */
-  setCellTabs: Dispatch<SetStateAction<CellTab[]>>;
-  /** Setter to restore the persisted active tab on mount. */
-  setActiveCellTab: Dispatch<SetStateAction<number>>;
-  /** Current project directory — cells are only persisted/restored when a project is open. */
-  currentProjectDir: string | null;
+  /** Active kernel ID — autosave is disabled until a kernel is running. */
+  currentKernelId: string | null;
 }
 
 export function useCodeCellsPersistence({
   cellTabs,
   activeCellTab,
-  setCellTabs,
-  setActiveCellTab,
-  currentProjectDir,
+  currentKernelId,
 }: UseCodeCellsPersistenceOptions): void {
-  const hasProjectRef = useRef(currentProjectDir);
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasKernelRef = useRef(currentKernelId);
   useEffect(() => {
-    hasProjectRef.current = currentProjectDir;
+    hasKernelRef.current = currentKernelId;
   });
 
   useEffect(() => {
-    if (!window.pdv?.codeCells || !currentProjectDir) {
-      return;
-    }
-    const loadCodeCells = async () => {
-      try {
-        const data = await window.pdv.codeCells.load();
-        if (data) {
-          setCellTabs(data.tabs);
-          setActiveCellTab(data.activeTabId);
-        }
-      } catch (error) {
-        console.error('[App] Failed to load code cells:', error);
-      }
-    };
-    void loadCodeCells();
-  }, [setActiveCellTab, setCellTabs, currentProjectDir]);
-
-  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => {
-    if (!window.pdv?.codeCells || !currentProjectDir) {
+    if (!window.pdv?.codeCells || !currentKernelId) {
       return;
     }
     if (saveTimeoutRef.current) {
@@ -69,7 +53,7 @@ export function useCodeCellsPersistence({
     return () => {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
-        if (hasProjectRef.current) {
+        if (hasKernelRef.current) {
           void window.pdv.codeCells.save({
             tabs: cellTabs,
             activeTabId: activeCellTab,
@@ -77,5 +61,5 @@ export function useCodeCellsPersistence({
         }
       }
     };
-  }, [activeCellTab, cellTabs, currentProjectDir]);
+  }, [activeCellTab, cellTabs, currentKernelId]);
 }

--- a/pdv-python/pdv_kernel/handlers/modules.py
+++ b/pdv-python/pdv_kernel/handlers/modules.py
@@ -116,11 +116,11 @@ def handle_module_register(msg: dict) -> None:
 
     # v4: mount subtree from module_index (same two-pass logic as project load).
     # When loading a saved project the tree is already populated from
-    # tree-index.json before MODULE_REGISTER runs.  Skip nodes that already
+    # tree-index.json before MODULE_REGISTER runs. Skip nodes that already
     # exist so that user data (e.g. result objects under "outputs") is not
-    # overwritten by empty default containers. lib sys.path injection is
-    # handled separately in handle_modules_setup via the lib_dir field, so
-    # the loader is told not to touch sys.path here.
+    # overwritten by empty default containers. sys.path for lib files is
+    # derived inside handle_modules_setup by walking the PDVModule subtree —
+    # the loader does not touch sys.path at all.
     if module_index:
         from pdv_kernel.tree_loader import load_tree_index  # noqa: PLC0415
 
@@ -132,7 +132,6 @@ def handle_module_register(msg: dict) -> None:
             patch_module_id_on_skip=module_id,
             module_id_default=module_id,
             working_dir=working_dir,
-            inject_lib_sys_path=False,
         )
 
     send_message(
@@ -142,19 +141,40 @@ def handle_module_register(msg: dict) -> None:
     )
 
 
+def _iter_pdv_libs(container: object):
+    """Yield every ``PDVLib`` descendant of ``container``.
+
+    Walks ``PDVTree``, ``PDVModule``, and plain ``dict`` containers
+    recursively. The walker deliberately does not assume libs live at any
+    particular sub-key (e.g. ``module.lib``) — it finds every ``PDVLib`` in
+    the subtree regardless of shape, which keeps it forward-compatible with
+    future storage layouts.
+    """
+    from pdv_kernel.tree import PDVLib  # noqa: PLC0415
+
+    if isinstance(container, PDVLib):
+        yield container
+        return
+    if not isinstance(container, dict):
+        return
+    for child in container.values():
+        yield from _iter_pdv_libs(child)
+
+
 def handle_modules_setup(msg: dict) -> None:
     """Handle the ``pdv.modules.setup`` message.
 
-    For each module in the payload, adds library directories to ``sys.path``
-    and imports the entry point module if specified.
+    For each module alias in the payload, walks the corresponding
+    :class:`~pdv_kernel.tree.PDVModule` subtree in the live tree, collects
+    the parent directory of every :class:`~pdv_kernel.tree.PDVLib`
+    descendant, dedupes, and inserts each unique parent into ``sys.path``.
+    Then imports any specified entry point.
 
-    Either or both path-style fields are accepted on the same payload — the
-    body iterates each unconditionally:
-
-    - ``lib_dir``: absolute path to a library directory; added directly to
-      ``sys.path``.
-    - ``lib_paths``: list of individual ``.py`` file paths; the parent
-      directory of each is added.
+    This is the single owner of module-related ``sys.path`` wiring. Main
+    process code must not pre-compute lib directories — the kernel derives
+    them from the in-memory tree, which keeps filesystem layout knowledge
+    on the side that owns the tree and keeps the setup contract stable
+    across storage-layout redesigns.
 
     Expected payload
     ----------------
@@ -162,11 +182,8 @@ def handle_modules_setup(msg: dict) -> None:
 
         {
             "modules": [
-                {
-                    "lib_paths": [],
-                    "lib_dir": "/tmp/pdv-xxx/n_pendulum/lib",
-                    "entry_point": "n_pendulum"
-                }
+                { "alias": "n_pendulum", "entry_point": "n_pendulum" },
+                { "alias": "ddho" }
             ]
         }
 
@@ -182,38 +199,51 @@ def handle_modules_setup(msg: dict) -> None:
         Parsed PDV message envelope.
     """
     import os  # noqa: PLC0415
+    import warnings  # noqa: PLC0415
 
-    from pdv_kernel.comms import send_message  # noqa: PLC0415
+    from pdv_kernel.comms import get_pdv_tree, send_message  # noqa: PLC0415
     from pdv_kernel.modules import get_handler_registry  # noqa: PLC0415
+    from pdv_kernel.tree import PDVModule  # noqa: PLC0415
 
     msg_id = msg.get("msg_id")
     payload = msg.get("payload", {})
     modules = payload.get("modules", [])
 
+    tree = get_pdv_tree()
+    working_dir = getattr(tree, "_working_dir", None) if tree is not None else None
+
     for mod_info in modules:
-        lib_paths = mod_info.get("lib_paths", [])
-        lib_dir = mod_info.get("lib_dir")
+        alias = mod_info.get("alias")
         entry_point = mod_info.get("entry_point")
 
-        # v4: add lib_dir directly to sys.path.
-        # Do not gate on os.path.isdir — the directory may not exist yet when
-        # pdv.modules.setup runs before bindActiveProjectModules copies files.
-        # Python handles non-existent sys.path entries gracefully.
-        if lib_dir and lib_dir not in sys.path:
-            sys.path.insert(1, lib_dir)
+        if not alias:
+            warnings.warn("pdv.modules.setup entry missing 'alias'; skipping")
+            continue
 
-        # Legacy: add parent directory of each lib .py file to sys.path.
-        for file_path in lib_paths:
-            parent_dir = os.path.dirname(file_path)
-            if parent_dir and parent_dir not in sys.path:
-                sys.path.insert(1, parent_dir)
+        module_node = tree.get(alias) if tree is not None else None
+        if not isinstance(module_node, PDVModule):
+            warnings.warn(
+                f"pdv.modules.setup: no PDVModule at alias '{alias}'; skipping"
+            )
+        else:
+            seen: set[str] = set()
+            for lib in _iter_pdv_libs(module_node):
+                abs_path = lib.resolve_path(working_dir)
+                parent_dir = os.path.dirname(abs_path)
+                if not parent_dir or parent_dir in seen:
+                    continue
+                seen.add(parent_dir)
+                # Do not gate on os.path.isdir — the directory may not
+                # exist yet when pdv.modules.setup runs before main-side
+                # file copies complete. Python handles non-existent
+                # sys.path entries gracefully.
+                if parent_dir not in sys.path:
+                    sys.path.insert(1, parent_dir)
 
         if entry_point:
             try:
                 importlib.import_module(entry_point)
             except Exception as exc:  # noqa: BLE001
-                import warnings  # noqa: PLC0415
-
                 warnings.warn(
                     f"Failed to import module entry point '{entry_point}': {exc}"
                 )

--- a/pdv-python/pdv_kernel/handlers/project.py
+++ b/pdv-python/pdv_kernel/handlers/project.py
@@ -502,7 +502,6 @@ def handle_project_load(msg: dict) -> None:
         on_progress=_emit_load_progress,
         conflict_strategy="replace",
         working_dir=working_dir,
-        inject_lib_sys_path=True,
     )
 
     os.chdir(os.path.expanduser("~"))

--- a/pdv-python/pdv_kernel/handlers/project.py
+++ b/pdv-python/pdv_kernel/handlers/project.py
@@ -64,8 +64,15 @@ def _collect_nodes(
     list
         List of node descriptor dicts.
     """
-    from pdv_kernel.serialization import serialize_node  # noqa: PLC0415
+    from pdv_kernel.errors import PDVSerializationError  # noqa: PLC0415
+    from pdv_kernel.serialization import (  # noqa: PLC0415
+        pickle_fallback_node,
+        serialize_node,
+    )
     from pdv_kernel.tree import PDVTree  # noqa: PLC0415
+    import logging  # noqa: PLC0415
+
+    log = logging.getLogger("pdv_kernel")
 
     if counter is None:
         counter = [0]
@@ -74,18 +81,45 @@ def _collect_nodes(
     for key in dict.keys(tree):
         path = f"{prefix}.{key}" if prefix else key
         value = dict.__getitem__(tree, key)
-        descriptor = serialize_node(
-            path,
-            value,
-            save_dir,
-            trusted=True,
-            source_dir=working_dir or save_dir,
-        )
+        # Super-fallback: if serialize_node refuses this value for any reason,
+        # fall back to an unconditional pickle so project.save never fails on
+        # a single unrepresentable leaf. See plan §2a and pickle_fallback_node.
+        try:
+            descriptor = serialize_node(
+                path,
+                value,
+                save_dir,
+                trusted=True,
+                source_dir=working_dir or save_dir,
+            )
+        except PDVSerializationError as exc:
+            log.warning(
+                "project.save: falling back to pickle for node '%s' (%s): %s",
+                path,
+                type(value).__name__,
+                exc,
+            )
+            descriptor = pickle_fallback_node(path, value, save_dir)
         nodes.append(descriptor)
         counter[0] += 1
         if on_progress is not None:
             on_progress(counter[0])
         if isinstance(value, PDVTree):
+            nodes.extend(
+                _collect_nodes(
+                    value,
+                    save_dir,
+                    prefix=path,
+                    working_dir=working_dir,
+                    on_progress=on_progress,
+                    counter=counter,
+                )
+            )
+        elif descriptor.get("metadata", {}).get("composite") and isinstance(value, dict):
+            # Composite plain dict (not a PDVTree): recurse to emit per-leaf
+            # descriptors. The recursive call accepts any dict-like because
+            # it iterates via dict.keys(), and per-leaf fallback applies to
+            # children too.
             nodes.extend(
                 _collect_nodes(
                     value,

--- a/pdv-python/pdv_kernel/namespace.py
+++ b/pdv-python/pdv_kernel/namespace.py
@@ -20,9 +20,10 @@ ARCHITECTURE.md §5.4 (protected namespace), §5.5 (user-facing names)
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
-from pdv_kernel.errors import PDVProtectedNameError
+from pdv_kernel.errors import PDVError, PDVProtectedNameError
 
 # Names that must never be reassigned by user code.
 _PROTECTED_NAMES: frozenset[str] = frozenset({"pdv_tree", "pdv"})
@@ -94,6 +95,34 @@ class PDVApp:
     --------
     ARCHITECTURE.md §5.5
     """
+
+    @property
+    def working_dir(self) -> Path:
+        """Filesystem path to the current kernel working directory.
+
+        This is the on-disk root that PDV uses to store scripts, files,
+        and other tree-backed content for the current session. It is the
+        per-session temp dir until the project is saved, and stays stable
+        for the lifetime of the kernel. Use it to locate data files that
+        should live alongside the tree::
+
+            np.loadtxt(pdv.working_dir / "data.csv")
+
+        The kernel's own ``os.getcwd()`` defaults to the user's home
+        directory and is never changed by PDV, so relative paths in
+        ``open()`` do **not** resolve here unless the user explicitly
+        ``os.chdir``s. Files written under ``pdv.working_dir`` are
+        scratch unless attached to the tree as ``PDVFile`` nodes — the
+        tree is the only persistent surface.
+        """
+        from pdv_kernel.comms import get_pdv_tree  # noqa: PLC0415
+
+        tree = get_pdv_tree()
+        if tree is None or not getattr(tree, "_working_dir", None):
+            raise PDVError(
+                "pdv.working_dir is not available: kernel has not received pdv.init"
+            )
+        return Path(tree._working_dir)
 
     def save(self) -> None:
         """Trigger a project save. Equivalent to File -> Save in the UI.
@@ -168,6 +197,7 @@ class PDVApp:
                 "  pdv_tree          — the project data tree (dict-like)\n"
                 "  pdv_tree['path']  — access or set a node by dot-path\n"
                 "  pdv_tree.run_script('path') — run a script node\n"
+                "  pdv.working_dir   — Path to the session working dir (for data files)\n"
                 "  pdv.save()        — save the project\n"
                 "  pdv.new_note('path', title='My Note') — create a markdown note\n"
                 "  pdv.help('pdv_tree') — help on a specific topic\n"

--- a/pdv-python/pdv_kernel/serialization.py
+++ b/pdv-python/pdv_kernel/serialization.py
@@ -131,6 +131,23 @@ def _read_parquet(path: str) -> Any:
             raise primary_err from primary_err
 
 
+def _is_json_native(value: Any) -> bool:
+    """Return True if ``value`` can be round-tripped through ``json.dumps``.
+
+    Used by :func:`serialize_node` to decide between the fast inline path for
+    plain dicts/lists of JSON-native values and the composite path that
+    emits per-leaf descriptors (for dicts containing ndarrays, DataFrames,
+    bytes, etc.).
+    """
+    import json  # noqa: PLC0415
+
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 def python_type_string(value: Any) -> str:
     """Return ``'module.qualname'`` for any object.
 
@@ -497,20 +514,41 @@ def serialize_node(
         descriptor["metadata"] = {"preview": preview}
         return descriptor
 
-    if kind in (KIND_MAPPING, KIND_SEQUENCE):
-        try:
-            json.dumps(value)
-        except (TypeError, ValueError) as exc:
-            raise PDVSerializationError(
-                f"Value at '{tree_path}' is not JSON-serializable: {exc}"
-            ) from exc
-        descriptor["storage"] = {
-            "backend": "inline",
-            "format": FORMAT_INLINE,
-            "value": value,
-        }
-        descriptor["metadata"] = {"preview": preview}
+    if kind == KIND_MAPPING:
+        if _is_json_native(value):
+            descriptor["storage"] = {
+                "backend": "inline",
+                "format": FORMAT_INLINE,
+                "value": value,
+            }
+            descriptor["metadata"] = {"preview": preview}
+            return descriptor
+        # Composite mapping: one or more leaves are not JSON-serializable.
+        # Emit a container descriptor; the save walker (_collect_nodes) is
+        # responsible for recursing into the dict and emitting per-leaf
+        # descriptors so each leaf reaches its own fast path (.npy, parquet,
+        # etc). Reconstructed on load as a plain dict, not a PDVTree.
+        descriptor["has_children"] = True
+        descriptor["storage"] = {"backend": "none", "format": "none"}
+        descriptor["metadata"] = {"preview": preview, "composite": True}
         return descriptor
+
+    if kind == KIND_SEQUENCE:
+        if _is_json_native(value):
+            descriptor["storage"] = {
+                "backend": "inline",
+                "format": FORMAT_INLINE,
+                "value": value,
+            }
+            descriptor["metadata"] = {"preview": preview}
+            return descriptor
+        raise PDVSerializationError(
+            f"Sequence at '{tree_path}' contains values that are not "
+            f"JSON-serializable (e.g. ndarray, DataFrame). PDV does not yet "
+            f"support composite sequences — wrap the values in a dict with "
+            f"named keys, e.g. {{'0': arr0, '1': arr1}}, so each element "
+            f"can be stored in its own file."
+        )
 
     if kind == KIND_BINARY:
         file_path = working_dir_tree_path(working_dir, tree_path, ".bin")
@@ -571,6 +609,84 @@ def serialize_node(
     }
     descriptor["metadata"] = {"preview": preview}
     return descriptor
+
+
+def pickle_fallback_node(tree_path: str, value: Any, working_dir: str) -> dict:
+    """Unconditionally write ``value`` as a pickle file and return a descriptor.
+
+    Super-fallback used by the save walker (:func:`_collect_nodes` in
+    ``handlers.project``) when :func:`serialize_node` raises
+    :class:`PDVSerializationError` for any reason. The policy is: the user's
+    data integrity trumps format purity — ``project.save`` must never fail
+    because of a single weird tree value.
+
+    Unlike the ``trusted=True`` branch of :func:`serialize_node`, this helper
+    bypasses the trusted gate entirely: the pickle file is written by this
+    same process and read back by this same process on project load (which
+    always passes ``trusted=True``), so there is no untrusted-code surface.
+
+    The returned descriptor carries ``metadata.fallback == "pickle"`` so that
+    tests, logs, and any future UI affordance can distinguish fallback nodes
+    from nodes whose value naturally required pickle.
+
+    Parameters
+    ----------
+    tree_path : str
+        Dot-separated tree path for the node.
+    value : Any
+        The value to pickle. May be anything picklable; if pickle itself
+        fails, the underlying exception propagates (at which point the save
+        truly cannot proceed).
+    working_dir : str
+        Absolute path to the save directory. The pickle file is written
+        under ``<working_dir>/tree/``.
+
+    Returns
+    -------
+    dict
+        A node descriptor with ``storage.backend == "local_file"``,
+        ``storage.format == FORMAT_PICKLE``, and
+        ``metadata.fallback == "pickle"``.
+    """
+    import datetime
+    import os
+    import pickle
+
+    from pdv_kernel.environment import ensure_parent, working_dir_tree_path  # noqa: PLC0415
+
+    file_path = working_dir_tree_path(working_dir, tree_path, ".pickle")
+    ensure_parent(file_path)
+    with open(file_path, "wb") as fh:
+        pickle.dump(value, fh)
+    rel_path = os.path.relpath(file_path, working_dir)
+
+    now = (
+        datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    parts = tree_path.split(".")
+    key = parts[-1]
+    parent_path = ".".join(parts[:-1]) if len(parts) > 1 else ""
+
+    return {
+        "id": tree_path,
+        "path": tree_path,
+        "key": key,
+        "parent_path": parent_path,
+        "type": KIND_UNKNOWN,
+        "has_children": False,
+        "created_at": now,
+        "updated_at": now,
+        "storage": {
+            "backend": "local_file",
+            "relative_path": rel_path,
+            "format": FORMAT_PICKLE,
+        },
+        "metadata": {
+            "preview": node_preview(value, KIND_UNKNOWN),
+            "python_type": python_type_string(value),
+            "fallback": "pickle",
+        },
+    }
 
 
 def deserialize_node(storage_ref: dict, save_dir: str, *, trusted: bool = False) -> Any:

--- a/pdv-python/pdv_kernel/tree_loader.py
+++ b/pdv-python/pdv_kernel/tree_loader.py
@@ -149,6 +149,13 @@ def load_tree_index(
             folder._working_dir = tree._working_dir
             folder._save_dir = tree._save_dir
             tree.set_quiet(full_path, folder)
+        elif node_type == "mapping" and meta.get("composite"):
+            # Composite mapping: the user assigned a plain dict containing
+            # non-JSON-native leaves (e.g. ndarrays). Reconstruct as a plain
+            # dict — NOT a PDVTree — so type(value) is dict on load, matching
+            # what the user originally stored. Children are populated in
+            # Pass 2 via set_quiet, which traverses through plain dicts.
+            tree.set_quiet(full_path, {})
         elif node_type == "module":
             storage = node.get("storage", {})
             old_meta = storage.get("value", {})
@@ -172,7 +179,14 @@ def load_tree_index(
                 on_progress(index, total)
             continue
         node_type = node.get("type", "")
+        meta = node.get("metadata", {})
         if node_type in ("folder", "module"):
+            if on_progress is not None:
+                on_progress(index, total)
+            continue
+        if node_type == "mapping" and meta.get("composite"):
+            # Composite mapping container was created in Pass 1; children
+            # will be inserted into it by subsequent Pass 2 iterations.
             if on_progress is not None:
                 on_progress(index, total)
             continue
@@ -180,7 +194,6 @@ def load_tree_index(
         full_path = _full_path(node_path_rel)
         storage = node.get("storage", {})
         backend = storage.get("backend", "")
-        meta = node.get("metadata", {})
 
         if conflict_strategy == "skip":
             exists, existing_value = _node_exists(full_path)

--- a/pdv-python/pdv_kernel/tree_loader.py
+++ b/pdv-python/pdv_kernel/tree_loader.py
@@ -31,10 +31,12 @@ Divergent details between the two callers are exposed as named arguments:
   :class:`PDVModule`.
 - ``module_id_default`` — fallback ``module_id`` for ``script`` nodes when
   the on-disk metadata is missing it.
-- ``inject_lib_sys_path`` — project load adds the parent directory of each
-  ``PDVLib`` file to ``sys.path`` so the library is importable; module
-  register defers ``sys.path`` injection to ``handle_modules_setup`` via
-  the ``lib_dir`` field, so the loader does not touch ``sys.path``.
+
+``sys.path`` wiring for module libraries is handled exclusively by
+``handle_modules_setup``: after ``load_tree_index`` populates the tree,
+main sends ``pdv.modules.setup`` and the kernel walks each ``PDVModule``
+subtree to collect the parent directories of every ``PDVLib``
+descendant. The loader itself never touches ``sys.path``.
 
 See Also
 --------
@@ -45,8 +47,6 @@ pdv_kernel.handlers.modules — pdv.module.register handler
 
 from __future__ import annotations
 
-import os
-import sys
 from typing import Any, Callable, Literal
 
 
@@ -65,7 +65,6 @@ def load_tree_index(
     patch_module_id_on_skip: str | None = None,
     module_id_default: str = "",
     working_dir: str = "",
-    inject_lib_sys_path: bool = False,
 ) -> None:
     """Mount a tree-index node list into ``tree`` using the two-pass algorithm.
 
@@ -98,12 +97,7 @@ def load_tree_index(
         metadata is missing it.
     working_dir : str
         Working directory used to resolve relative paths during
-        deserialization and (when ``inject_lib_sys_path`` is True) lib
-        ``sys.path`` injection.
-    inject_lib_sys_path : bool
-        When True, the parent directory of each ``PDVLib`` file is added
-        to ``sys.path``. Project load uses True; module register uses
-        False because ``handle_modules_setup`` handles this separately.
+        deserialization of file-backed leaves.
     """
     # Local imports to avoid circular dependencies — tree.py imports nothing
     # from this module, so importing tree.py here is safe.
@@ -280,12 +274,6 @@ def load_tree_index(
                     source_rel_path=src_rel,
                 ),
             )
-            if inject_lib_sys_path:
-                abs_path = os.path.join(working_dir, rel_path) if rel_path else ""
-                if abs_path:
-                    parent_dir = os.path.dirname(abs_path)
-                    if parent_dir and parent_dir not in sys.path:
-                        sys.path.insert(1, parent_dir)
         elif backend == "inline":
             tree.set_quiet(full_path, storage.get("value"))
         elif backend == "local_file":

--- a/pdv-python/tests/test_handlers_modules.py
+++ b/pdv-python/tests/test_handlers_modules.py
@@ -54,38 +54,165 @@ def _make_msg(msg_type, payload, msg_id=None):
 
 
 class TestHandleModulesSetup:
-    def test_adds_to_sys_path(self):
-        """pdv.modules.setup should add parent dirs of lib_paths to sys.path."""
+    """Tests for the kernel-walks-tree implementation of pdv.modules.setup.
+
+    Payload shape: ``{"modules": [{"alias": str, "entry_point"?: str}]}``.
+    The handler looks up ``tree[alias]``, walks its PDVModule subtree for
+    PDVLib descendants, and inserts each unique parent directory into
+    ``sys.path``. No main-side path synthesis.
+    """
+
+    def _install_module_with_libs(self, tree, tmp_path, alias, lib_rel_names):
+        from pdv_kernel.tree import PDVLib, PDVModule, PDVTree
+
+        # Point the tree at tmp_path so PDVLib.resolve_path() lines up with
+        # the on-disk files we create below.
+        tree._set_working_dir(str(tmp_path))
+
+        module = PDVModule(module_id=alias, name=alias, version="0.1.0")
+        module._working_dir = str(tmp_path)
+        lib_container = PDVTree()
+        lib_container._working_dir = str(tmp_path)
+        for rel in lib_rel_names:
+            abs_path = tmp_path / rel
+            abs_path.parent.mkdir(parents=True, exist_ok=True)
+            abs_path.write_text("# test lib\n")
+            lib_node = PDVLib(relative_path=rel, module_id=alias)
+            key = abs_path.stem
+            dict.__setitem__(lib_container, key, lib_node)
+        dict.__setitem__(module, "lib", lib_container)
+        dict.__setitem__(tree, alias, module)
+        return module
+
+    def test_walks_module_for_libs(self, tree_with_comm, tmp_path):
+        """Walker adds the parent dir of every PDVLib descendant to sys.path."""
+        module = self._install_module_with_libs(
+            tree_with_comm,
+            tmp_path,
+            "toy",
+            ["tree/toy/lib/helpers.py", "tree/toy/extras/more.py"],
+        )
+        assert module is not None
+
+        expected_dirs = [
+            str(tmp_path / "tree" / "toy" / "lib"),
+            str(tmp_path / "tree" / "toy" / "extras"),
+        ]
+
         mock_comm = _make_mock_comm()
-        fake_file = "/tmp/fake-module-path-for-test/n_pendulum.py"
-        expected_dir = "/tmp/fake-module-path-for-test"
+        msg = _make_msg("pdv.modules.setup", {"modules": [{"alias": "toy"}]})
+
+        try:
+            with (
+                patch.object(comms_mod, "_comm", mock_comm),
+                patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+            ):
+                handle_modules_setup(msg)
+
+            for expected in expected_dirs:
+                assert expected in sys.path, (
+                    f"{expected} missing from sys.path after setup"
+                )
+            response = mock_comm._sent[-1]
+            assert response["type"] == "pdv.modules.setup.response"
+        finally:
+            for expected in expected_dirs:
+                while expected in sys.path:
+                    sys.path.remove(expected)
+
+    def test_deduplicates_sibling_libs(self, tree_with_comm, tmp_path):
+        """Two PDVLib nodes in the same directory produce one sys.path entry."""
+        self._install_module_with_libs(
+            tree_with_comm,
+            tmp_path,
+            "toy",
+            ["tree/toy/lib/a.py", "tree/toy/lib/b.py"],
+        )
+        expected_dir = str(tmp_path / "tree" / "toy" / "lib")
+
+        # Clear any prior entries so the count assertion is meaningful.
+        while expected_dir in sys.path:
+            sys.path.remove(expected_dir)
+
+        mock_comm = _make_mock_comm()
+        msg = _make_msg("pdv.modules.setup", {"modules": [{"alias": "toy"}]})
+
+        try:
+            with (
+                patch.object(comms_mod, "_comm", mock_comm),
+                patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+            ):
+                handle_modules_setup(msg)
+
+            assert sys.path.count(expected_dir) == 1
+        finally:
+            while expected_dir in sys.path:
+                sys.path.remove(expected_dir)
+
+    def test_missing_module_warns_and_continues(self, tree_with_comm, tmp_path):
+        """Unknown aliases warn but do not abort the loop — other modules still set up."""
+        self._install_module_with_libs(
+            tree_with_comm,
+            tmp_path,
+            "present",
+            ["tree/present/lib/p.py"],
+        )
+        expected_dir = str(tmp_path / "tree" / "present" / "lib")
+
+        mock_comm = _make_mock_comm()
         msg = _make_msg(
             "pdv.modules.setup",
-            {"modules": [{"lib_paths": [fake_file]}]},
+            {"modules": [{"alias": "ghost"}, {"alias": "present"}]},
         )
 
         try:
-            with patch.object(comms_mod, "_comm", mock_comm):
+            with (
+                patch.object(comms_mod, "_comm", mock_comm),
+                patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+                pytest.warns(UserWarning, match="no PDVModule"),
+            ):
                 handle_modules_setup(msg)
 
             assert expected_dir in sys.path
-            response = mock_comm._sent[0]
-            assert response["type"] == "pdv.modules.setup.response"
-            assert response["status"] == "ok"
         finally:
-            # Clean up sys.path
-            if expected_dir in sys.path:
+            while expected_dir in sys.path:
                 sys.path.remove(expected_dir)
 
-    def test_runs_entry_point(self):
+    def test_empty_module_is_noop_but_not_error(self, tree_with_comm):
+        """An empty PDVModule (create_empty just ran) triggers no sys.path edits and no warnings."""
+        from pdv_kernel.tree import PDVModule, PDVTree
+
+        module = PDVModule(module_id="fresh", name="fresh", version="0.1.0")
+        for child in ("scripts", "lib", "plots"):
+            dict.__setitem__(module, child, PDVTree())
+        dict.__setitem__(tree_with_comm, "fresh", module)
+
+        mock_comm = _make_mock_comm()
+        msg = _make_msg("pdv.modules.setup", {"modules": [{"alias": "fresh"}]})
+
+        sys_path_before = list(sys.path)
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_modules_setup(msg)
+        # No new entries added for an empty module.
+        assert sys.path == sys_path_before
+        assert mock_comm._sent[-1]["type"] == "pdv.modules.setup.response"
+
+    def test_runs_entry_point(self, tree_with_comm, tmp_path):
         """pdv.modules.setup should import the entry_point module."""
+        self._install_module_with_libs(
+            tree_with_comm, tmp_path, "ep_mod", []
+        )
+
         mock_comm = _make_mock_comm()
         msg = _make_msg(
             "pdv.modules.setup",
             {
                 "modules": [
                     {
-                        "lib_paths": ["/tmp/fake/my_module.py"],
+                        "alias": "ep_mod",
                         "entry_point": "pdv_kernel_test_fake_entry",
                     }
                 ]
@@ -95,11 +222,85 @@ class TestHandleModulesSetup:
         mock_module = MagicMock()
         with (
             patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
             patch("importlib.import_module", return_value=mock_module) as mock_import,
         ):
             handle_modules_setup(msg)
 
         mock_import.assert_called_once_with("pdv_kernel_test_fake_entry")
+
+    def test_create_empty_then_register_lib_allows_sibling_import(
+        self, tree_with_comm, tmp_path
+    ):
+        """End-to-end kernel-side audit repro.
+
+        Create an empty module, register a PDVLib with real on-disk contents,
+        register a sibling PDVScript, run setup, and assert the script can
+        import from the sibling lib.
+        """
+        from pdv_kernel.tree import PDVLib, PDVModule, PDVScript, PDVTree
+
+        alias = "ddho"
+        scripts_dir = tmp_path / "tree" / alias / "scripts"
+        lib_dir = tmp_path / "tree" / alias / "lib"
+        scripts_dir.mkdir(parents=True)
+        lib_dir.mkdir(parents=True)
+
+        lib_file = lib_dir / "ddho_lib.py"
+        lib_file.write_text("K = 1.25\n")
+        script_file = scripts_dir / "run_ddho.py"
+        script_file.write_text(
+            "from ddho_lib import K\n"
+            "def run(pdv_tree):\n"
+            "    return {'k': K}\n"
+        )
+
+        tree_with_comm._set_working_dir(str(tmp_path))
+        module = PDVModule(module_id=alias, name=alias, version="0.1.0")
+        module._working_dir = str(tmp_path)
+        scripts_container = PDVTree()
+        scripts_container._working_dir = str(tmp_path)
+        libs_container = PDVTree()
+        libs_container._working_dir = str(tmp_path)
+        dict.__setitem__(
+            libs_container,
+            "ddho_lib",
+            PDVLib(
+                relative_path=f"tree/{alias}/lib/ddho_lib.py",
+                module_id=alias,
+            ),
+        )
+        dict.__setitem__(
+            scripts_container,
+            "run_ddho",
+            PDVScript(
+                relative_path=f"tree/{alias}/scripts/run_ddho.py",
+                language="python",
+                module_id=alias,
+            ),
+        )
+        dict.__setitem__(module, "lib", libs_container)
+        dict.__setitem__(module, "scripts", scripts_container)
+        dict.__setitem__(tree_with_comm, alias, module)
+
+        mock_comm = _make_mock_comm()
+        msg = _make_msg("pdv.modules.setup", {"modules": [{"alias": alias}]})
+
+        try:
+            with (
+                patch.object(comms_mod, "_comm", mock_comm),
+                patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+            ):
+                handle_modules_setup(msg)
+
+            script_node = tree_with_comm[f"{alias}.scripts.run_ddho"]
+            result = script_node.run(tree_with_comm)
+            assert result == {"k": 1.25}
+        finally:
+            lib_parent = str(lib_dir)
+            while lib_parent in sys.path:
+                sys.path.remove(lib_parent)
+            sys.modules.pop("ddho_lib", None)
 
 
 class TestHandleHandlerInvoke:

--- a/pdv-python/tests/test_handlers_project.py
+++ b/pdv-python/tests/test_handlers_project.py
@@ -676,3 +676,190 @@ class TestTwoPassLoading:
         mod = tree_with_comm["mymod"]
         assert isinstance(mod, PDVModule)
         assert mod._working_dir == tree_with_comm._working_dir
+
+
+class TestCompositeMapping:
+    """Save/load round-trips for dicts containing non-JSON-native leaves.
+
+    Reference: plan at /Users/pharr/.claude/plans/replicated-stirring-newt.md
+    """
+
+    def test_dict_of_ndarrays_save_load_roundtrip(
+        self, tree_with_comm, tmp_save_dir
+    ):
+        """The exact audit repro: dict with ndarray values must save and load."""
+        numpy = pytest.importorskip("numpy")
+        arr_t = numpy.linspace(0, 1, 10)
+        arr_x = numpy.sin(arr_t)
+        arr_v = numpy.cos(arr_t)
+        tree_with_comm["runs"] = PDVTree()
+        tree_with_comm["runs.last"] = {
+            "t": arr_t,
+            "x": arr_x,
+            "v": arr_v,
+            "amplitude": 3.0,
+        }
+
+        mock_comm = _make_mock_comm()
+        msg_save = _make_msg("pdv.project.save", {"save_dir": tmp_save_dir})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_project_save(msg_save)
+        response = mock_comm._sent[-1]
+        assert response["status"] == "ok", (
+            f"save failed: {response.get('payload')}"
+        )
+
+        fresh_tree = PDVTree()
+        mock_comm2 = _make_mock_comm()
+        msg_load = _make_msg("pdv.project.load", {"save_dir": tmp_save_dir})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm2),
+            patch.object(comms_mod, "_pdv_tree", fresh_tree),
+        ):
+            handle_project_load(msg_load)
+
+        loaded = fresh_tree["runs.last"]
+        assert type(loaded) is dict, (
+            f"expected plain dict, got {type(loaded).__name__}"
+        )
+        assert set(loaded.keys()) == {"t", "x", "v", "amplitude"}
+        assert numpy.array_equal(loaded["t"], arr_t)
+        assert numpy.array_equal(loaded["x"], arr_x)
+        assert numpy.array_equal(loaded["v"], arr_v)
+        assert loaded["amplitude"] == 3.0
+
+    def test_composite_dict_with_raising_leaf_falls_back_per_leaf(
+        self, tree_with_comm, tmp_save_dir
+    ):
+        """Per-leaf pickle fallback inside a composite dict: if one child makes
+        serialize_node raise, only that child gets pickled. Siblings keep their
+        fast paths. Uses a nested list-of-ndarrays (which raises by design) as
+        the raising leaf."""
+        numpy = pytest.importorskip("numpy")
+        arr = numpy.array([1.0, 2.0, 3.0])
+        raising_leaf = [numpy.array([1, 2]), numpy.array([3, 4])]
+        tree_with_comm["data"] = {
+            "arr": arr,
+            "raising": raising_leaf,
+            "scalar": 7,
+        }
+
+        mock_comm = _make_mock_comm()
+        msg_save = _make_msg("pdv.project.save", {"save_dir": tmp_save_dir})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_project_save(msg_save)
+        response = mock_comm._sent[-1]
+        assert response["status"] == "ok"
+
+        with open(os.path.join(tmp_save_dir, "tree-index.json")) as f:
+            nodes = json.load(f)
+        by_path = {n["path"]: n for n in nodes}
+        # Siblings take their native fast paths.
+        assert by_path["data.arr"]["storage"]["format"] == "npy"
+        assert by_path["data.scalar"]["storage"]["backend"] == "inline"
+        # The raising leaf falls back to pickle via the walker.
+        assert by_path["data.raising"]["storage"]["format"] == "pickle"
+        assert by_path["data.raising"]["metadata"]["fallback"] == "pickle"
+
+        fresh_tree = PDVTree()
+        mock_comm2 = _make_mock_comm()
+        msg_load = _make_msg("pdv.project.load", {"save_dir": tmp_save_dir})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm2),
+            patch.object(comms_mod, "_pdv_tree", fresh_tree),
+        ):
+            handle_project_load(msg_load)
+        loaded = fresh_tree["data"]
+        assert type(loaded) is dict
+        assert numpy.array_equal(loaded["arr"], arr)
+        assert loaded["scalar"] == 7
+        assert len(loaded["raising"]) == 2
+        assert numpy.array_equal(loaded["raising"][0], numpy.array([1, 2]))
+
+    def test_nested_composite_mapping_roundtrip(
+        self, tree_with_comm, tmp_save_dir
+    ):
+        """A dict-in-dict with ndarray at the innermost level round-trips."""
+        numpy = pytest.importorskip("numpy")
+        arr = numpy.arange(5)
+        tree_with_comm["outer"] = {"inner": {"arr": arr, "tag": "hello"}}
+
+        mock_comm = _make_mock_comm()
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_project_save(
+                _make_msg("pdv.project.save", {"save_dir": tmp_save_dir})
+            )
+
+        fresh_tree = PDVTree()
+        mock_comm2 = _make_mock_comm()
+        with (
+            patch.object(comms_mod, "_comm", mock_comm2),
+            patch.object(comms_mod, "_pdv_tree", fresh_tree),
+        ):
+            handle_project_load(
+                _make_msg("pdv.project.load", {"save_dir": tmp_save_dir})
+            )
+        loaded = fresh_tree["outer"]
+        assert type(loaded) is dict
+        assert type(loaded["inner"]) is dict
+        assert numpy.array_equal(loaded["inner"]["arr"], arr)
+        assert loaded["inner"]["tag"] == "hello"
+
+    def test_json_native_mapping_still_inline(
+        self, tree_with_comm, tmp_save_dir
+    ):
+        """Regression: a pure JSON dict stays on the fast inline path."""
+        tree_with_comm["meta"] = {"author": "Matt", "count": 3, "ok": True}
+        mock_comm = _make_mock_comm()
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_project_save(
+                _make_msg("pdv.project.save", {"save_dir": tmp_save_dir})
+            )
+        with open(os.path.join(tmp_save_dir, "tree-index.json")) as f:
+            nodes = json.load(f)
+        meta_node = next(n for n in nodes if n["path"] == "meta")
+        assert meta_node["storage"]["backend"] == "inline"
+        assert meta_node["storage"]["value"] == {
+            "author": "Matt",
+            "count": 3,
+            "ok": True,
+        }
+        assert not meta_node["metadata"].get("composite")
+        # No child descriptors emitted for a JSON-native dict.
+        child_paths = [n["path"] for n in nodes if n["path"].startswith("meta.")]
+        assert child_paths == []
+
+    def test_sequence_with_ndarray_falls_back_to_pickle_via_walker(
+        self, tree_with_comm, tmp_save_dir
+    ):
+        """serialize_node raises a helpful error for list-of-ndarrays, but the
+        walker's pickle fallback catches it so project.save still succeeds."""
+        numpy = pytest.importorskip("numpy")
+        tree_with_comm["seq"] = [numpy.array([1, 2]), numpy.array([3, 4])]
+        mock_comm = _make_mock_comm()
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_project_save(
+                _make_msg("pdv.project.save", {"save_dir": tmp_save_dir})
+            )
+        response = mock_comm._sent[-1]
+        assert response["status"] == "ok"
+        with open(os.path.join(tmp_save_dir, "tree-index.json")) as f:
+            nodes = json.load(f)
+        seq_node = next(n for n in nodes if n["path"] == "seq")
+        assert seq_node["storage"]["format"] == "pickle"
+        assert seq_node["metadata"]["fallback"] == "pickle"

--- a/pdv-python/tests/test_namespace.py
+++ b/pdv-python/tests/test_namespace.py
@@ -10,10 +10,13 @@ Reference: ARCHITECTURE.md §5.4, §5.5
 """
 
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
-from pdv_kernel.namespace import PDVNamespace, pdv_namespace
-from pdv_kernel.errors import PDVProtectedNameError
+from pdv_kernel import comms
+from pdv_kernel.namespace import PDVApp, PDVNamespace, pdv_namespace
+from pdv_kernel.errors import PDVError, PDVProtectedNameError
+from pdv_kernel.tree import PDVTree
 
 
 class TestPDVNamespace:
@@ -55,6 +58,25 @@ class TestPDVNamespace:
         # Bootstrap uses dict.__setitem__ to bypass the guard
         dict.__setitem__(ns, "pdv_tree", object())
         assert "pdv_tree" in ns
+
+
+class TestPDVAppWorkingDir:
+    def test_working_dir_returns_tree_working_dir(self, tmp_path, monkeypatch):
+        tree = PDVTree()
+        tree._set_working_dir(str(tmp_path))
+        monkeypatch.setattr(comms, "_pdv_tree", tree)
+        assert PDVApp().working_dir == Path(str(tmp_path))
+
+    def test_working_dir_raises_before_init(self, monkeypatch):
+        monkeypatch.setattr(comms, "_pdv_tree", None)
+        with pytest.raises(PDVError):
+            _ = PDVApp().working_dir
+
+    def test_working_dir_raises_when_unset(self, monkeypatch):
+        tree = PDVTree()
+        monkeypatch.setattr(comms, "_pdv_tree", tree)
+        with pytest.raises(PDVError):
+            _ = PDVApp().working_dir
 
 
 class TestPDVNamespaceSnapshot:

--- a/pdv-python/tests/test_serialization.py
+++ b/pdv-python/tests/test_serialization.py
@@ -413,3 +413,47 @@ class TestMetadataSubDict:
         meta = desc["metadata"]
         assert meta["shape"] == [2, 2]
         assert "preview" in meta
+
+
+class TestCompositeMappingSerialize:
+    """Unit tests for the composite-mapping branch of serialize_node."""
+
+    def test_dict_with_ndarray_emits_composite_descriptor(
+        self, tmp_working_dir
+    ):
+        numpy = pytest.importorskip("numpy")
+        data = {"arr": numpy.array([1, 2]), "label": "x"}
+        desc = serialize_node("m", data, tmp_working_dir)
+        assert desc["type"] == KIND_MAPPING
+        assert desc["has_children"] is True
+        assert desc["storage"] == {"backend": "none", "format": "none"}
+        assert desc["metadata"]["composite"] is True
+
+    def test_json_native_dict_stays_inline(self, tmp_working_dir):
+        desc = serialize_node("m", {"a": 1, "b": [1, 2]}, tmp_working_dir)
+        assert desc["storage"]["backend"] == "inline"
+        assert not desc["metadata"].get("composite")
+
+    def test_sequence_with_ndarray_raises_helpful_error(self, tmp_working_dir):
+        numpy = pytest.importorskip("numpy")
+        with pytest.raises(PDVSerializationError, match="wrap"):
+            serialize_node(
+                "s", [numpy.array([1, 2]), numpy.array([3, 4])], tmp_working_dir
+            )
+
+    def test_pickle_fallback_node_writes_file(self, tmp_working_dir):
+        from pdv_kernel.serialization import pickle_fallback_node
+
+        obj = WeirdPicklable()
+        desc = pickle_fallback_node("u", obj, tmp_working_dir)
+        assert desc["storage"]["backend"] == "local_file"
+        assert desc["storage"]["format"] == "pickle"
+        assert desc["metadata"]["fallback"] == "pickle"
+        assert "python_type" in desc["metadata"]
+        rel = desc["storage"]["relative_path"]
+        assert os.path.exists(os.path.join(tmp_working_dir, rel))
+        # Round-trips via deserialize_node with trusted=True.
+        restored = deserialize_node(
+            desc["storage"], tmp_working_dir, trusted=True
+        )
+        assert isinstance(restored, WeirdPicklable)


### PR DESCRIPTION
## Summary

Pre-beta bug fixes across serialization, module loading, namespace, and code-cell persistence.

- **fix(serialization):** Dictionaries containing special data types (dict/list/tuple/set with embedded arrays, etc.) now serialize and round-trip correctly. Regression tests added in `test_serialization.py`.
- **fix(modules):** Module library `sys.path` derivation is now kernel-owned rather than computed in the main process, so module imports resolve against the kernel's actual working directory. Expanded coverage in `test_handlers_modules.py` and `module-runtime.test.ts`.
- **feat(namespace):** Exposes `pdv.working_dir` in the protected namespace so user scripts can resolve data file paths relative to the project without hardcoding.
- **fix(code-cells):** Code cell persistence is now scoped to the kernel working directory, preventing cells from one project leaking into another when switching projects.

## Test plan

- [x] `cd pdv-python && pytest tests/ -v`
- [x] `cd electron && npm test`
- [x] Manual: open two projects in sequence, confirm code cells don't bleed across
- [x] Manual: run a script that imports from a module library in a non-default working dir
- [x] Manual: serialize/load a tree containing a dict of mixed special types
- [x] Manual: reference `pdv.working_dir` from a user script

🤖 Generated with [Claude Code](https://claude.com/claude-code)