### PR TITLE
Ping kernel on system wake and refresh renderer state

### DIFF
--- a/electron/main/bootstrap.ts
+++ b/electron/main/bootstrap.ts
@@ -27,7 +27,7 @@
  * index.ts — IPC handler registration (called from {@link createWindow})
  */
 
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, powerMonitor } from "electron";
 import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
@@ -38,6 +38,7 @@ import { QueryRouter } from "./query-router";
 import { ConfigStore } from "./config";
 import { KernelManager } from "./kernel-manager";
 import { ProjectManager } from "./project-manager";
+import { handleSystemResume } from "./wake-handler";
 
 let kernelManager: KernelManager | null = null;
 let mainWindow: BrowserWindow | null = null;
@@ -114,6 +115,15 @@ if (!hasSingleInstanceLock) {
     if (process.env.NODE_ENV === "development" && !process.env.VITE_DEV_SERVER_URL) {
       process.env.VITE_DEV_SERVER_URL = "http://localhost:5173";
     }
+
+    powerMonitor.on("resume", () => {
+      void handleSystemResume(kernelManager, () => mainWindow).catch(
+        (err) => {
+          console.error("[PDV] Wake handler error:", err);
+        }
+      );
+    });
+
     void openMainWindow().catch((error) => {
       console.error("[PDV] Failed to open main window:", error);
     });

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -189,6 +189,7 @@ export const IPC = {
      * unrecoverable session loss.
      */
     kernelCrashed: "pdv.kernel.crashed",
+    kernelReconnected: "pdv.kernel.reconnected",
     menuAction: "menu:action",
     chromeStateChanged: "chrome:stateChanged",
     executeOutput: "pdv.execute.output",
@@ -1384,6 +1385,14 @@ export interface PDVApi {
      * @returns Unsubscribe function.
      */
     onKernelCrashed(callback: (payload: { kernelId: string }) => void): () => void;
+    /**
+     * Subscribe to kernel reconnection push notifications. Fires after a
+     * system sleep/wake cycle when the kernel is confirmed still alive.
+     *
+     * @param callback - Invoked with the reconnected kernel ID.
+     * @returns Unsubscribe function.
+     */
+    onReconnected(callback: (payload: { kernelId: string }) => void): () => void;
   };
 
   /** Tree browsing and updates. */

--- a/electron/main/wake-handler.ts
+++ b/electron/main/wake-handler.ts
@@ -1,0 +1,58 @@
+/**
+ * wake-handler.ts — System sleep/wake recovery for the kernel connection.
+ *
+ * On macOS (and other platforms), system sleep suspends all processes.
+ * When the machine wakes, ZeroMQ sockets on loopback normally survive
+ * because both endpoints were frozen simultaneously. However the kernel
+ * process may have been killed by the OS during sleep (memory pressure /
+ * jetsam), or a long hibernation may leave sockets in a bad state.
+ *
+ * This module pings the active kernel after wake and notifies the renderer
+ * so it can refresh its cached tree/namespace state.
+ *
+ * See Also
+ * --------
+ * bootstrap.ts — registers the powerMonitor listener
+ * kernel-manager.ts — owns the ping() method
+ */
+
+import type { BrowserWindow } from "electron";
+import type { KernelManager } from "./kernel-manager";
+import { IPC } from "./ipc";
+
+/**
+ * Check the active kernel after a system resume event.
+ *
+ * PDV runs a single kernel at a time. If the kernel responds to a
+ * shell-channel ping, a `kernelReconnected` push is sent to the renderer
+ * so it can refresh stale UI state. If the ping fails, the kernel's
+ * existing process-exit crash handler will fire independently — no extra
+ * action is needed here.
+ *
+ * @param kernelManager - Active kernel manager (may be null before first use).
+ * @param getMainWindow - Returns the main BrowserWindow, or null.
+ */
+export async function handleSystemResume(
+  kernelManager: KernelManager | null,
+  getMainWindow: () => BrowserWindow | null
+): Promise<void> {
+  if (!kernelManager) return;
+
+  const kernels = kernelManager.list();
+  const kernel = kernels.find((k) => k.status !== "dead");
+  if (!kernel) return;
+
+  const win = getMainWindow();
+  if (!win || win.isDestroyed()) return;
+
+  try {
+    await kernelManager.ping(kernel.id, 10_000);
+    win.webContents.send(IPC.push.kernelReconnected, {
+      kernelId: kernel.id,
+    });
+  } catch {
+    console.warn(
+      `[PDV] Kernel ${kernel.id.slice(0, 8)} unresponsive after wake`
+    );
+  }
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -54,6 +54,7 @@ const api: PDVApi = {
       ipcRenderer.invoke(IPC.kernels.validate, executablePath, language),
     onOutput: (callback) => onPush(IPC.push.executeOutput, callback),
     onKernelCrashed: (callback) => onPush(IPC.push.kernelCrashed, callback),
+    onReconnected: (callback) => onPush(IPC.push.kernelReconnected, callback),
   },
   tree: {
     list: (kernelId, nodePath = "") =>

--- a/electron/renderer/src/app/useKernelSubscriptions.ts
+++ b/electron/renderer/src/app/useKernelSubscriptions.ts
@@ -113,12 +113,18 @@ export function useKernelSubscriptions({
       }
     });
 
+    const unsubscribeReconnected = window.pdv.kernels.onReconnected(() => {
+      setTreeRefreshToken((prev) => prev + 1);
+      setModulesRefreshToken((prev) => prev + 1);
+    });
+
     return () => {
       unsubscribeTree();
       unsubscribeProject();
       unsubscribeKernelCrashed();
       unsubscribeProgress();
       unsubscribeReloading();
+      unsubscribeReconnected();
     };
   }, [
     currentKernelId,

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -685,6 +685,7 @@ export interface PDVApi {
     ): Promise<{ valid: boolean; error?: string }>;
     onOutput(callback: (chunk: ExecuteOutputChunk) => void): () => void;
     onKernelCrashed(callback: (payload: { kernelId: string }) => void): () => void;
+    onReconnected(callback: (payload: { kernelId: string }) => void): () => void;
   };
   tree: {
     list(kernelId: string, path?: string): Promise<NodeDescriptor[]>;


### PR DESCRIPTION
After macOS sleep/wake, the kernel process usually survives but the renderer's cached tree and namespace state may be stale. Register a powerMonitor 'resume' handler that pings the active kernel and, if alive, sends a kernelReconnected push so the renderer re-fetches. Addresses #201 maybe?