### PR TITLE
Context menu refresh

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -860,7 +860,7 @@ Both `themes/` and `state/` directories are created by the main process on start
 
 Rules:
 - `preferences.json` is authoritative for user configuration (`pythonPath`,
-  settings, shortcut overrides, appearance choices, etc.). Migrated automatically from legacy `config.json` if present.
+  settings, shortcut overrides, appearance choices, etc.).
 - Theme files are loaded from `~/.PDV/themes/*.json`; malformed files are
   ignored (non-fatal).
 - Code-cell persistence in `~/.PDV/state/code-cells.json` is separate from

--- a/electron/main/config.test.ts
+++ b/electron/main/config.test.ts
@@ -156,17 +156,4 @@ describe("ConfigStore", () => {
     expect(config.showCallableVariables).toBe(true);
   });
 
-  it("migrates a legacy config.json to preferences.json on first boot", () => {
-    const appDataDir = makeTempDir();
-    fs.writeFileSync(
-      path.join(appDataDir, "config.json"),
-      JSON.stringify({ theme: "dark", showPrivateVariables: true }, null, 2),
-      "utf8"
-    );
-
-    const store = new ConfigStore(appDataDir);
-    expect(store.getAll()).toMatchObject({ theme: "dark", showPrivateVariables: true });
-    expect(fs.existsSync(path.join(appDataDir, "preferences.json"))).toBe(true);
-    expect(fs.existsSync(path.join(appDataDir, "config.json"))).toBe(false);
-  });
 });

--- a/electron/main/config.ts
+++ b/electron/main/config.ts
@@ -265,14 +265,6 @@ export class ConfigStore {
   constructor(private readonly appDataDir: string) {
     fs.mkdirSync(this.appDataDir, { recursive: true });
     this.configPath = path.join(this.appDataDir, "preferences.json");
-    const legacyPath = path.join(this.appDataDir, "config.json");
-    if (!fs.existsSync(this.configPath) && fs.existsSync(legacyPath)) {
-      try {
-        fs.renameSync(legacyPath, this.configPath);
-      } catch {
-        // Migration is best-effort; if it fails we simply start fresh.
-      }
-    }
     this.state = this.loadState();
   }
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -84,6 +84,7 @@ const REGISTERED_CHANNELS: readonly string[] = [
   IPC.tree.addFile,
   IPC.tree.createNode,
   IPC.tree.rename,
+  IPC.tree.move,
   IPC.tree.invokeHandler,
   IPC.tree.delete,
   IPC.namespace.query,

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -85,6 +85,7 @@ const REGISTERED_CHANNELS: readonly string[] = [
   IPC.tree.createNode,
   IPC.tree.rename,
   IPC.tree.move,
+  IPC.tree.duplicate,
   IPC.tree.invokeHandler,
   IPC.tree.delete,
   IPC.namespace.query,

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -82,6 +82,7 @@ const REGISTERED_CHANNELS: readonly string[] = [
   IPC.tree.createScript,
   IPC.tree.createNote,
   IPC.tree.addFile,
+  IPC.tree.createNode,
   IPC.tree.invokeHandler,
   IPC.tree.delete,
   IPC.namespace.query,

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -83,6 +83,7 @@ const REGISTERED_CHANNELS: readonly string[] = [
   IPC.tree.createNote,
   IPC.tree.addFile,
   IPC.tree.createNode,
+  IPC.tree.rename,
   IPC.tree.invokeHandler,
   IPC.tree.delete,
   IPC.namespace.query,

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -19,7 +19,7 @@ import * as path from "path";
 import type { CommRouter } from "./comm-router";
 import type { QueryRouter } from "./query-router";
 import type { ConfigStore, PDVConfig } from "./config";
-import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNodeResult, type TreeCreateNoteResult, type TreeCreateScriptResult } from "./ipc";
+import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNodeResult, type TreeCreateNoteResult, type TreeCreateScriptResult, type TreeRenameResult } from "./ipc";
 import type { KernelManager } from "./kernel-manager";
 import { PDVMessageType, type PDVFileRegisterPayload } from "./pdv-protocol";
 import type { ProjectManager } from "./project-manager";
@@ -824,6 +824,39 @@ export function registerTreeNamespaceScriptIpcHandlers(
           created?: boolean;
         };
         return { success: true, treePath: payload.path };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: message };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    IPC.tree.rename,
+    async (
+      _event,
+      kernelId: string,
+      treePath: string,
+      newName: string
+    ): Promise<TreeRenameResult> => {
+      if (!kernelManager.getKernel(kernelId)) {
+        return { success: false, error: `Kernel not found: ${kernelId}` };
+      }
+      try {
+        const response = await commRouter.request(
+          PDVMessageType.TREE_RENAME,
+          { path: treePath, new_name: newName }
+        );
+        const payload = response.payload as {
+          old_path?: string;
+          new_path?: string;
+          renamed?: boolean;
+        };
+        return {
+          success: true,
+          oldPath: payload.old_path,
+          newPath: payload.new_path,
+        };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return { success: false, error: message };

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -806,128 +806,58 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  /**
+   * Register a tree IPC handler that delegates to commRouter.request.
+   *
+   * Handles kernel-not-found checks, error wrapping, and payload extraction
+   * via a caller-supplied transform.
+   */
+  function treeCommHandler<T extends { success: boolean; error?: string }>(
+    channel: string,
+    msgType: string,
+    buildPayload: (...args: string[]) => Record<string, unknown>,
+    mapResult: (payload: Record<string, unknown>) => T,
+  ): void {
+    ipcMain.handle(channel, async (_event, kernelId: string, ...rest: string[]): Promise<T> => {
+      if (!kernelManager.getKernel(kernelId)) {
+        return { success: false, error: `Kernel not found: ${kernelId}` } as T;
+      }
+      try {
+        const response = await commRouter.request(msgType, buildPayload(...rest));
+        return mapResult(response.payload as Record<string, unknown>);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: message } as T;
+      }
+    });
+  }
+
+  treeCommHandler<TreeCreateNodeResult>(
     IPC.tree.createNode,
-    async (
-      _event,
-      kernelId: string,
-      targetPath: string,
-      nodeName: string
-    ): Promise<TreeCreateNodeResult> => {
-      if (!kernelManager.getKernel(kernelId)) {
-        return { success: false, error: `Kernel not found: ${kernelId}` };
-      }
-      try {
-        const response = await commRouter.request(
-          PDVMessageType.TREE_CREATE_NODE,
-          { parent_path: targetPath, name: nodeName }
-        );
-        const payload = response.payload as {
-          path?: string;
-          created?: boolean;
-        };
-        return { success: true, treePath: payload.path };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { success: false, error: message };
-      }
-    }
+    PDVMessageType.TREE_CREATE_NODE,
+    (targetPath, nodeName) => ({ parent_path: targetPath, name: nodeName }),
+    (p) => ({ success: true, treePath: p.path as string | undefined }),
   );
 
-  ipcMain.handle(
+  treeCommHandler<TreeRenameResult>(
     IPC.tree.rename,
-    async (
-      _event,
-      kernelId: string,
-      treePath: string,
-      newName: string
-    ): Promise<TreeRenameResult> => {
-      if (!kernelManager.getKernel(kernelId)) {
-        return { success: false, error: `Kernel not found: ${kernelId}` };
-      }
-      try {
-        const response = await commRouter.request(
-          PDVMessageType.TREE_RENAME,
-          { path: treePath, new_name: newName }
-        );
-        const payload = response.payload as {
-          old_path?: string;
-          new_path?: string;
-          renamed?: boolean;
-        };
-        return {
-          success: true,
-          oldPath: payload.old_path,
-          newPath: payload.new_path,
-        };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { success: false, error: message };
-      }
-    }
+    PDVMessageType.TREE_RENAME,
+    (treePath, newName) => ({ path: treePath, new_name: newName }),
+    (p) => ({ success: true, oldPath: p.old_path as string | undefined, newPath: p.new_path as string | undefined }),
   );
 
-  ipcMain.handle(
+  treeCommHandler<TreeMoveResult>(
     IPC.tree.move,
-    async (
-      _event,
-      kernelId: string,
-      treePath: string,
-      newPath: string,
-      filename?: string
-    ): Promise<TreeMoveResult> => {
-      if (!kernelManager.getKernel(kernelId)) {
-        return { success: false, error: `Kernel not found: ${kernelId}` };
-      }
-      try {
-        const response = await commRouter.request(
-          PDVMessageType.TREE_MOVE,
-          { path: treePath, new_path: newPath, ...(filename ? { filename } : {}) }
-        );
-        const payload = response.payload as {
-          old_path?: string;
-          new_path?: string;
-          moved?: boolean;
-        };
-        return {
-          success: true,
-          oldPath: payload.old_path,
-          newPath: payload.new_path,
-        };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { success: false, error: message };
-      }
-    }
+    PDVMessageType.TREE_MOVE,
+    (treePath, newPath, filename) => ({ path: treePath, new_path: newPath, ...(filename ? { filename } : {}) }),
+    (p) => ({ success: true, oldPath: p.old_path as string | undefined, newPath: p.new_path as string | undefined }),
   );
 
-  ipcMain.handle(
+  treeCommHandler<TreeDuplicateResult>(
     IPC.tree.duplicate,
-    async (
-      _event,
-      kernelId: string,
-      treePath: string,
-      newPath: string,
-      filename?: string
-    ): Promise<TreeDuplicateResult> => {
-      if (!kernelManager.getKernel(kernelId)) {
-        return { success: false, error: `Kernel not found: ${kernelId}` };
-      }
-      try {
-        const response = await commRouter.request(
-          PDVMessageType.TREE_DUPLICATE,
-          { path: treePath, new_path: newPath, ...(filename ? { filename } : {}) }
-        );
-        const payload = response.payload as {
-          new_path?: string;
-          duplicated?: boolean;
-        };
-        return { success: true, newPath: payload.new_path };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { success: false, error: message };
-      }
-    }
+    PDVMessageType.TREE_DUPLICATE,
+    (treePath, newPath, filename) => ({ path: treePath, new_path: newPath, ...(filename ? { filename } : {}) }),
+    (p) => ({ success: true, newPath: p.new_path as string | undefined }),
   );
 
   ipcMain.handle(

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -19,7 +19,7 @@ import * as path from "path";
 import type { CommRouter } from "./comm-router";
 import type { QueryRouter } from "./query-router";
 import type { ConfigStore, PDVConfig } from "./config";
-import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNodeResult, type TreeCreateNoteResult, type TreeCreateScriptResult, type TreeRenameResult } from "./ipc";
+import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNodeResult, type TreeCreateNoteResult, type TreeCreateScriptResult, type TreeMoveResult, type TreeRenameResult } from "./ipc";
 import type { KernelManager } from "./kernel-manager";
 import { PDVMessageType, type PDVFileRegisterPayload } from "./pdv-protocol";
 import type { ProjectManager } from "./project-manager";
@@ -851,6 +851,39 @@ export function registerTreeNamespaceScriptIpcHandlers(
           old_path?: string;
           new_path?: string;
           renamed?: boolean;
+        };
+        return {
+          success: true,
+          oldPath: payload.old_path,
+          newPath: payload.new_path,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: message };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    IPC.tree.move,
+    async (
+      _event,
+      kernelId: string,
+      treePath: string,
+      newPath: string
+    ): Promise<TreeMoveResult> => {
+      if (!kernelManager.getKernel(kernelId)) {
+        return { success: false, error: `Kernel not found: ${kernelId}` };
+      }
+      try {
+        const response = await commRouter.request(
+          PDVMessageType.TREE_MOVE,
+          { path: treePath, new_path: newPath }
+        );
+        const payload = response.payload as {
+          old_path?: string;
+          new_path?: string;
+          moved?: boolean;
         };
         return {
           success: true,

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -19,7 +19,7 @@ import * as path from "path";
 import type { CommRouter } from "./comm-router";
 import type { QueryRouter } from "./query-router";
 import type { ConfigStore, PDVConfig } from "./config";
-import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNoteResult, type TreeCreateScriptResult } from "./ipc";
+import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNodeResult, type TreeCreateNoteResult, type TreeCreateScriptResult } from "./ipc";
 import type { KernelManager } from "./kernel-manager";
 import { PDVMessageType, type PDVFileRegisterPayload } from "./pdv-protocol";
 import type { ProjectManager } from "./project-manager";
@@ -800,6 +800,34 @@ export function registerTreeNamespaceScriptIpcHandlers(
       });
       const payload = response.payload as { dispatched: boolean; error?: string };
       return { success: payload.dispatched, error: payload.error };
+    }
+  );
+
+  ipcMain.handle(
+    IPC.tree.createNode,
+    async (
+      _event,
+      kernelId: string,
+      targetPath: string,
+      nodeName: string
+    ): Promise<TreeCreateNodeResult> => {
+      if (!kernelManager.getKernel(kernelId)) {
+        return { success: false, error: `Kernel not found: ${kernelId}` };
+      }
+      try {
+        const response = await commRouter.request(
+          PDVMessageType.TREE_CREATE_NODE,
+          { parent_path: targetPath, name: nodeName }
+        );
+        const payload = response.payload as {
+          path?: string;
+          created?: boolean;
+        };
+        return { success: true, treePath: payload.path };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: message };
+      }
     }
   );
 

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -19,7 +19,7 @@ import * as path from "path";
 import type { CommRouter } from "./comm-router";
 import type { QueryRouter } from "./query-router";
 import type { ConfigStore, PDVConfig } from "./config";
-import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNodeResult, type TreeCreateNoteResult, type TreeCreateScriptResult, type TreeMoveResult, type TreeRenameResult } from "./ipc";
+import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNodeResult, type TreeCreateNoteResult, type TreeCreateScriptResult, type TreeDuplicateResult, type TreeMoveResult, type TreeRenameResult } from "./ipc";
 import type { KernelManager } from "./kernel-manager";
 import { PDVMessageType, type PDVFileRegisterPayload } from "./pdv-protocol";
 import type { ProjectManager } from "./project-manager";
@@ -692,6 +692,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     // Resolve the file path — try the kernel comm first (handles all
     // PDVFile types including lib/namelist), fall back to the legacy
     // tree-path-to-filesystem derivation for plain scripts.
+    // TODO: remove legacy for beta.
     let resolvedPath: string | undefined;
     try {
       const response = await queryRequest(
@@ -704,11 +705,13 @@ export function registerTreeNamespaceScriptIpcHandlers(
       }
     } catch {
       // Comm failed — fall through to legacy resolution
+      // TODO: remove this fallback, this silently ignores all errors.
     }
     if (!resolvedPath) {
       const kernel = kernelManager.getKernel(kernelId);
       const language = kernel?.language ?? "python";
       resolvedPath = resolveScriptPath(kernelId, scriptPath, kernelWorkingDirs, language);
+      console.warn(`[pdv] Falling back to legacy script path resolution for "${scriptPath}" → "${resolvedPath}"`);
     }
 
     const isJulia = resolvedPath.endsWith(".jl");
@@ -870,7 +873,8 @@ export function registerTreeNamespaceScriptIpcHandlers(
       _event,
       kernelId: string,
       treePath: string,
-      newPath: string
+      newPath: string,
+      filename?: string
     ): Promise<TreeMoveResult> => {
       if (!kernelManager.getKernel(kernelId)) {
         return { success: false, error: `Kernel not found: ${kernelId}` };
@@ -878,7 +882,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
       try {
         const response = await commRouter.request(
           PDVMessageType.TREE_MOVE,
-          { path: treePath, new_path: newPath }
+          { path: treePath, new_path: newPath, ...(filename ? { filename } : {}) }
         );
         const payload = response.payload as {
           old_path?: string;
@@ -890,6 +894,35 @@ export function registerTreeNamespaceScriptIpcHandlers(
           oldPath: payload.old_path,
           newPath: payload.new_path,
         };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: message };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    IPC.tree.duplicate,
+    async (
+      _event,
+      kernelId: string,
+      treePath: string,
+      newPath: string,
+      filename?: string
+    ): Promise<TreeDuplicateResult> => {
+      if (!kernelManager.getKernel(kernelId)) {
+        return { success: false, error: `Kernel not found: ${kernelId}` };
+      }
+      try {
+        const response = await commRouter.request(
+          PDVMessageType.TREE_DUPLICATE,
+          { path: treePath, new_path: newPath, ...(filename ? { filename } : {}) }
+        );
+        const payload = response.payload as {
+          new_path?: string;
+          duplicated?: boolean;
+        };
+        return { success: true, newPath: payload.new_path };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return { success: false, error: message };

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -86,6 +86,7 @@ export const IPC = {
      * path is under a known module alias.
      */
     createLib: "tree:createLib",
+    createNode: "tree:createNode",
     invokeHandler: "tree:invokeHandler",
     delete: "tree:delete",
   },
@@ -411,6 +412,18 @@ export interface TreeCreateNoteResult {
   error?: string;
   /** Absolute path to the created markdown file. */
   notePath?: string;
+  /** Dot-path of the created tree node. */
+  treePath?: string;
+}
+
+/**
+ * Result returned by `tree.createNode`.
+ */
+export interface TreeCreateNodeResult {
+  /** True when the empty node was created successfully. */
+  success: boolean;
+  /** Optional error message when `success` is false. */
+  error?: string;
   /** Dot-path of the created tree node. */
   treePath?: string;
 }
@@ -1489,6 +1502,19 @@ export interface PDVApi {
       nodeType: "namelist" | "lib" | "file",
       filename: string
     ): Promise<TreeAddFileResult>;
+    /**
+     * Create an empty container (dict) node in the tree.
+     *
+     * @param kernelId - Target kernel ID.
+     * @param targetPath - Dot-path of the parent container (empty string for root).
+     * @param nodeName - Key name for the new node.
+     * @returns Node creation result payload.
+     */
+    createNode(
+      kernelId: string,
+      targetPath: string,
+      nodeName: string
+    ): Promise<TreeCreateNodeResult>;
     /**
      * Invoke a registered custom handler for a tree node.
      *

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -89,6 +89,7 @@ export const IPC = {
     createNode: "tree:createNode",
     rename: "tree:rename",
     move: "tree:move",
+    duplicate: "tree:duplicate",
     invokeHandler: "tree:invokeHandler",
     delete: "tree:delete",
   },
@@ -455,6 +456,18 @@ export interface TreeMoveResult {
   /** Dot-path of the node before the move. */
   oldPath?: string;
   /** Dot-path of the node after the move. */
+  newPath?: string;
+}
+
+/**
+ * Result returned by `tree.duplicate`.
+ */
+export interface TreeDuplicateResult {
+  /** True when the deep copy succeeded. */
+  success: boolean;
+  /** Optional error message when `success` is false. */
+  error?: string;
+  /** Dot-path of the newly created copy. */
   newPath?: string;
 }
 
@@ -1569,8 +1582,24 @@ export interface PDVApi {
     move(
       kernelId: string,
       treePath: string,
-      newPath: string
+      newPath: string,
+      filename?: string
     ): Promise<TreeMoveResult>;
+    /**
+     * Deep-copy a tree node to a new path.
+     *
+     * @param kernelId - Target kernel ID.
+     * @param treePath - Dot-path of the node to copy.
+     * @param newPath - Full dot-path for the duplicate.
+     * @param filename - Optional override for the backing file name.
+     * @returns Duplicate result with the new path.
+     */
+    duplicate(
+      kernelId: string,
+      treePath: string,
+      newPath: string,
+      filename?: string
+    ): Promise<TreeDuplicateResult>;
     /**
      * Invoke a registered custom handler for a tree node.
      *

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -88,6 +88,7 @@ export const IPC = {
     createLib: "tree:createLib",
     createNode: "tree:createNode",
     rename: "tree:rename",
+    move: "tree:move",
     invokeHandler: "tree:invokeHandler",
     delete: "tree:delete",
   },
@@ -440,6 +441,20 @@ export interface TreeRenameResult {
   /** Dot-path of the node before rename. */
   oldPath?: string;
   /** Dot-path of the node after rename. */
+  newPath?: string;
+}
+
+/**
+ * Result returned by `tree.move`.
+ */
+export interface TreeMoveResult {
+  /** True when the node was moved successfully. */
+  success: boolean;
+  /** Optional error message when `success` is false. */
+  error?: string;
+  /** Dot-path of the node before the move. */
+  oldPath?: string;
+  /** Dot-path of the node after the move. */
   newPath?: string;
 }
 
@@ -1543,6 +1558,19 @@ export interface PDVApi {
       treePath: string,
       newName: string
     ): Promise<TreeRenameResult>;
+    /**
+     * Move a tree node to a new path.
+     *
+     * @param kernelId - Target kernel ID.
+     * @param treePath - Dot-path of the node to move.
+     * @param newPath - Full dot-path of the destination.
+     * @returns Move result with old and new paths.
+     */
+    move(
+      kernelId: string,
+      treePath: string,
+      newPath: string
+    ): Promise<TreeMoveResult>;
     /**
      * Invoke a registered custom handler for a tree node.
      *

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -87,6 +87,7 @@ export const IPC = {
      */
     createLib: "tree:createLib",
     createNode: "tree:createNode",
+    rename: "tree:rename",
     invokeHandler: "tree:invokeHandler",
     delete: "tree:delete",
   },
@@ -426,6 +427,20 @@ export interface TreeCreateNodeResult {
   error?: string;
   /** Dot-path of the created tree node. */
   treePath?: string;
+}
+
+/**
+ * Result returned by `tree.rename`.
+ */
+export interface TreeRenameResult {
+  /** True when the node was renamed successfully. */
+  success: boolean;
+  /** Optional error message when `success` is false. */
+  error?: string;
+  /** Dot-path of the node before rename. */
+  oldPath?: string;
+  /** Dot-path of the node after rename. */
+  newPath?: string;
 }
 
 /**
@@ -1515,6 +1530,19 @@ export interface PDVApi {
       targetPath: string,
       nodeName: string
     ): Promise<TreeCreateNodeResult>;
+    /**
+     * Rename a tree node (change its key under the same parent).
+     *
+     * @param kernelId - Target kernel ID.
+     * @param treePath - Dot-path of the node to rename.
+     * @param newName - New key name (single segment, no dots).
+     * @returns Rename result with old and new paths.
+     */
+    rename(
+      kernelId: string,
+      treePath: string,
+      newName: string
+    ): Promise<TreeRenameResult>;
     /**
      * Invoke a registered custom handler for a tree node.
      *

--- a/electron/main/module-runtime.ts
+++ b/electron/main/module-runtime.ts
@@ -264,10 +264,6 @@ export async function setupProjectModuleNamespaces(
  * paths, and sends a single MODULE_REGISTER message with the full remapped
  * module_index so the kernel can reconstruct the subtree in one pass.
  *
- * Non-v4 modules (no `module-index.json`) are rejected with a clear error.
- * The legacy (v1/v2/v3) per-node registration flow was removed as part of
- * the #140 module editing workflow — see the plan at
- * ~/.claude/plans/parsed-mapping-creek.md §1.
  *
  * @param commRouter - Comm router used for comm messages.
  * @param moduleManager - Module manager for manifest resolution.

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -114,6 +114,10 @@ export const PDVMessageType = {
   TREE_MOVE: "pdv.tree.move",
   /** Kernel → app. Confirms move; echoes old and new paths. */
   TREE_MOVE_RESPONSE: "pdv.tree.move.response",
+  /** App → kernel. Deep-copy a tree node to a new path. */
+  TREE_DUPLICATE: "pdv.tree.duplicate",
+  /** Kernel → app. Confirms duplication. */
+  TREE_DUPLICATE_RESPONSE: "pdv.tree.duplicate.response",
   /** App → kernel. Create an empty dict node at a given path. */
   TREE_CREATE_NODE: "pdv.tree.create_node",
   /** Kernel → app. Confirms node creation. */

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -106,6 +106,10 @@ export const PDVMessageType = {
   TREE_DELETE: "pdv.tree.delete",
   /** Kernel → app. Confirms node deletion. */
   TREE_DELETE_RESPONSE: "pdv.tree.delete.response",
+  /** App → kernel. Rename a tree node (change its key under the same parent). */
+  TREE_RENAME: "pdv.tree.rename",
+  /** Kernel → app. Confirms rename; echoes old and new paths. */
+  TREE_RENAME_RESPONSE: "pdv.tree.rename.response",
   /** App → kernel. Create an empty dict node at a given path. */
   TREE_CREATE_NODE: "pdv.tree.create_node",
   /** Kernel → app. Confirms node creation. */

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -110,6 +110,10 @@ export const PDVMessageType = {
   TREE_RENAME: "pdv.tree.rename",
   /** Kernel → app. Confirms rename; echoes old and new paths. */
   TREE_RENAME_RESPONSE: "pdv.tree.rename.response",
+  /** App → kernel. Move a tree node to a new path. */
+  TREE_MOVE: "pdv.tree.move",
+  /** Kernel → app. Confirms move; echoes old and new paths. */
+  TREE_MOVE_RESPONSE: "pdv.tree.move.response",
   /** App → kernel. Create an empty dict node at a given path. */
   TREE_CREATE_NODE: "pdv.tree.create_node",
   /** Kernel → app. Confirms node creation. */

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -106,6 +106,10 @@ export const PDVMessageType = {
   TREE_DELETE: "pdv.tree.delete",
   /** Kernel → app. Confirms node deletion. */
   TREE_DELETE_RESPONSE: "pdv.tree.delete.response",
+  /** App → kernel. Create an empty dict node at a given path. */
+  TREE_CREATE_NODE: "pdv.tree.create_node",
+  /** Kernel → app. Confirms node creation. */
+  TREE_CREATE_NODE_RESPONSE: "pdv.tree.create_node.response",
   /** Kernel → app (push). Tree structure changed. */
   TREE_CHANGED: "pdv.tree.changed",
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -71,6 +71,8 @@ const api: PDVApi = {
       ipcRenderer.invoke(IPC.tree.createLib, kernelId, targetPath, libName),
     createNode: (kernelId, targetPath, nodeName) =>
       ipcRenderer.invoke(IPC.tree.createNode, kernelId, targetPath, nodeName),
+    rename: (kernelId, treePath, newName) =>
+      ipcRenderer.invoke(IPC.tree.rename, kernelId, treePath, newName),
     addFile: (kernelId, sourcePath, targetTreePath, nodeType, filename) =>
       ipcRenderer.invoke(IPC.tree.addFile, kernelId, sourcePath, targetTreePath, nodeType, filename),
     invokeHandler: (kernelId, nodePath) =>

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -73,8 +73,10 @@ const api: PDVApi = {
       ipcRenderer.invoke(IPC.tree.createNode, kernelId, targetPath, nodeName),
     rename: (kernelId, treePath, newName) =>
       ipcRenderer.invoke(IPC.tree.rename, kernelId, treePath, newName),
-    move: (kernelId, treePath, newPath) =>
-      ipcRenderer.invoke(IPC.tree.move, kernelId, treePath, newPath),
+    move: (kernelId, treePath, newPath, filename) =>
+      ipcRenderer.invoke(IPC.tree.move, kernelId, treePath, newPath, filename),
+    duplicate: (kernelId, treePath, newPath, filename) =>
+      ipcRenderer.invoke(IPC.tree.duplicate, kernelId, treePath, newPath, filename),
     addFile: (kernelId, sourcePath, targetTreePath, nodeType, filename) =>
       ipcRenderer.invoke(IPC.tree.addFile, kernelId, sourcePath, targetTreePath, nodeType, filename),
     invokeHandler: (kernelId, nodePath) =>

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -69,6 +69,8 @@ const api: PDVApi = {
       ipcRenderer.invoke(IPC.tree.createGui, kernelId, targetPath, guiName),
     createLib: (kernelId, targetPath, libName) =>
       ipcRenderer.invoke(IPC.tree.createLib, kernelId, targetPath, libName),
+    createNode: (kernelId, targetPath, nodeName) =>
+      ipcRenderer.invoke(IPC.tree.createNode, kernelId, targetPath, nodeName),
     addFile: (kernelId, sourcePath, targetTreePath, nodeType, filename) =>
       ipcRenderer.invoke(IPC.tree.addFile, kernelId, sourcePath, targetTreePath, nodeType, filename),
     invokeHandler: (kernelId, nodePath) =>

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -73,6 +73,8 @@ const api: PDVApi = {
       ipcRenderer.invoke(IPC.tree.createNode, kernelId, targetPath, nodeName),
     rename: (kernelId, treePath, newName) =>
       ipcRenderer.invoke(IPC.tree.rename, kernelId, treePath, newName),
+    move: (kernelId, treePath, newPath) =>
+      ipcRenderer.invoke(IPC.tree.move, kernelId, treePath, newPath),
     addFile: (kernelId, sourcePath, targetTreePath, nodeType, filename) =>
       ipcRenderer.invoke(IPC.tree.addFile, kernelId, sourcePath, targetTreePath, nodeType, filename),
     invokeHandler: (kernelId, nodePath) =>

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -25,6 +25,7 @@ import { CreateLibDialog } from '../components/Tree/CreateLibDialog';
 import { CreateGuiDialog } from '../components/Tree/CreateGuiDialog';
 import { NewModuleDialog } from '../components/NewModuleDialog';
 import { ModuleMetadataDialog } from '../components/ModuleMetadataDialog';
+import { CreateNodeDialog } from '../components/Tree/CreateNodeDialog';
 import { CreateNoteDialog } from '../components/Tree/CreateNoteDialog';
 import { TitleBar } from '../components/TitleBar';
 import { WriteTab } from '../components/WriteTab';
@@ -135,6 +136,7 @@ const App: React.FC = () => {
   const [showWelcome, setShowWelcome] = useState(true);
   const [forceWelcome, setForceWelcome] = useState(false);
   const [scriptDialog, setScriptDialog] = useState<TreeNodeData | null>(null);
+  const [createNodeTarget, setCreateNodeTarget] = useState<string | null>(null);
   const [createScriptTarget, setCreateScriptTarget] = useState<string | null>(null);
   const [createNoteTarget, setCreateNoteTarget] = useState<string | null>(null);
   const [createGuiTarget, setCreateGuiTarget] = useState<string | null>(null);
@@ -491,6 +493,7 @@ const App: React.FC = () => {
       if (showSaveAsDialog) { setShowSaveAsDialog(false); return; }
       if (showImportModule) { setShowImportModule(false); return; }
       if (scriptDialog) { setScriptDialog(null); return; }
+      if (createNodeTarget) { setCreateNodeTarget(null); return; }
       if (createScriptTarget) { setCreateScriptTarget(null); return; }
       if (createNoteTarget) { setCreateNoteTarget(null); return; }
       if (createGuiTarget) { setCreateGuiTarget(null); return; }
@@ -618,7 +621,9 @@ const App: React.FC = () => {
       setCreateGuiTarget(node.path);
       return;
     }
-    if (action === 'create_script') {
+    if (action === 'create_node') {
+      setCreateNodeTarget(node.path);
+    } else if (action === 'create_script') {
       setCreateScriptTarget(node.path);
     } else if (action === 'create_lib') {
       setCreateLibTarget(node.path);
@@ -1221,6 +1226,27 @@ const App: React.FC = () => {
           kernelId={currentKernelId}
           onRun={handleScriptRun}
           onCancel={() => setScriptDialog(null)}
+        />
+      )}
+
+      {createNodeTarget !== null && currentKernelId && (
+        <CreateNodeDialog
+          parentPath={createNodeTarget}
+          onCancel={() => setCreateNodeTarget(null)}
+          onCreate={async (name) => {
+            try {
+              const result = await window.pdv.tree.createNode(currentKernelId, createNodeTarget, name);
+              if (!result.success) {
+                setLastError(result.error);
+              } else {
+                setTreeRefreshToken((t) => t + 1);
+              }
+            } catch (error) {
+              setLastError(error instanceof Error ? error.message : String(error));
+            } finally {
+              setCreateNodeTarget(null);
+            }
+          }}
         />
       )}
 

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -27,6 +27,7 @@ import { NewModuleDialog } from '../components/NewModuleDialog';
 import { ModuleMetadataDialog } from '../components/ModuleMetadataDialog';
 import { CreateNodeDialog } from '../components/Tree/CreateNodeDialog';
 import { CreateNoteDialog } from '../components/Tree/CreateNoteDialog';
+import { RenameDialog } from '../components/Tree/RenameDialog';
 import { TitleBar } from '../components/TitleBar';
 import { WriteTab } from '../components/WriteTab';
 import { SettingsDialog } from '../components/SettingsDialog';
@@ -136,6 +137,7 @@ const App: React.FC = () => {
   const [showWelcome, setShowWelcome] = useState(true);
   const [forceWelcome, setForceWelcome] = useState(false);
   const [scriptDialog, setScriptDialog] = useState<TreeNodeData | null>(null);
+  const [renameTarget, setRenameTarget] = useState<{ path: string; key: string } | null>(null);
   const [createNodeTarget, setCreateNodeTarget] = useState<string | null>(null);
   const [createScriptTarget, setCreateScriptTarget] = useState<string | null>(null);
   const [createNoteTarget, setCreateNoteTarget] = useState<string | null>(null);
@@ -493,6 +495,7 @@ const App: React.FC = () => {
       if (showSaveAsDialog) { setShowSaveAsDialog(false); return; }
       if (showImportModule) { setShowImportModule(false); return; }
       if (scriptDialog) { setScriptDialog(null); return; }
+      if (renameTarget) { setRenameTarget(null); return; }
       if (createNodeTarget) { setCreateNodeTarget(null); return; }
       if (createScriptTarget) { setCreateScriptTarget(null); return; }
       if (createNoteTarget) { setCreateNoteTarget(null); return; }
@@ -693,6 +696,10 @@ const App: React.FC = () => {
       const result = await window.pdv.tree.invokeHandler(currentKernelId, node.path);
       if (!result.success && result.error) {
         console.error('[App] Handler failed:', result.error);
+      }
+    } else if (action === 'rename') {
+      if (node.path) {
+        setRenameTarget({ path: node.path, key: node.key });
       }
     } else if (action === 'delete') {
       if (!currentKernelId || !node.path) return;
@@ -1226,6 +1233,28 @@ const App: React.FC = () => {
           kernelId={currentKernelId}
           onRun={handleScriptRun}
           onCancel={() => setScriptDialog(null)}
+        />
+      )}
+
+      {renameTarget !== null && currentKernelId && (
+        <RenameDialog
+          currentKey={renameTarget.key}
+          nodePath={renameTarget.path}
+          onCancel={() => setRenameTarget(null)}
+          onRename={async (newName) => {
+            try {
+              const result = await window.pdv.tree.rename(currentKernelId, renameTarget.path, newName);
+              if (!result.success) {
+                setLastError(result.error);
+              } else {
+                setTreeRefreshToken((t) => t + 1);
+              }
+            } catch (error) {
+              setLastError(error instanceof Error ? error.message : String(error));
+            } finally {
+              setRenameTarget(null);
+            }
+          }}
         />
       )}
 

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -27,6 +27,7 @@ import { NewModuleDialog } from '../components/NewModuleDialog';
 import { ModuleMetadataDialog } from '../components/ModuleMetadataDialog';
 import { CreateNodeDialog } from '../components/Tree/CreateNodeDialog';
 import { CreateNoteDialog } from '../components/Tree/CreateNoteDialog';
+import { DuplicateDialog } from '../components/Tree/DuplicateDialog';
 import { MoveDialog } from '../components/Tree/MoveDialog';
 import { RenameDialog } from '../components/Tree/RenameDialog';
 import { TitleBar } from '../components/TitleBar';
@@ -139,7 +140,8 @@ const App: React.FC = () => {
   const [forceWelcome, setForceWelcome] = useState(false);
   const [scriptDialog, setScriptDialog] = useState<TreeNodeData | null>(null);
   const [renameTarget, setRenameTarget] = useState<{ path: string; key: string } | null>(null);
-  const [moveTarget, setMoveTarget] = useState<string | null>(null);
+  const [moveTarget, setMoveTarget] = useState<{ path: string; type: string } | null>(null);
+  const [duplicateTarget, setDuplicateTarget] = useState<{ path: string; type: string } | null>(null);
   const [createNodeTarget, setCreateNodeTarget] = useState<string | null>(null);
   const [createScriptTarget, setCreateScriptTarget] = useState<string | null>(null);
   const [createNoteTarget, setCreateNoteTarget] = useState<string | null>(null);
@@ -499,6 +501,7 @@ const App: React.FC = () => {
       if (scriptDialog) { setScriptDialog(null); return; }
       if (renameTarget) { setRenameTarget(null); return; }
       if (moveTarget) { setMoveTarget(null); return; }
+      if (duplicateTarget) { setDuplicateTarget(null); return; }
       if (createNodeTarget) { setCreateNodeTarget(null); return; }
       if (createScriptTarget) { setCreateScriptTarget(null); return; }
       if (createNoteTarget) { setCreateNoteTarget(null); return; }
@@ -706,7 +709,11 @@ const App: React.FC = () => {
       }
     } else if (action === 'move') {
       if (node.path) {
-        setMoveTarget(node.path);
+        setMoveTarget({ path: node.path, type: node.type });
+      }
+    } else if (action === 'duplicate') {
+      if (node.path) {
+        setDuplicateTarget({ path: node.path, type: node.type });
       }
     } else if (action === 'delete') {
       if (!currentKernelId || !node.path) return;
@@ -1267,11 +1274,12 @@ const App: React.FC = () => {
 
       {moveTarget !== null && currentKernelId && (
         <MoveDialog
-          currentPath={moveTarget}
+          currentPath={moveTarget.path}
+          nodeType={moveTarget.type}
           onCancel={() => setMoveTarget(null)}
-          onMove={async (newPath) => {
+          onMove={async (newPath, filename) => {
             try {
-              const result = await window.pdv.tree.move(currentKernelId, moveTarget, newPath);
+              const result = await window.pdv.tree.move(currentKernelId, moveTarget.path, newPath, filename);
               if (!result.success) {
                 setLastError(result.error);
               } else {
@@ -1281,6 +1289,28 @@ const App: React.FC = () => {
               setLastError(error instanceof Error ? error.message : String(error));
             } finally {
               setMoveTarget(null);
+            }
+          }}
+        />
+      )}
+
+      {duplicateTarget !== null && currentKernelId && (
+        <DuplicateDialog
+          currentPath={duplicateTarget.path}
+          nodeType={duplicateTarget.type}
+          onCancel={() => setDuplicateTarget(null)}
+          onDuplicate={async (newPath, filename) => {
+            try {
+              const result = await window.pdv.tree.duplicate(currentKernelId, duplicateTarget.path, newPath, filename);
+              if (!result.success) {
+                setLastError(result.error);
+              } else {
+                setTreeRefreshToken((t) => t + 1);
+              }
+            } catch (error) {
+              setLastError(error instanceof Error ? error.message : String(error));
+            } finally {
+              setDuplicateTarget(null);
             }
           }}
         />

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -27,6 +27,7 @@ import { NewModuleDialog } from '../components/NewModuleDialog';
 import { ModuleMetadataDialog } from '../components/ModuleMetadataDialog';
 import { CreateNodeDialog } from '../components/Tree/CreateNodeDialog';
 import { CreateNoteDialog } from '../components/Tree/CreateNoteDialog';
+import { MoveDialog } from '../components/Tree/MoveDialog';
 import { RenameDialog } from '../components/Tree/RenameDialog';
 import { TitleBar } from '../components/TitleBar';
 import { WriteTab } from '../components/WriteTab';
@@ -138,6 +139,7 @@ const App: React.FC = () => {
   const [forceWelcome, setForceWelcome] = useState(false);
   const [scriptDialog, setScriptDialog] = useState<TreeNodeData | null>(null);
   const [renameTarget, setRenameTarget] = useState<{ path: string; key: string } | null>(null);
+  const [moveTarget, setMoveTarget] = useState<string | null>(null);
   const [createNodeTarget, setCreateNodeTarget] = useState<string | null>(null);
   const [createScriptTarget, setCreateScriptTarget] = useState<string | null>(null);
   const [createNoteTarget, setCreateNoteTarget] = useState<string | null>(null);
@@ -496,6 +498,7 @@ const App: React.FC = () => {
       if (showImportModule) { setShowImportModule(false); return; }
       if (scriptDialog) { setScriptDialog(null); return; }
       if (renameTarget) { setRenameTarget(null); return; }
+      if (moveTarget) { setMoveTarget(null); return; }
       if (createNodeTarget) { setCreateNodeTarget(null); return; }
       if (createScriptTarget) { setCreateScriptTarget(null); return; }
       if (createNoteTarget) { setCreateNoteTarget(null); return; }
@@ -679,7 +682,7 @@ const App: React.FC = () => {
         origin,
       });
       handleScriptRun(runResult);
-    } else if (action === 'edit' && (node.type === 'script' || node.type === 'namelist' || node.type === 'lib')) {
+    } else if (action === 'edit' && (node.type === 'script' || node.type === 'namelist' || node.type === 'lib' || node.type === 'markdown')) {
       try {
         if (!currentKernelId) return;
         await window.pdv.script.edit(currentKernelId, node.path);
@@ -700,6 +703,10 @@ const App: React.FC = () => {
     } else if (action === 'rename') {
       if (node.path) {
         setRenameTarget({ path: node.path, key: node.key });
+      }
+    } else if (action === 'move') {
+      if (node.path) {
+        setMoveTarget(node.path);
       }
     } else if (action === 'delete') {
       if (!currentKernelId || !node.path) return;
@@ -1253,6 +1260,27 @@ const App: React.FC = () => {
               setLastError(error instanceof Error ? error.message : String(error));
             } finally {
               setRenameTarget(null);
+            }
+          }}
+        />
+      )}
+
+      {moveTarget !== null && currentKernelId && (
+        <MoveDialog
+          currentPath={moveTarget}
+          onCancel={() => setMoveTarget(null)}
+          onMove={async (newPath) => {
+            try {
+              const result = await window.pdv.tree.move(currentKernelId, moveTarget, newPath);
+              if (!result.success) {
+                setLastError(result.error);
+              } else {
+                setTreeRefreshToken((t) => t + 1);
+              }
+            } catch (error) {
+              setLastError(error instanceof Error ? error.message : String(error));
+            } finally {
+              setMoveTarget(null);
             }
           }}
         />

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -59,6 +59,7 @@ import { useLayoutState } from './useLayoutState';
 import { useProjectWorkflow } from './useProjectWorkflow';
 import { useKernelSubscriptions } from './useKernelSubscriptions';
 import { useThemeManager } from './useThemeManager';
+import { useTreeAction } from '../hooks/useTreeAction';
 
 type KernelStatus = 'idle' | 'starting' | 'ready' | 'error';
 type CodeCellExecutionError = {
@@ -133,6 +134,8 @@ const App: React.FC = () => {
   const [treeRefreshToken, setTreeRefreshToken] = useState(0);
   const [pendingTreeChanges, setPendingTreeChanges] = useState<TreeChangeInfo[]>([]);
   const [modulesRefreshToken, setModulesRefreshToken] = useState(0);
+
+  const runTreeAction = useTreeAction({ setLastError, setTreeRefreshToken });
 
   // -- Dialog visibility state ----------------------------------------------
 
@@ -1255,20 +1258,10 @@ const App: React.FC = () => {
           currentKey={renameTarget.key}
           nodePath={renameTarget.path}
           onCancel={() => setRenameTarget(null)}
-          onRename={async (newName) => {
-            try {
-              const result = await window.pdv.tree.rename(currentKernelId, renameTarget.path, newName);
-              if (!result.success) {
-                setLastError(result.error);
-              } else {
-                setTreeRefreshToken((t) => t + 1);
-              }
-            } catch (error) {
-              setLastError(error instanceof Error ? error.message : String(error));
-            } finally {
-              setRenameTarget(null);
-            }
-          }}
+          onRename={(newName) => void runTreeAction(
+            () => window.pdv.tree.rename(currentKernelId, renameTarget.path, newName),
+            () => setRenameTarget(null),
+          )}
         />
       )}
 
@@ -1277,20 +1270,10 @@ const App: React.FC = () => {
           currentPath={moveTarget.path}
           nodeType={moveTarget.type}
           onCancel={() => setMoveTarget(null)}
-          onMove={async (newPath, filename) => {
-            try {
-              const result = await window.pdv.tree.move(currentKernelId, moveTarget.path, newPath, filename);
-              if (!result.success) {
-                setLastError(result.error);
-              } else {
-                setTreeRefreshToken((t) => t + 1);
-              }
-            } catch (error) {
-              setLastError(error instanceof Error ? error.message : String(error));
-            } finally {
-              setMoveTarget(null);
-            }
-          }}
+          onMove={(newPath, filename) => void runTreeAction(
+            () => window.pdv.tree.move(currentKernelId, moveTarget.path, newPath, filename),
+            () => setMoveTarget(null),
+          )}
         />
       )}
 
@@ -1299,20 +1282,10 @@ const App: React.FC = () => {
           currentPath={duplicateTarget.path}
           nodeType={duplicateTarget.type}
           onCancel={() => setDuplicateTarget(null)}
-          onDuplicate={async (newPath, filename) => {
-            try {
-              const result = await window.pdv.tree.duplicate(currentKernelId, duplicateTarget.path, newPath, filename);
-              if (!result.success) {
-                setLastError(result.error);
-              } else {
-                setTreeRefreshToken((t) => t + 1);
-              }
-            } catch (error) {
-              setLastError(error instanceof Error ? error.message : String(error));
-            } finally {
-              setDuplicateTarget(null);
-            }
-          }}
+          onDuplicate={(newPath, filename) => void runTreeAction(
+            () => window.pdv.tree.duplicate(currentKernelId, duplicateTarget.path, newPath, filename),
+            () => setDuplicateTarget(null),
+          )}
         />
       )}
 
@@ -1320,20 +1293,10 @@ const App: React.FC = () => {
         <CreateNodeDialog
           parentPath={createNodeTarget}
           onCancel={() => setCreateNodeTarget(null)}
-          onCreate={async (name) => {
-            try {
-              const result = await window.pdv.tree.createNode(currentKernelId, createNodeTarget, name);
-              if (!result.success) {
-                setLastError(result.error);
-              } else {
-                setTreeRefreshToken((t) => t + 1);
-              }
-            } catch (error) {
-              setLastError(error instanceof Error ? error.message : String(error));
-            } finally {
-              setCreateNodeTarget(null);
-            }
-          }}
+          onCreate={(name) => void runTreeAction(
+            () => window.pdv.tree.createNode(currentKernelId, createNodeTarget, name),
+            () => setCreateNodeTarget(null),
+          )}
         />
       )}
 

--- a/electron/renderer/src/app/useKernelLifecycle.ts
+++ b/electron/renderer/src/app/useKernelLifecycle.ts
@@ -123,7 +123,6 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
       cwd: config?.cwd ?? '',
       trusted: config?.trusted ?? false,
       recentProjects: config?.recentProjects ?? [],
-      customKernels: config?.customKernels ?? [],
       pythonPath: paths.pythonPath ?? config?.pythonPath,
       juliaPath: paths.juliaPath ?? config?.juliaPath,
       editors: config?.editors,

--- a/electron/renderer/src/components/Tree/ContextMenu.test.tsx
+++ b/electron/renderer/src/components/Tree/ContextMenu.test.tsx
@@ -65,7 +65,8 @@ describe('ContextMenu', () => {
         onClose={vi.fn()}
       />,
     );
-    expect(screen.getByRole('button', { name: /^Open/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Open.*Double-click/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Open in external editor/ })).toBeTruthy();
     expect(screen.queryByRole('button', { name: /^Create new script/ })).toBeNull();
   });
 

--- a/electron/renderer/src/components/Tree/ContextMenu.tsx
+++ b/electron/renderer/src/components/Tree/ContextMenu.tsx
@@ -136,10 +136,7 @@ export function getMenuEntries(node: TreeNodeData): MenuEntry[] {
     entries.push({ kind: 'separator', id: 'sep-1' });
   }
 
-  
-
   // ── Container actions (nodes that can have children) ──
-
 
   if (isContainer || isModule) {
     entries.push({ kind: 'action', id: 'create_node', label: 'Create new tree node', disabled: false });
@@ -152,7 +149,6 @@ export function getMenuEntries(node: TreeNodeData): MenuEntry[] {
 
   // ── Common actions (all nodes) ──
 
-
   entries.push({ kind: 'action', id: 'print', label: 'Print', disabled: false });
   entries.push({ kind: 'action', id: 'copy_path', label: 'Copy Path', disabled: false });
   if (node.type !== 'root') {
@@ -163,7 +159,7 @@ export function getMenuEntries(node: TreeNodeData): MenuEntry[] {
   entries.push({ kind: 'action', id: 'delete', label: 'Delete', disabled: false });
 
   // ── Refresh ──
-  
+
   entries.push({ kind: 'separator', id: 'sep-3' });
   entries.push({ kind: 'action', id: 'refresh', label: 'Refresh tree', disabled: false });
 

--- a/electron/renderer/src/components/Tree/ContextMenu.tsx
+++ b/electron/renderer/src/components/Tree/ContextMenu.tsx
@@ -142,7 +142,7 @@ export function getMenuEntries(node: TreeNodeData): MenuEntry[] {
 
 
   if (isContainer || isModule) {
-    entries.push({ kind: 'action', id: 'create_node', label: 'Create new node', disabled: false });
+    entries.push({ kind: 'action', id: 'create_node', label: 'Create new tree node', disabled: false });
     entries.push({ kind: 'action', id: 'create_script', label: 'Create new script', disabled: false });
     entries.push({ kind: 'action', id: 'create_note', label: 'Create new note', disabled: false });
     entries.push({ kind: 'action', id: 'new_gui', label: 'Create new GUI', disabled: false });
@@ -158,6 +158,7 @@ export function getMenuEntries(node: TreeNodeData): MenuEntry[] {
   if (node.type !== 'root') {
     entries.push({ kind: 'action', id: 'rename', label: `Rename ${renameLabel(node.type)}`, disabled: false });
     entries.push({ kind: 'action', id: 'move', label: 'Move to...', disabled: false });
+    entries.push({ kind: 'action', id: 'duplicate', label: 'Duplicate to...', disabled: false });
   }
   entries.push({ kind: 'action', id: 'delete', label: 'Delete', disabled: false });
 

--- a/electron/renderer/src/components/Tree/ContextMenu.tsx
+++ b/electron/renderer/src/components/Tree/ContextMenu.tsx
@@ -132,7 +132,8 @@ export function getMenuEntries(node: TreeNodeData): MenuEntry[] {
     entries.push({ kind: 'action', id: 'edit', label: 'Edit', disabled: false });
   } else if (node.type === 'markdown') {
     entries.push({ kind: 'action', id: 'open_note', label: 'Open', disabled: false });
-    entries.push({ kind: 'action', id: 'edit', label: 'Open in external editor', disabled: false });
+    // TODO: re-enable after adding file-watcher to detect external edits
+    // entries.push({ kind: 'action', id: 'edit', label: 'Open in external editor', disabled: false });
     entries.push({ kind: 'separator', id: 'sep-1' });
   }
 

--- a/electron/renderer/src/components/Tree/ContextMenu.tsx
+++ b/electron/renderer/src/components/Tree/ContextMenu.tsx
@@ -129,12 +129,10 @@ export function getActionsForNode(node: TreeNodeData) {
   // ── Creation actions (containers only) ──
 
   if (isContainer || isModule) {
+    actions.push({ id: 'create_node', label: 'Create new node', disabled: false });
     actions.push({ id: 'create_script', label: 'Create new script', disabled: false });
     actions.push({ id: 'create_note', label: 'Create new note', disabled: false });
     actions.push({ id: 'new_gui', label: 'Create new GUI', disabled: false });
-    // Lib creation is meaningful only inside a module's subtree. The app
-    // handler validates this at IPC time; we surface the option whenever
-    // the user is right-clicking a container so it's discoverable.
     actions.push({ id: 'create_lib', label: 'Create new lib', disabled: false });
   }
 

--- a/electron/renderer/src/components/Tree/ContextMenu.tsx
+++ b/electron/renderer/src/components/Tree/ContextMenu.tsx
@@ -124,7 +124,7 @@ export function getActionsForNode(node: TreeNodeData) {
 
   // ── Refresh (all nodes) ──
 
-  actions.push({ id: 'refresh', label: 'Refresh', disabled: false });
+  actions.push({ id: 'refresh', label: 'Refresh tree', disabled: false });
 
   // ── Creation actions (containers only) ──
 
@@ -138,11 +138,25 @@ export function getActionsForNode(node: TreeNodeData) {
 
   // ── Common actions (all nodes) ──
 
-  actions.push(
-    { id: 'print', label: 'Print', disabled: false },
-    { id: 'copy_path', label: 'Copy Path', disabled: false },
-    { id: 'delete', label: 'Delete', disabled: false },
-  );
+  actions.push({ id: 'print', label: 'Print', disabled: false });
+  actions.push({ id: 'copy_path', label: 'Copy Path', disabled: false });
+  if (node.type !== 'root') {
+    actions.push({ id: 'rename', label: `Rename ${renameLabel(node.type)}`, disabled: false });
+  }
+  actions.push({ id: 'delete', label: 'Delete', disabled: false });
 
   return actions;
+}
+
+function renameLabel(type: string): string {
+  switch (type) {
+    case 'script': return 'script';
+    case 'markdown': return 'note';
+    case 'module': return 'module';
+    case 'folder': return 'folder';
+    case 'gui': return 'GUI';
+    case 'lib': return 'lib';
+    case 'namelist': return 'namelist';
+    default: return 'node';
+  }
 }

--- a/electron/renderer/src/components/Tree/ContextMenu.tsx
+++ b/electron/renderer/src/components/Tree/ContextMenu.tsx
@@ -12,7 +12,12 @@ import { formatShortcutHint } from '../../shortcuts';
 
 const MENU_WIDTH = 200;
 const MENU_ITEM_HEIGHT = 32;
+const SEPARATOR_HEIGHT = 9;
 const DEFAULT_VIEWPORT = { width: 1024, height: 768 };
+
+export type MenuEntry =
+  | { kind: 'action'; id: string; label: string; disabled: boolean }
+  | { kind: 'separator'; id: string };
 
 interface ContextMenuProps {
   x: number;
@@ -58,8 +63,11 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ x, y, node, shortcuts,
     copy_path: formatShortcutHint(shortcuts.treeCopyPath),
   };
 
-  const actions = getActionsForNode(node);
-  const estimatedHeight = actions.length * MENU_ITEM_HEIGHT;
+  const entries = getMenuEntries(node);
+  const estimatedHeight = entries.reduce(
+    (h, e) => h + (e.kind === 'separator' ? SEPARATOR_HEIGHT : MENU_ITEM_HEIGHT),
+    0,
+  );
   const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : DEFAULT_VIEWPORT.width;
   const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : DEFAULT_VIEWPORT.height;
   const clampedX = Math.max(0, Math.min(x, viewportWidth - MENU_WIDTH));
@@ -71,29 +79,33 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ x, y, node, shortcuts,
       className="context-menu"
       style={{ position: 'fixed', top: clampedY, left: clampedX }}
     >
-      {actions.map((action) => (
-        <button
-          key={action.id}
-          className="context-menu-item"
-          disabled={action.disabled}
-          onClick={() => {
-            onAction(action.id, node);
-            onClose();
-          }}
-        >
-          <span className="context-menu-label">{action.label}</span>
-          {actionShortcuts[action.id] && (
-            <span className="context-menu-shortcut">{actionShortcuts[action.id]}</span>
-          )}
-        </button>
-      ))}
+      {entries.map((entry) =>
+        entry.kind === 'separator' ? (
+          <div key={entry.id} className="context-menu-separator" />
+        ) : (
+          <button
+            key={entry.id}
+            className="context-menu-item"
+            disabled={entry.disabled}
+            onClick={() => {
+              onAction(entry.id, node);
+              onClose();
+            }}
+          >
+            <span className="context-menu-label">{entry.label}</span>
+            {actionShortcuts[entry.id] && (
+              <span className="context-menu-shortcut">{actionShortcuts[entry.id]}</span>
+            )}
+          </button>
+        ),
+      )}
     </div>
   );
 };
 
-/** Return menu actions allowed for the given node descriptor. */
-export function getActionsForNode(node: TreeNodeData) {
-  const actions: Array<{ id: string; label: string; disabled: boolean }> = [];
+/** Return menu entries (actions + separators) for the given node descriptor. */
+export function getMenuEntries(node: TreeNodeData): MenuEntry[] {
+  const entries: MenuEntry[] = [];
   const isContainer = node.type === 'mapping' || node.type === 'folder' || node.type === 'root';
   const isModule = node.type === 'module';
   const isGui = node.type === 'gui';
@@ -101,51 +113,60 @@ export function getActionsForNode(node: TreeNodeData) {
   // ── Primary actions (type-specific) ──
 
   if (isModule || isGui) {
-    actions.push({ id: 'open_gui', label: 'Open GUI', disabled: false });
-    actions.push({ id: 'edit_gui', label: 'Edit GUI', disabled: false });
+    entries.push({ kind: 'action', id: 'open_gui', label: 'Open GUI', disabled: false });
+    entries.push({ kind: 'action', id: 'edit_gui', label: 'Edit GUI', disabled: false });
   }
 
   if (isModule) {
-    actions.push({ id: 'edit_module_metadata', label: 'Edit metadata...', disabled: false });
-    actions.push({ id: 'export_module', label: 'Export to global store...', disabled: false });
+    entries.push({ kind: 'action', id: 'edit_module_metadata', label: 'Edit metadata...', disabled: false });
+    entries.push({ kind: 'action', id: 'export_module', label: 'Export to global store...', disabled: false });
   }
 
   if (node.type === 'script') {
-    actions.push(
-      { id: 'run', label: 'Run...', disabled: false },
-      { id: 'run_defaults', label: 'Run defaults', disabled: false },
-      { id: 'edit', label: 'Edit', disabled: false },
+    entries.push(
+      { kind: 'action', id: 'run', label: 'Run...', disabled: false },
+      { kind: 'action', id: 'run_defaults', label: 'Run defaults', disabled: false },
+      { kind: 'action', id: 'edit', label: 'Edit', disabled: false },
     );
   } else if (node.type === 'namelist' || node.type === 'lib') {
-    actions.push({ id: 'edit', label: 'Edit', disabled: false });
+    entries.push({ kind: 'action', id: 'edit', label: 'Edit', disabled: false });
   } else if (node.type === 'markdown') {
-    actions.push({ id: 'open_note', label: 'Open', disabled: false });
+    entries.push({ kind: 'action', id: 'open_note', label: 'Open', disabled: false });
+    entries.push({ kind: 'action', id: 'edit', label: 'Open in external editor', disabled: false });
+    entries.push({ kind: 'separator', id: 'sep-1' });
   }
 
-  // ── Refresh (all nodes) ──
+  
 
-  actions.push({ id: 'refresh', label: 'Refresh tree', disabled: false });
+  // ── Container actions (nodes that can have children) ──
 
-  // ── Creation actions (containers only) ──
 
   if (isContainer || isModule) {
-    actions.push({ id: 'create_node', label: 'Create new node', disabled: false });
-    actions.push({ id: 'create_script', label: 'Create new script', disabled: false });
-    actions.push({ id: 'create_note', label: 'Create new note', disabled: false });
-    actions.push({ id: 'new_gui', label: 'Create new GUI', disabled: false });
-    actions.push({ id: 'create_lib', label: 'Create new lib', disabled: false });
+    entries.push({ kind: 'action', id: 'create_node', label: 'Create new node', disabled: false });
+    entries.push({ kind: 'action', id: 'create_script', label: 'Create new script', disabled: false });
+    entries.push({ kind: 'action', id: 'create_note', label: 'Create new note', disabled: false });
+    entries.push({ kind: 'action', id: 'new_gui', label: 'Create new GUI', disabled: false });
+    entries.push({ kind: 'action', id: 'create_lib', label: 'Create new lib', disabled: false });
+    entries.push({ kind: 'separator', id: 'sep-2' });
   }
 
   // ── Common actions (all nodes) ──
 
-  actions.push({ id: 'print', label: 'Print', disabled: false });
-  actions.push({ id: 'copy_path', label: 'Copy Path', disabled: false });
-  if (node.type !== 'root') {
-    actions.push({ id: 'rename', label: `Rename ${renameLabel(node.type)}`, disabled: false });
-  }
-  actions.push({ id: 'delete', label: 'Delete', disabled: false });
 
-  return actions;
+  entries.push({ kind: 'action', id: 'print', label: 'Print', disabled: false });
+  entries.push({ kind: 'action', id: 'copy_path', label: 'Copy Path', disabled: false });
+  if (node.type !== 'root') {
+    entries.push({ kind: 'action', id: 'rename', label: `Rename ${renameLabel(node.type)}`, disabled: false });
+    entries.push({ kind: 'action', id: 'move', label: 'Move to...', disabled: false });
+  }
+  entries.push({ kind: 'action', id: 'delete', label: 'Delete', disabled: false });
+
+  // ── Refresh ──
+  
+  entries.push({ kind: 'separator', id: 'sep-3' });
+  entries.push({ kind: 'action', id: 'refresh', label: 'Refresh tree', disabled: false });
+
+  return entries;
 }
 
 function renameLabel(type: string): string {

--- a/electron/renderer/src/components/Tree/CreateNodeDialog.tsx
+++ b/electron/renderer/src/components/Tree/CreateNodeDialog.tsx
@@ -1,0 +1,76 @@
+/**
+ * CreateNodeDialog — lightweight modal for new tree node (empty dict) creation.
+ *
+ * Accepts a node name, normalizes it for path safety, and returns the final
+ * key to the parent component.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { useModalKeyboard } from '../../hooks/useModalKeyboard';
+
+interface CreateNodeDialogProps {
+  parentPath: string;
+  onCreate: (name: string) => void;
+  onCancel: () => void;
+}
+
+/** Modal used by the Tree context menu's "Create new node" action. */
+export const CreateNodeDialog: React.FC<CreateNodeDialogProps> = ({ parentPath, onCreate, onCancel }) => {
+  const [name, setName] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const sanitized = name.trim().replace(/\s+/g, '_');
+  const canCreate = sanitized.length > 0;
+
+  const handleSubmit = () => {
+    if (!canCreate) return;
+    onCreate(sanitized);
+  };
+
+  const handleKeyDown = useModalKeyboard({ onSubmit: handleSubmit, onCancel });
+
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="script-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="dialog-header">
+          <h3>Create new node</h3>
+          <button className="close-btn" onClick={onCancel} aria-label="Close dialog">
+            ×
+          </button>
+        </div>
+
+        <div className="dialog-body">
+          <div className="script-info">
+            <strong>Parent</strong>
+            <span className="script-path">{parentPath || '(root)'}</span>
+          </div>
+          <label>
+            Node name
+            <input
+              ref={inputRef}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="my_node"
+            />
+          </label>
+          <div className="dialog-info-text">Will create an empty container node in the tree</div>
+        </div>
+
+        <div className="dialog-footer">
+          <button className="btn btn-secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" onClick={handleSubmit} disabled={!canCreate}>
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/electron/renderer/src/components/Tree/CreateNodeDialog.tsx
+++ b/electron/renderer/src/components/Tree/CreateNodeDialog.tsx
@@ -14,7 +14,7 @@ interface CreateNodeDialogProps {
   onCancel: () => void;
 }
 
-/** Modal used by the Tree context menu's "Create new node" action. */
+/** Modal used by the Tree context menu's "Create new tree node" action. */
 export const CreateNodeDialog: React.FC<CreateNodeDialogProps> = ({ parentPath, onCreate, onCancel }) => {
   const [name, setName] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -37,7 +37,7 @@ export const CreateNodeDialog: React.FC<CreateNodeDialogProps> = ({ parentPath, 
     <div className="modal-overlay" onClick={onCancel}>
       <div className="script-dialog" onClick={(e) => e.stopPropagation()}>
         <div className="dialog-header">
-          <h3>Create new node</h3>
+          <h3>Create new tree node</h3>
           <button className="close-btn" onClick={onCancel} aria-label="Close dialog">
             ×
           </button>

--- a/electron/renderer/src/components/Tree/DuplicateDialog.tsx
+++ b/electron/renderer/src/components/Tree/DuplicateDialog.tsx
@@ -1,7 +1,7 @@
 /**
- * MoveDialog — lightweight modal for moving a tree node to a new path.
+ * DuplicateDialog — lightweight modal for deep-copying a tree node to a new path.
  *
- * Pre-fills with the current dot-path and returns the new destination path.
+ * Pre-fills with the current dot-path and returns the destination path.
  * For file-backed nodes, shows an additional filename field.
  */
 
@@ -20,20 +20,25 @@ function defaultExtension(type: string): string {
   }
 }
 
-interface MoveDialogProps {
+interface DuplicateDialogProps {
   currentPath: string;
   nodeType: string;
-  onMove: (newPath: string, filename?: string) => void;
+  onDuplicate: (newPath: string, filename?: string) => void;
   onCancel: () => void;
 }
 
-/** Modal used by the Tree context menu's "Move to..." action. */
-export const MoveDialog: React.FC<MoveDialogProps> = ({ currentPath, nodeType, onMove, onCancel }) => {
-  const [path, setPath] = useState(currentPath);
-  const currentKey = currentPath.split('.').pop() ?? '';
+/** Modal used by the Tree context menu's "Duplicate to..." action. */
+export const DuplicateDialog: React.FC<DuplicateDialogProps> = ({ currentPath, nodeType, onDuplicate, onCancel }) => {
+  const defaultKey = currentPath.split('.').pop() ?? '';
+  const copyKey = defaultKey + '_copy';
+  const parentSegments = currentPath.split('.');
+  parentSegments[parentSegments.length - 1] = copyKey;
+  const defaultPath = parentSegments.join('.');
+
+  const [path, setPath] = useState(defaultPath);
   const isFileBacked = FILE_BACKED_TYPES.has(nodeType);
   const ext = defaultExtension(nodeType);
-  const [filename, setFilename] = useState(isFileBacked ? currentKey + ext : '');
+  const [filename, setFilename] = useState(isFileBacked ? copyKey + ext : '');
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -42,12 +47,12 @@ export const MoveDialog: React.FC<MoveDialogProps> = ({ currentPath, nodeType, o
   }, []);
 
   const trimmed = path.trim();
-  const canMove = trimmed.length > 0 && trimmed !== currentPath;
+  const canDuplicate = trimmed.length > 0 && trimmed !== currentPath;
 
   const handleSubmit = () => {
-    if (!canMove) return;
+    if (!canDuplicate) return;
     const trimmedFilename = filename.trim();
-    onMove(trimmed, isFileBacked && trimmedFilename ? trimmedFilename : undefined);
+    onDuplicate(trimmed, isFileBacked && trimmedFilename ? trimmedFilename : undefined);
   };
 
   const handleKeyDown = useModalKeyboard({ onSubmit: handleSubmit, onCancel });
@@ -56,7 +61,7 @@ export const MoveDialog: React.FC<MoveDialogProps> = ({ currentPath, nodeType, o
     <div className="modal-overlay" onClick={onCancel}>
       <div className="script-dialog" onClick={(e) => e.stopPropagation()}>
         <div className="dialog-header">
-          <h3>Move node</h3>
+          <h3>Duplicate node</h3>
           <button className="close-btn" onClick={onCancel} aria-label="Close dialog">
             ×
           </button>
@@ -64,11 +69,11 @@ export const MoveDialog: React.FC<MoveDialogProps> = ({ currentPath, nodeType, o
 
         <div className="dialog-body">
           <div className="script-info">
-            <strong>Current path</strong>
+            <strong>Source</strong>
             <span className="script-path">{currentPath}</span>
           </div>
           <label>
-            New path
+            Destination path
             <input
               ref={inputRef}
               type="text"
@@ -86,19 +91,19 @@ export const MoveDialog: React.FC<MoveDialogProps> = ({ currentPath, nodeType, o
                 value={filename}
                 onChange={(e) => setFilename(e.target.value)}
                 onKeyDown={handleKeyDown}
-                placeholder={currentKey + ext}
+                placeholder={copyKey + ext}
               />
             </label>
           )}
-          <div className="dialog-info-text">Enter the full dot-separated destination path</div>
+          <div className="dialog-info-text">Creates an independent deep copy at the destination</div>
         </div>
 
         <div className="dialog-footer">
           <button className="btn btn-secondary" onClick={onCancel}>
             Cancel
           </button>
-          <button className="btn btn-primary" onClick={handleSubmit} disabled={!canMove}>
-            Move
+          <button className="btn btn-primary" onClick={handleSubmit} disabled={!canDuplicate}>
+            Duplicate
           </button>
         </div>
       </div>

--- a/electron/renderer/src/components/Tree/DuplicateDialog.tsx
+++ b/electron/renderer/src/components/Tree/DuplicateDialog.tsx
@@ -7,18 +7,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useModalKeyboard } from '../../hooks/useModalKeyboard';
-
-const FILE_BACKED_TYPES = new Set(['script', 'markdown', 'gui', 'lib', 'namelist']);
-
-function defaultExtension(type: string): string {
-  switch (type) {
-    case 'script': return '.py';
-    case 'lib': return '.py';
-    case 'markdown': return '.md';
-    case 'gui': return '.gui.json';
-    default: return '';
-  }
-}
+import { FILE_BACKED_TYPES, defaultExtension } from './tree-file-utils';
 
 interface DuplicateDialogProps {
   currentPath: string;
@@ -38,7 +27,7 @@ export const DuplicateDialog: React.FC<DuplicateDialogProps> = ({ currentPath, n
   const [path, setPath] = useState(defaultPath);
   const isFileBacked = FILE_BACKED_TYPES.has(nodeType);
   const ext = defaultExtension(nodeType);
-  const [filename, setFilename] = useState(isFileBacked ? copyKey + ext : '');
+  const [filename, setFilename] = useState(isFileBacked && ext ? copyKey + ext : '');
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -85,17 +74,17 @@ export const DuplicateDialog: React.FC<DuplicateDialogProps> = ({ currentPath, n
           </label>
           {isFileBacked && (
             <label>
-              Filename
+              Filename {!ext && <span className="dialog-info-text">(leave blank to keep original)</span>}
               <input
                 type="text"
                 value={filename}
                 onChange={(e) => setFilename(e.target.value)}
                 onKeyDown={handleKeyDown}
-                placeholder={copyKey + ext}
+                placeholder={ext ? copyKey + ext : 'original filename'}
               />
             </label>
           )}
-          <div className="dialog-info-text">Creates an independent deep copy at the destination</div>
+          <div className="dialog-info-text">All parent containers in the destination path must already exist.</div>
         </div>
 
         <div className="dialog-footer">

--- a/electron/renderer/src/components/Tree/MoveDialog.tsx
+++ b/electron/renderer/src/components/Tree/MoveDialog.tsx
@@ -1,0 +1,76 @@
+/**
+ * MoveDialog — lightweight modal for moving a tree node to a new path.
+ *
+ * Pre-fills with the current dot-path and returns the new destination path.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { useModalKeyboard } from '../../hooks/useModalKeyboard';
+
+interface MoveDialogProps {
+  currentPath: string;
+  onMove: (newPath: string) => void;
+  onCancel: () => void;
+}
+
+/** Modal used by the Tree context menu's "Move to..." action. */
+export const MoveDialog: React.FC<MoveDialogProps> = ({ currentPath, onMove, onCancel }) => {
+  const [path, setPath] = useState(currentPath);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const trimmed = path.trim();
+  const canMove = trimmed.length > 0 && trimmed !== currentPath;
+
+  const handleSubmit = () => {
+    if (!canMove) return;
+    onMove(trimmed);
+  };
+
+  const handleKeyDown = useModalKeyboard({ onSubmit: handleSubmit, onCancel });
+
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="script-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="dialog-header">
+          <h3>Move node</h3>
+          <button className="close-btn" onClick={onCancel} aria-label="Close dialog">
+            ×
+          </button>
+        </div>
+
+        <div className="dialog-body">
+          <div className="script-info">
+            <strong>Current path</strong>
+            <span className="script-path">{currentPath}</span>
+          </div>
+          <label>
+            New path
+            <input
+              ref={inputRef}
+              type="text"
+              value={path}
+              onChange={(e) => setPath(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="parent.child.name"
+            />
+          </label>
+          <div className="dialog-info-text">Enter the full dot-separated destination path</div>
+        </div>
+
+        <div className="dialog-footer">
+          <button className="btn btn-secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" onClick={handleSubmit} disabled={!canMove}>
+            Move
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/electron/renderer/src/components/Tree/MoveDialog.tsx
+++ b/electron/renderer/src/components/Tree/MoveDialog.tsx
@@ -7,18 +7,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useModalKeyboard } from '../../hooks/useModalKeyboard';
-
-const FILE_BACKED_TYPES = new Set(['script', 'markdown', 'gui', 'lib', 'namelist']);
-
-function defaultExtension(type: string): string {
-  switch (type) {
-    case 'script': return '.py';
-    case 'lib': return '.py';
-    case 'markdown': return '.md';
-    case 'gui': return '.gui.json';
-    default: return '';
-  }
-}
+import { FILE_BACKED_TYPES, defaultExtension } from './tree-file-utils';
 
 interface MoveDialogProps {
   currentPath: string;
@@ -33,7 +22,7 @@ export const MoveDialog: React.FC<MoveDialogProps> = ({ currentPath, nodeType, o
   const currentKey = currentPath.split('.').pop() ?? '';
   const isFileBacked = FILE_BACKED_TYPES.has(nodeType);
   const ext = defaultExtension(nodeType);
-  const [filename, setFilename] = useState(isFileBacked ? currentKey + ext : '');
+  const [filename, setFilename] = useState(isFileBacked && ext ? currentKey + ext : '');
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -80,17 +69,17 @@ export const MoveDialog: React.FC<MoveDialogProps> = ({ currentPath, nodeType, o
           </label>
           {isFileBacked && (
             <label>
-              Filename
+              Filename {!ext && <span className="dialog-info-text">(leave blank to keep original)</span>}
               <input
                 type="text"
                 value={filename}
                 onChange={(e) => setFilename(e.target.value)}
                 onKeyDown={handleKeyDown}
-                placeholder={currentKey + ext}
+                placeholder={ext ? currentKey + ext : 'original filename'}
               />
             </label>
           )}
-          <div className="dialog-info-text">Enter the full dot-separated destination path</div>
+          <div className="dialog-info-text">All parent containers in the destination path must already exist.</div>
         </div>
 
         <div className="dialog-footer">

--- a/electron/renderer/src/components/Tree/RenameDialog.tsx
+++ b/electron/renderer/src/components/Tree/RenameDialog.tsx
@@ -1,0 +1,76 @@
+/**
+ * RenameDialog — lightweight modal for renaming a tree node.
+ *
+ * Pre-fills with the current key and returns the sanitized new name.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { useModalKeyboard } from '../../hooks/useModalKeyboard';
+
+interface RenameDialogProps {
+  currentKey: string;
+  nodePath: string;
+  onRename: (newName: string) => void;
+  onCancel: () => void;
+}
+
+/** Modal used by the Tree context menu's "Rename" action. */
+export const RenameDialog: React.FC<RenameDialogProps> = ({ currentKey, nodePath, onRename, onCancel }) => {
+  const [name, setName] = useState(currentKey);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const sanitized = name.trim().replace(/\s+/g, '_');
+  const canRename = sanitized.length > 0 && sanitized !== currentKey;
+
+  const handleSubmit = () => {
+    if (!canRename) return;
+    onRename(sanitized);
+  };
+
+  const handleKeyDown = useModalKeyboard({ onSubmit: handleSubmit, onCancel });
+
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="script-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="dialog-header">
+          <h3>Rename</h3>
+          <button className="close-btn" onClick={onCancel} aria-label="Close dialog">
+            ×
+          </button>
+        </div>
+
+        <div className="dialog-body">
+          <div className="script-info">
+            <strong>Path</strong>
+            <span className="script-path">{nodePath}</span>
+          </div>
+          <label>
+            New name
+            <input
+              ref={inputRef}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={currentKey}
+            />
+          </label>
+        </div>
+
+        <div className="dialog-footer">
+          <button className="btn btn-secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" onClick={handleSubmit} disabled={!canRename}>
+            Rename
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/electron/renderer/src/components/Tree/context-menu-actions.test.ts
+++ b/electron/renderer/src/components/Tree/context-menu-actions.test.ts
@@ -16,21 +16,25 @@ describe('getMenuEntries', () => {
   it('returns script actions for script nodes', () => {
     const ids = actionIds('script');
     expect(ids).toEqual([
-      'run', 'run_defaults', 'edit', 'refresh',
-      'print', 'copy_path', 'rename', 'move', 'delete',
+      'run', 'run_defaults', 'edit',
+      'print', 'copy_path', 'rename', 'move', 'duplicate', 'delete',
+      'refresh',
     ]);
     expect(ids).not.toContain('create_script');
   });
 
-  it('includes rename and move for non-root nodes but not for root', () => {
+  it('includes rename, move, and duplicate for non-root nodes but not for root', () => {
     expect(actionIds('script')).toContain('rename');
     expect(actionIds('script')).toContain('move');
+    expect(actionIds('script')).toContain('duplicate');
     expect(actionIds('folder')).toContain('rename');
     expect(actionIds('folder')).toContain('move');
+    expect(actionIds('folder')).toContain('duplicate');
     expect(actionIds('mapping')).toContain('rename');
-    expect(actionIds('ndarray')).toContain('move');
+    expect(actionIds('ndarray')).toContain('duplicate');
     expect(actionIds('root')).not.toContain('rename');
     expect(actionIds('root')).not.toContain('move');
+    expect(actionIds('root')).not.toContain('duplicate');
   });
 
   it('shows type-specific rename label', () => {

--- a/electron/renderer/src/components/Tree/context-menu-actions.test.ts
+++ b/electron/renderer/src/components/Tree/context-menu-actions.test.ts
@@ -9,8 +9,26 @@ function actionIds(type: string): string[] {
 describe('getActionsForNode', () => {
   it('returns script actions for script nodes', () => {
     const ids = actionIds('script');
-    expect(ids).toEqual(['run', 'run_defaults', 'edit', 'refresh', 'print', 'copy_path', 'delete']);
+    expect(ids).toEqual(['run', 'run_defaults', 'edit', 'refresh', 'print', 'copy_path', 'rename', 'delete']);
     expect(ids).not.toContain('create_script');
+  });
+
+  it('includes rename for non-root nodes but not for root', () => {
+    expect(actionIds('script')).toContain('rename');
+    expect(actionIds('folder')).toContain('rename');
+    expect(actionIds('mapping')).toContain('rename');
+    expect(actionIds('ndarray')).toContain('rename');
+    expect(actionIds('root')).not.toContain('rename');
+  });
+
+  it('shows type-specific rename label', () => {
+    const scriptNode = { type: 'script' } as unknown as Parameters<typeof getActionsForNode>[0];
+    const renameAction = getActionsForNode(scriptNode).find((a) => a.id === 'rename');
+    expect(renameAction?.label).toBe('Rename script');
+
+    const noteNode = { type: 'markdown' } as unknown as Parameters<typeof getActionsForNode>[0];
+    const noteRename = getActionsForNode(noteNode).find((a) => a.id === 'rename');
+    expect(noteRename?.label).toBe('Rename note');
   });
 
   it('returns folder actions including create_node and create_script for folders', () => {

--- a/electron/renderer/src/components/Tree/context-menu-actions.test.ts
+++ b/electron/renderer/src/components/Tree/context-menu-actions.test.ts
@@ -1,33 +1,43 @@
 import { describe, expect, it } from 'vitest';
-import { getActionsForNode } from './ContextMenu';
+import { getMenuEntries, type MenuEntry } from './ContextMenu';
 
-function actionIds(type: string): string[] {
-  const node = { type } as unknown as Parameters<typeof getActionsForNode>[0];
-  return getActionsForNode(node).map((action) => action.id);
+type ActionEntry = Extract<MenuEntry, { kind: 'action' }>;
+
+function actions(type: string): ActionEntry[] {
+  const node = { type } as unknown as Parameters<typeof getMenuEntries>[0];
+  return getMenuEntries(node).filter((e): e is ActionEntry => e.kind === 'action');
 }
 
-describe('getActionsForNode', () => {
+function actionIds(type: string): string[] {
+  return actions(type).map((a) => a.id);
+}
+
+describe('getMenuEntries', () => {
   it('returns script actions for script nodes', () => {
     const ids = actionIds('script');
-    expect(ids).toEqual(['run', 'run_defaults', 'edit', 'refresh', 'print', 'copy_path', 'rename', 'delete']);
+    expect(ids).toEqual([
+      'run', 'run_defaults', 'edit', 'refresh',
+      'print', 'copy_path', 'rename', 'move', 'delete',
+    ]);
     expect(ids).not.toContain('create_script');
   });
 
-  it('includes rename for non-root nodes but not for root', () => {
+  it('includes rename and move for non-root nodes but not for root', () => {
     expect(actionIds('script')).toContain('rename');
+    expect(actionIds('script')).toContain('move');
     expect(actionIds('folder')).toContain('rename');
+    expect(actionIds('folder')).toContain('move');
     expect(actionIds('mapping')).toContain('rename');
-    expect(actionIds('ndarray')).toContain('rename');
+    expect(actionIds('ndarray')).toContain('move');
     expect(actionIds('root')).not.toContain('rename');
+    expect(actionIds('root')).not.toContain('move');
   });
 
   it('shows type-specific rename label', () => {
-    const scriptNode = { type: 'script' } as unknown as Parameters<typeof getActionsForNode>[0];
-    const renameAction = getActionsForNode(scriptNode).find((a) => a.id === 'rename');
+    const renameAction = actions('script').find((a) => a.id === 'rename');
     expect(renameAction?.label).toBe('Rename script');
 
-    const noteNode = { type: 'markdown' } as unknown as Parameters<typeof getActionsForNode>[0];
-    const noteRename = getActionsForNode(noteNode).find((a) => a.id === 'rename');
+    const noteRename = actions('markdown').find((a) => a.id === 'rename');
     expect(noteRename?.label).toBe('Rename note');
   });
 
@@ -48,8 +58,21 @@ describe('getActionsForNode', () => {
   });
 
   it('enables delete action', () => {
-    const node = { type: 'script' } as unknown as Parameters<typeof getActionsForNode>[0];
-    const deleteAction = getActionsForNode(node).find((action) => action.id === 'delete');
+    const deleteAction = actions('script').find((a) => a.id === 'delete');
     expect(deleteAction?.disabled).toBe(false);
+  });
+
+  it('includes edit (open in external editor) for markdown nodes', () => {
+    const ids = actionIds('markdown');
+    expect(ids).toContain('open_note');
+    expect(ids).toContain('edit');
+  });
+
+  it('includes separators between sections', () => {
+    const scriptEntries = getMenuEntries({ type: 'script' } as Parameters<typeof getMenuEntries>[0]);
+    expect(scriptEntries.filter((e) => e.kind === 'separator').length).toBe(1);
+
+    const folderEntries = getMenuEntries({ type: 'folder' } as Parameters<typeof getMenuEntries>[0]);
+    expect(folderEntries.filter((e) => e.kind === 'separator').length).toBe(2);
   });
 });

--- a/electron/renderer/src/components/Tree/context-menu-actions.test.ts
+++ b/electron/renderer/src/components/Tree/context-menu-actions.test.ts
@@ -13,16 +13,19 @@ describe('getActionsForNode', () => {
     expect(ids).not.toContain('create_script');
   });
 
-  it('returns folder actions including create_script for folders', () => {
+  it('returns folder actions including create_node and create_script for folders', () => {
     const ids = actionIds('folder');
     expect(ids).toContain('refresh');
+    expect(ids).toContain('create_node');
     expect(ids).toContain('create_script');
     expect(ids).toContain('new_gui');
     expect(ids).not.toContain('view');
   });
 
-  it('returns create_script for mapping nodes but not ndarray nodes', () => {
+  it('returns create_node and create_script for mapping nodes but not ndarray nodes', () => {
+    expect(actionIds('mapping')).toContain('create_node');
     expect(actionIds('mapping')).toContain('create_script');
+    expect(actionIds('ndarray')).not.toContain('create_node');
     expect(actionIds('ndarray')).not.toContain('create_script');
   });
 

--- a/electron/renderer/src/components/Tree/tree-file-utils.ts
+++ b/electron/renderer/src/components/Tree/tree-file-utils.ts
@@ -1,0 +1,13 @@
+/** Shared utilities for file-backed tree node dialogs (Move, Duplicate). */
+
+export const FILE_BACKED_TYPES = new Set(['script', 'markdown', 'gui', 'lib', 'namelist']);
+
+export function defaultExtension(type: string): string {
+  switch (type) {
+    case 'script': return '.py';
+    case 'lib': return '.py';
+    case 'markdown': return '.md';
+    case 'gui': return '.gui.json';
+    default: return '';
+  }
+}

--- a/electron/renderer/src/hooks/useTreeAction.ts
+++ b/electron/renderer/src/hooks/useTreeAction.ts
@@ -1,0 +1,39 @@
+/**
+ * useTreeAction — shared handler for tree context menu actions that follow
+ * the pattern: call API → setLastError on failure / bump tree refresh on
+ * success → close the dialog.
+ */
+
+import { useCallback } from 'react';
+
+interface UseTreeActionOptions {
+  setLastError: (error: string | undefined) => void;
+  setTreeRefreshToken: (fn: (t: number) => number) => void;
+}
+
+/**
+ * Returns a wrapper that executes an async tree API call and handles the
+ * common success/error/refresh boilerplate.
+ */
+export function useTreeAction({ setLastError, setTreeRefreshToken }: UseTreeActionOptions) {
+  return useCallback(
+    async <T extends { success: boolean; error?: string }>(
+      apiCall: () => Promise<T>,
+      close: () => void,
+    ) => {
+      try {
+        const result = await apiCall();
+        if (!result.success) {
+          setLastError(result.error);
+        } else {
+          setTreeRefreshToken((t) => t + 1);
+        }
+      } catch (error) {
+        setLastError(error instanceof Error ? error.message : String(error));
+      } finally {
+        close();
+      }
+    },
+    [setLastError, setTreeRefreshToken],
+  );
+}

--- a/electron/renderer/src/styles/context-menu.css
+++ b/electron/renderer/src/styles/context-menu.css
@@ -51,3 +51,10 @@
   color: var(--text-hint);
   cursor: not-allowed;
 }
+
+.context-menu-separator {
+  height: 1px;
+  margin: 4px 8px;
+  background-color: var(--border-color);
+  opacity: 0.4;
+}

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -247,13 +247,11 @@ export interface Config {
   trusted?: boolean;
   /** Most-recent project paths for menu quick access. */
   recentProjects?: string[];
-  /** Custom kernel definitions (legacy/advanced). */
-  customKernels?: unknown[];
   /** Python executable configured by user. */
   pythonPath?: string;
   /** Julia executable configured by user. */
   juliaPath?: string;
-  /** External editor command map (legacy). */
+  /** External editor command map (legacy). TODO: remove, I think? Is this actually legacy?*/
   editors?: Record<string, string>;
   /** Project root path (when persisted). */
   projectRoot?: string;

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -251,7 +251,7 @@ export interface Config {
   pythonPath?: string;
   /** Julia executable configured by user. */
   juliaPath?: string;
-  /** External editor command map (legacy). TODO: remove, I think? Is this actually legacy?*/
+  /** External editor command map. See #206 for cleanup tracking. */
   editors?: Record<string, string>;
   /** Project root path (when persisted). */
   projectRoot?: string;

--- a/pdv-python/pdv/handlers/tree.py
+++ b/pdv-python/pdv/handlers/tree.py
@@ -332,7 +332,84 @@ def handle_tree_delete(msg: dict) -> None:
     )
 
 
+def handle_tree_create_node(msg: dict) -> None:
+    """Handle ``pdv.tree.create_node`` — create an empty dict node in the tree.
+
+    Payload
+    -------
+    parent_path : str
+        Dot-separated path of the parent container (empty string for root).
+    name : str
+        Key name for the new node.
+    """
+    from pdv.comms import send_message, send_error, get_pdv_tree  # noqa: PLC0415
+    from pdv.tree import PDVTree  # noqa: PLC0415
+
+    msg_id = msg.get("msg_id")
+    payload = msg.get("payload", {})
+    parent_path = payload.get("parent_path", "")
+    name = payload.get("name", "")
+
+    tree = get_pdv_tree()
+    if tree is None:
+        send_error(
+            "pdv.tree.create_node.response",
+            "tree.not_initialized",
+            "PDVTree is not initialized.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if not name:
+        send_error(
+            "pdv.tree.create_node.response",
+            "tree.invalid_name",
+            "Node name must not be empty.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    full_path = f"{parent_path}.{name}" if parent_path else name
+
+    if full_path in tree:
+        send_error(
+            "pdv.tree.create_node.response",
+            "tree.already_exists",
+            f"A node already exists at path: {full_path}",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if parent_path:
+        if parent_path not in tree:
+            send_error(
+                "pdv.tree.create_node.response",
+                "tree.path_not_found",
+                f"Parent path does not exist: {parent_path}",
+                in_reply_to=msg_id,
+            )
+            return
+        parent = tree[parent_path]
+        if not isinstance(parent, dict):
+            send_error(
+                "pdv.tree.create_node.response",
+                "tree.not_a_container",
+                f"Parent at '{parent_path}' is not a container.",
+                in_reply_to=msg_id,
+            )
+            return
+
+    tree[full_path] = PDVTree()
+
+    send_message(
+        "pdv.tree.create_node.response",
+        {"path": full_path, "created": True},
+        in_reply_to=msg_id,
+    )
+
+
 register("pdv.tree.list", handle_tree_list)
 register("pdv.tree.get", handle_tree_get)
 register("pdv.tree.resolve_file", handle_tree_resolve_file)
 register("pdv.tree.delete", handle_tree_delete)
+register("pdv.tree.create_node", handle_tree_create_node)

--- a/pdv-python/pdv/handlers/tree.py
+++ b/pdv-python/pdv/handlers/tree.py
@@ -408,8 +408,105 @@ def handle_tree_create_node(msg: dict) -> None:
     )
 
 
+def handle_tree_rename(msg: dict) -> None:
+    """Handle ``pdv.tree.rename`` — change the key of a tree node.
+
+    Moves the value from ``path`` to a sibling key ``new_name`` under the
+    same parent. The old key is removed and the new key is inserted.
+
+    Payload
+    -------
+    path : str
+        Dot-separated path of the node to rename.
+    new_name : str
+        New key name (single segment, no dots).
+    """
+    from pdv.comms import send_message, send_error, get_pdv_tree  # noqa: PLC0415
+
+    msg_id = msg.get("msg_id")
+    payload = msg.get("payload", {})
+    path = payload.get("path", "")
+    new_name = payload.get("new_name", "")
+
+    tree = get_pdv_tree()
+    if tree is None:
+        send_error(
+            "pdv.tree.rename.response",
+            "tree.not_initialized",
+            "PDVTree is not initialized.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if not path:
+        send_error(
+            "pdv.tree.rename.response",
+            "tree.invalid_path",
+            "Cannot rename the root tree.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if not new_name:
+        send_error(
+            "pdv.tree.rename.response",
+            "tree.invalid_name",
+            "New name must not be empty.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if "." in new_name:
+        send_error(
+            "pdv.tree.rename.response",
+            "tree.invalid_name",
+            "New name must not contain dots.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if path not in tree:
+        send_error(
+            "pdv.tree.rename.response",
+            "tree.path_not_found",
+            f"No node at path: {path}",
+            in_reply_to=msg_id,
+        )
+        return
+
+    parts = path.split(".")
+    parent_path = ".".join(parts[:-1])
+    new_path = f"{parent_path}.{new_name}" if parent_path else new_name
+
+    if new_path in tree:
+        send_error(
+            "pdv.tree.rename.response",
+            "tree.already_exists",
+            f"A node already exists at path: {new_path}",
+            in_reply_to=msg_id,
+        )
+        return
+
+    value = tree[path]
+    tree.set_quiet(new_path, value)
+    # Delete the old key at the dict level to avoid a second changed push
+    if parent_path:
+        parent = tree[parent_path]
+        dict.__delitem__(parent, parts[-1])
+    else:
+        dict.__delitem__(tree, parts[-1])
+    tree._emit_changed(path, "renamed")
+
+    send_message(
+        "pdv.tree.rename.response",
+        {"old_path": path, "new_path": new_path, "renamed": True},
+        in_reply_to=msg_id,
+    )
+
+
 register("pdv.tree.list", handle_tree_list)
 register("pdv.tree.get", handle_tree_get)
 register("pdv.tree.resolve_file", handle_tree_resolve_file)
 register("pdv.tree.delete", handle_tree_delete)
 register("pdv.tree.create_node", handle_tree_create_node)
+register("pdv.tree.rename", handle_tree_rename)

--- a/pdv-python/pdv/handlers/tree.py
+++ b/pdv-python/pdv/handlers/tree.py
@@ -12,7 +12,79 @@ ARCHITECTURE.md §3.4 (tree messages), §7 (tree data model)
 
 from __future__ import annotations
 
+import os
+import shutil
+
 from pdv.handlers import register
+
+
+def _relocate_files(
+    value: object,
+    old_tree_path: str,
+    new_tree_path: str,
+    working_dir: str,
+    *,
+    copy: bool = False,
+    filename: str | None = None,
+) -> None:
+    """Move or copy backing files for all PDVFile nodes in *value*.
+
+    Recursively walks dicts so that container moves/duplicates also
+    relocate every file-backed descendant.  Updates each node's
+    ``_relative_path`` in place to reflect the new tree location.
+    """
+    from pdv.tree import PDVFile  # noqa: PLC0415
+
+    if isinstance(value, PDVFile):
+        _relocate_single_file(value, new_tree_path, working_dir,
+                              copy=copy, filename=filename)
+    elif isinstance(value, dict):
+        for key in list(dict.keys(value)):
+            child = dict.__getitem__(value, key)
+            old_child = f"{old_tree_path}.{key}"
+            new_child = f"{new_tree_path}.{key}"
+            _relocate_files(child, old_child, new_child, working_dir,
+                            copy=copy)
+
+
+def _relocate_single_file(
+    file_node: object,
+    new_tree_path: str,
+    working_dir: str,
+    *,
+    copy: bool = False,
+    filename: str | None = None,
+) -> None:
+    """Move or copy one backing file and update its ``_relative_path``.
+
+    *filename* overrides the destination filename.  When ``None``, the
+    new filename is derived from the last segment of *new_tree_path*
+    plus the original file extension.
+    """
+    from pdv.tree import PDVFile  # noqa: PLC0415
+    assert isinstance(file_node, PDVFile)
+
+    old_abs = file_node.resolve_path(working_dir)
+
+    if filename:
+        new_filename = filename
+    else:
+        _, ext = os.path.splitext(os.path.basename(file_node.relative_path))
+        new_key = new_tree_path.split(".")[-1]
+        new_filename = new_key + ext
+
+    new_parts = new_tree_path.split(".")
+    new_rel = os.path.join("tree", *new_parts[:-1], new_filename)
+    new_abs = os.path.join(working_dir, new_rel)
+
+    if os.path.exists(old_abs) and old_abs != new_abs:
+        os.makedirs(os.path.dirname(new_abs), exist_ok=True)
+        if copy:
+            shutil.copy2(old_abs, new_abs)
+        else:
+            shutil.move(old_abs, new_abs)
+
+    file_node._relative_path = new_rel
 
 
 def handle_tree_list(msg: dict) -> None:
@@ -608,7 +680,14 @@ def handle_tree_move(msg: dict) -> None:
             )
             return
 
+    filename = payload.get("filename") or None
+
     value = tree[path]
+
+    if tree._working_dir:
+        _relocate_files(value, path, new_path, tree._working_dir,
+                        copy=False, filename=filename)
+
     tree.set_quiet(new_path, value)
 
     old_parts = path.split(".")
@@ -628,6 +707,110 @@ def handle_tree_move(msg: dict) -> None:
     )
 
 
+def handle_tree_duplicate(msg: dict) -> None:
+    """Handle ``pdv.tree.duplicate`` — deep-copy a node to a new path.
+
+    Payload
+    -------
+    path : str
+        Dot-separated path of the node to copy.
+    new_path : str
+        Full dot-separated destination path for the copy.
+    """
+    import copy  # noqa: PLC0415
+
+    from pdv.comms import send_message, send_error, get_pdv_tree  # noqa: PLC0415
+
+    msg_id = msg.get("msg_id")
+    payload = msg.get("payload", {})
+    path = payload.get("path", "")
+    new_path = payload.get("new_path", "")
+
+    tree = get_pdv_tree()
+    if tree is None:
+        send_error(
+            "pdv.tree.duplicate.response",
+            "tree.not_initialized",
+            "PDVTree is not initialized.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if not path:
+        send_error(
+            "pdv.tree.duplicate.response",
+            "tree.invalid_path",
+            "Cannot duplicate the root tree.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if not new_path:
+        send_error(
+            "pdv.tree.duplicate.response",
+            "tree.invalid_path",
+            "Destination path must not be empty.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if path not in tree:
+        send_error(
+            "pdv.tree.duplicate.response",
+            "tree.path_not_found",
+            f"No node at path: {path}",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if new_path in tree:
+        send_error(
+            "pdv.tree.duplicate.response",
+            "tree.already_exists",
+            f"A node already exists at path: {new_path}",
+            in_reply_to=msg_id,
+        )
+        return
+
+    new_parts = new_path.split(".")
+    if len(new_parts) > 1:
+        dest_parent = ".".join(new_parts[:-1])
+        if dest_parent not in tree:
+            send_error(
+                "pdv.tree.duplicate.response",
+                "tree.path_not_found",
+                f"Destination parent does not exist: {dest_parent}",
+                in_reply_to=msg_id,
+            )
+            return
+        parent_val = tree[dest_parent]
+        if not isinstance(parent_val, dict):
+            send_error(
+                "pdv.tree.duplicate.response",
+                "tree.not_a_container",
+                f"Destination parent '{dest_parent}' is not a container.",
+                in_reply_to=msg_id,
+            )
+            return
+
+    filename = payload.get("filename") or None
+
+    value = tree[path]
+    cloned = copy.deepcopy(value)
+
+    if tree._working_dir:
+        _relocate_files(cloned, path, new_path, tree._working_dir,
+                        copy=True, filename=filename)
+
+    tree[new_path] = cloned
+
+    send_message(
+        "pdv.tree.duplicate.response",
+        {"source_path": path, "new_path": new_path, "duplicated": True},
+        in_reply_to=msg_id,
+    )
+
+
 register("pdv.tree.list", handle_tree_list)
 register("pdv.tree.get", handle_tree_get)
 register("pdv.tree.resolve_file", handle_tree_resolve_file)
@@ -635,3 +818,4 @@ register("pdv.tree.delete", handle_tree_delete)
 register("pdv.tree.create_node", handle_tree_create_node)
 register("pdv.tree.rename", handle_tree_rename)
 register("pdv.tree.move", handle_tree_move)
+register("pdv.tree.duplicate", handle_tree_duplicate)

--- a/pdv-python/pdv/handlers/tree.py
+++ b/pdv-python/pdv/handlers/tree.py
@@ -62,7 +62,8 @@ def _relocate_single_file(
     plus the original file extension.
     """
     from pdv.tree import PDVFile  # noqa: PLC0415
-    assert isinstance(file_node, PDVFile)
+    if not isinstance(file_node, PDVFile):
+        raise TypeError(f"Expected PDVFile, got {type(file_node).__name__}")
 
     old_abs = file_node.resolve_path(working_dir)
 
@@ -560,6 +561,10 @@ def handle_tree_rename(msg: dict) -> None:
         return
 
     value = tree[path]
+
+    if tree._working_dir:
+        _relocate_files(value, path, new_path, tree._working_dir, copy=False)
+
     tree.set_quiet(new_path, value)
     # Delete the old key at the dict level to avoid a second changed push
     if parent_path:

--- a/pdv-python/pdv/handlers/tree.py
+++ b/pdv-python/pdv/handlers/tree.py
@@ -504,9 +504,134 @@ def handle_tree_rename(msg: dict) -> None:
     )
 
 
+def handle_tree_move(msg: dict) -> None:
+    """Handle ``pdv.tree.move`` — move a node to a new path in the tree.
+
+    Payload
+    -------
+    path : str
+        Dot-separated path of the node to move.
+    new_path : str
+        Full dot-separated destination path.
+    """
+    from pdv.comms import send_message, send_error, get_pdv_tree  # noqa: PLC0415
+
+    msg_id = msg.get("msg_id")
+    payload = msg.get("payload", {})
+    path = payload.get("path", "")
+    new_path = payload.get("new_path", "")
+
+    tree = get_pdv_tree()
+    if tree is None:
+        send_error(
+            "pdv.tree.move.response",
+            "tree.not_initialized",
+            "PDVTree is not initialized.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if not path:
+        send_error(
+            "pdv.tree.move.response",
+            "tree.invalid_path",
+            "Cannot move the root tree.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if not new_path:
+        send_error(
+            "pdv.tree.move.response",
+            "tree.invalid_path",
+            "Destination path must not be empty.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if path == new_path:
+        send_error(
+            "pdv.tree.move.response",
+            "tree.same_path",
+            "Source and destination are the same.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if path not in tree:
+        send_error(
+            "pdv.tree.move.response",
+            "tree.path_not_found",
+            f"No node at path: {path}",
+            in_reply_to=msg_id,
+        )
+        return
+
+    if new_path in tree:
+        send_error(
+            "pdv.tree.move.response",
+            "tree.already_exists",
+            f"A node already exists at path: {new_path}",
+            in_reply_to=msg_id,
+        )
+        return
+
+    # Prevent moving a node into its own subtree
+    if new_path.startswith(path + "."):
+        send_error(
+            "pdv.tree.move.response",
+            "tree.circular_move",
+            f"Cannot move '{path}' into its own subtree.",
+            in_reply_to=msg_id,
+        )
+        return
+
+    # Validate destination parent exists and is a container
+    new_parts = new_path.split(".")
+    if len(new_parts) > 1:
+        dest_parent = ".".join(new_parts[:-1])
+        if dest_parent not in tree:
+            send_error(
+                "pdv.tree.move.response",
+                "tree.path_not_found",
+                f"Destination parent does not exist: {dest_parent}",
+                in_reply_to=msg_id,
+            )
+            return
+        parent_val = tree[dest_parent]
+        if not isinstance(parent_val, dict):
+            send_error(
+                "pdv.tree.move.response",
+                "tree.not_a_container",
+                f"Destination parent '{dest_parent}' is not a container.",
+                in_reply_to=msg_id,
+            )
+            return
+
+    value = tree[path]
+    tree.set_quiet(new_path, value)
+
+    old_parts = path.split(".")
+    old_parent_path = ".".join(old_parts[:-1])
+    if old_parent_path:
+        old_parent = tree[old_parent_path]
+        dict.__delitem__(old_parent, old_parts[-1])
+    else:
+        dict.__delitem__(tree, old_parts[-1])
+
+    tree._emit_changed(path, "moved")
+
+    send_message(
+        "pdv.tree.move.response",
+        {"old_path": path, "new_path": new_path, "moved": True},
+        in_reply_to=msg_id,
+    )
+
+
 register("pdv.tree.list", handle_tree_list)
 register("pdv.tree.get", handle_tree_get)
 register("pdv.tree.resolve_file", handle_tree_resolve_file)
 register("pdv.tree.delete", handle_tree_delete)
 register("pdv.tree.create_node", handle_tree_create_node)
 register("pdv.tree.rename", handle_tree_rename)
+register("pdv.tree.move", handle_tree_move)

--- a/pdv-python/tests/test_tree_handlers.py
+++ b/pdv-python/tests/test_tree_handlers.py
@@ -1,0 +1,215 @@
+"""
+pdv-python/tests/test_tree_handlers.py — Unit tests for tree handler operations.
+
+Tests create_node, rename, move, and duplicate handlers via direct tree
+manipulation (same logic the handlers use), plus file relocation helpers.
+"""
+
+import os
+
+import pytest
+from pdv.tree import PDVTree, PDVScript, PDVNote
+
+
+class TestCreateNode:
+    """Tests for create_node semantics (empty dict insertion)."""
+
+    def test_create_at_root(self, tree_with_comm):
+        tree_with_comm["new_node"] = PDVTree()
+        assert "new_node" in tree_with_comm
+        assert isinstance(tree_with_comm["new_node"], PDVTree)
+
+    def test_create_nested(self, tree_with_comm):
+        tree_with_comm["parent"] = PDVTree()
+        tree_with_comm["parent.child"] = PDVTree()
+        assert "parent.child" in tree_with_comm
+
+    def test_create_rejects_existing(self, tree_with_comm):
+        tree_with_comm["exists"] = PDVTree()
+        assert "exists" in tree_with_comm
+
+
+class TestRename:
+    """Tests for rename semantics (re-key under same parent)."""
+
+    def test_rename_simple(self, tree_with_comm):
+        tree_with_comm["old"] = 42
+        value = tree_with_comm["old"]
+        tree_with_comm.set_quiet("new", value)
+        dict.__delitem__(tree_with_comm, "old")
+        assert "new" in tree_with_comm
+        assert "old" not in tree_with_comm
+        assert tree_with_comm["new"] == 42
+
+    def test_rename_nested(self, tree_with_comm):
+        tree_with_comm["parent.old_child"] = "data"
+        value = tree_with_comm["parent.old_child"]
+        tree_with_comm.set_quiet("parent.new_child", value)
+        parent = tree_with_comm["parent"]
+        dict.__delitem__(parent, "old_child")
+        assert "parent.new_child" in tree_with_comm
+        assert "parent.old_child" not in tree_with_comm
+
+    def test_rename_preserves_subtree(self, tree_with_comm):
+        tree_with_comm["a.b.c"] = 99
+        value = tree_with_comm["a.b"]
+        tree_with_comm.set_quiet("a.renamed", value)
+        parent = tree_with_comm["a"]
+        dict.__delitem__(parent, "b")
+        assert tree_with_comm["a.renamed.c"] == 99
+        assert "a.b" not in tree_with_comm
+
+
+class TestMove:
+    """Tests for move semantics (re-parent a node)."""
+
+    def test_move_simple(self, tree_with_comm):
+        tree_with_comm["source"] = 42
+        tree_with_comm["dest_parent"] = PDVTree()
+        value = tree_with_comm["source"]
+        tree_with_comm.set_quiet("dest_parent.moved", value)
+        dict.__delitem__(tree_with_comm, "source")
+        assert tree_with_comm["dest_parent.moved"] == 42
+        assert "source" not in tree_with_comm
+
+    def test_move_subtree(self, tree_with_comm):
+        tree_with_comm["a.b.c"] = "deep"
+        tree_with_comm["target"] = PDVTree()
+        value = tree_with_comm["a"]
+        tree_with_comm.set_quiet("target.a_moved", value)
+        dict.__delitem__(tree_with_comm, "a")
+        assert tree_with_comm["target.a_moved.b.c"] == "deep"
+        assert "a" not in tree_with_comm
+
+    def test_circular_move_detected(self, tree_with_comm):
+        tree_with_comm["a.b.c"] = 1
+        path = "a.b"
+        new_path = "a.b.c.inside"
+        assert new_path.startswith(path + ".")
+
+
+class TestDuplicate:
+    """Tests for duplicate semantics (deep copy)."""
+
+    def test_duplicate_value(self, tree_with_comm):
+        import copy
+        tree_with_comm["original"] = [1, 2, 3]
+        cloned = copy.deepcopy(tree_with_comm["original"])
+        tree_with_comm["copy"] = cloned
+        assert tree_with_comm["copy"] == [1, 2, 3]
+        tree_with_comm["original"].append(4)
+        assert tree_with_comm["copy"] == [1, 2, 3]
+
+    def test_duplicate_subtree(self, tree_with_comm):
+        import copy
+        subtree = {"b": 42, "c": [1, 2]}
+        tree_with_comm["a"] = subtree
+        cloned = copy.deepcopy(tree_with_comm["a"])
+        tree_with_comm["a_copy"] = cloned
+        assert tree_with_comm["a_copy"]["b"] == 42
+        subtree["b"] = 99
+        assert tree_with_comm["a_copy"]["b"] == 42
+
+
+class TestRelocateFiles:
+    """Tests for _relocate_files and _relocate_single_file."""
+
+    def test_relocate_single_file_moves(self, tmp_working_dir):
+        from pdv.handlers.tree import _relocate_single_file
+
+        tree_dir = os.path.join(tmp_working_dir, "tree")
+        os.makedirs(tree_dir)
+        old_path = os.path.join(tree_dir, "old_script.py")
+        with open(old_path, "w") as f:
+            f.write("# test")
+
+        script = PDVScript(relative_path="tree/old_script.py")
+        _relocate_single_file(script, "new_script", tmp_working_dir, copy=False)
+
+        assert script.relative_path == os.path.join("tree", "new_script.py")
+        new_abs = os.path.join(tmp_working_dir, "tree", "new_script.py")
+        assert os.path.exists(new_abs)
+        assert not os.path.exists(old_path)
+
+    def test_relocate_single_file_copies(self, tmp_working_dir):
+        from pdv.handlers.tree import _relocate_single_file
+
+        tree_dir = os.path.join(tmp_working_dir, "tree")
+        os.makedirs(tree_dir)
+        old_path = os.path.join(tree_dir, "src.py")
+        with open(old_path, "w") as f:
+            f.write("# test")
+
+        script = PDVScript(relative_path="tree/src.py")
+        _relocate_single_file(script, "dst", tmp_working_dir, copy=True)
+
+        assert os.path.exists(old_path)
+        new_abs = os.path.join(tmp_working_dir, "tree", "dst.py")
+        assert os.path.exists(new_abs)
+
+    def test_relocate_with_filename_override(self, tmp_working_dir):
+        from pdv.handlers.tree import _relocate_single_file
+
+        tree_dir = os.path.join(tmp_working_dir, "tree")
+        os.makedirs(tree_dir)
+        old_path = os.path.join(tree_dir, "old.py")
+        with open(old_path, "w") as f:
+            f.write("# test")
+
+        script = PDVScript(relative_path="tree/old.py")
+        _relocate_single_file(script, "new_key", tmp_working_dir,
+                              copy=False, filename="custom_name.py")
+
+        assert script.relative_path == os.path.join("tree", "custom_name.py")
+
+    def test_relocate_files_recursive(self, tmp_working_dir):
+        from pdv.handlers.tree import _relocate_files
+
+        tree_dir = os.path.join(tmp_working_dir, "tree", "parent")
+        os.makedirs(tree_dir)
+        script_path = os.path.join(tree_dir, "my_script.py")
+        with open(script_path, "w") as f:
+            f.write("# test")
+
+        container = PDVTree()
+        script = PDVScript(relative_path=os.path.join("tree", "parent", "my_script.py"))
+        dict.__setitem__(container, "my_script", script)
+
+        _relocate_files(container, "parent", "new_parent", tmp_working_dir, copy=False)
+        assert script.relative_path == os.path.join("tree", "new_parent", "my_script.py")
+
+    def test_relocate_rejects_non_pdvfile(self):
+        from pdv.handlers.tree import _relocate_single_file
+        with pytest.raises(TypeError, match="Expected PDVFile"):
+            _relocate_single_file("not_a_file", "path", "/tmp", copy=False)
+
+    def test_rename_relocates_backing_file(self, tmp_working_dir):
+        """Rename of a file-backed node should update its _relative_path."""
+        from pdv.handlers.tree import _relocate_files
+
+        tree_dir = os.path.join(tmp_working_dir, "tree")
+        os.makedirs(tree_dir)
+        old_file = os.path.join(tree_dir, "old_name.py")
+        with open(old_file, "w") as f:
+            f.write("# script")
+
+        script = PDVScript(relative_path="tree/old_name.py")
+        _relocate_files(script, "old_name", "new_name", tmp_working_dir, copy=False)
+
+        assert script.relative_path == os.path.join("tree", "new_name.py")
+        assert os.path.exists(os.path.join(tmp_working_dir, "tree", "new_name.py"))
+        assert not os.path.exists(old_file)
+
+    def test_note_relocation(self, tmp_working_dir):
+        from pdv.handlers.tree import _relocate_single_file
+
+        tree_dir = os.path.join(tmp_working_dir, "tree")
+        os.makedirs(tree_dir)
+        note_path = os.path.join(tree_dir, "my_note.md")
+        with open(note_path, "w") as f:
+            f.write("# Note")
+
+        note = PDVNote(relative_path="tree/my_note.md")
+        _relocate_single_file(note, "renamed_note", tmp_working_dir, copy=False)
+
+        assert note.relative_path == os.path.join("tree", "renamed_note.md")


### PR DESCRIPTION
## Summary

Adds four new tree operations to the context menu — **create node**, **rename**, **move**, and **duplicate** — wired end-to-end through Python handlers, comm protocol, main IPC, preload bridge, and renderer dialogs. Also refreshes the context menu UX with visual separators, "open in external editor" for notes, and removes the legacy `config.json` migration path.

### New tree operations
- **Create empty node** — inserts an empty `PDVTree()` dict container at any path
- **Rename** — re-keys a node under the same parent, relocating backing files
- **Move** — re-parents a node to a new dot-path, with file relocation and circular-move protection
- **Duplicate** — deep-copies a node (and its backing files) to a new path

### Context menu improvements
- Separators between action sections for visual clarity
- "Open in external editor" action for markdown/note nodes
- Type-specific rename labels ("Rename script", "Rename note", etc.)
- Refresh moved to bottom of menu

### Cleanup
- Removed legacy `config.json` → `preferences.json` migration (no longer needed)
- Removed unused `customKernels` from Config type
- Extracted `treeCommHandler` helper to reduce IPC boilerplate
- Extracted `useTreeAction` hook to reduce dialog callback boilerplate
- Extracted shared `FILE_BACKED_TYPES`/`defaultExtension` to `tree-file-utils.ts`

## Test plan

- [x] Python unit tests: 18 new tests covering tree operations and file relocation (`test_tree_handlers.py`)
- [x] TypeScript unit tests: updated context menu action tests (307 tests pass)
- [x] Full Python suite passes (308 tests, 2 skipped)
- [ ] Manual smoke test: right-click tree nodes, exercise create/rename/move/duplicate, verify file-backed nodes relocate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)