### PR TITLE
File UUID organization

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -3,7 +3,7 @@
 # Generates release-notes.md for a published release.
 #
 # Required environment variables:
-#   TAG       - the release tag (e.g. v0.0.11)
+#   TAG       - the release tag (e.g. v0.0.12)
 #   REPO      - "owner/repo"
 #   GH_TOKEN  - GitHub token with read access
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    name: Python tests (${{ matrix.python-version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +51,8 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install Python dependencies
         run: pip install ipykernel "pdv-python/[dev]"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,5 @@
 # PDV Architecture Document
-**Version**: 0.0.11
+**Version**: 0.0.12
 **Date**: 2026-04-07
 **Status**: Authoritative design specification. All new code must conform to this document. Deviations require updating this document first.
 
@@ -117,7 +117,7 @@ Every PDV message — whether sent by the app or by the kernel — has the follo
 
 ```json
 {
-  "pdv_version": "0.0.11",
+  "pdv_version": "0.0.12",
   "msg_id": "<uuid-v4>",
   "in_reply_to": "<uuid-v4-or-null>",
   "type": "<message-type-string>",
@@ -128,7 +128,7 @@ Every PDV message — whether sent by the app or by the kernel — has the follo
 
 | Field | Type | Description |
 |---|---|---|
-| `pdv_version` | string | App/package version (e.g. `"0.0.11"`). Both the Electron app and `pdv-python` use their installed version as this value. The app rejects messages with an incompatible major version. |
+| `pdv_version` | string | App/package version (e.g. `"0.0.12"`). Both the Electron app and `pdv-python` use their installed version as this value. The app rejects messages with an incompatible major version. |
 | `msg_id` | string | UUID v4. Unique identifier for this message. |
 | `in_reply_to` | string \| null | The `msg_id` of the request this is responding to. `null` for unsolicited push messages. |
 | `type` | string | Dot-namespaced message type (see Section 3.4). |
@@ -815,7 +815,7 @@ Each `modules/<id>/` subdirectory is maintained authoritatively by `project:save
 | `schema_version` | string | Semantic version of the project.json format. The app rejects manifests with an incompatible major version. Currently `"1.2"`. |
 | `project_id` | string | UUIDv4 assigned on first save under schema 1.2. Stable across renames and moves. Used by per-project environment bookkeeping (§10.5). 1.1 manifests without this field get one assigned on upgrade. |
 | `saved_at` | string | ISO 8601 timestamp of last save. |
-| `pdv_version` | string | PDV app version used when saving (e.g. `"0.0.11"`). |
+| `pdv_version` | string | PDV app version used when saving (e.g. `"0.0.12"`). |
 | `project_name` | string? | Optional human-readable project name chosen by the user. Displayed in the title bar and recent projects list. Falls back to the directory name when absent (backward compat). |
 | `language` | string | Kernel language: `"python"` or `"julia"`. |
 | `interpreter_path` | string? | Optional path to the interpreter used at save time. Used for pre-selection when `environment.mode == "shared"`; ignored when `environment.mode == "project"`. |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -606,14 +606,20 @@ A parameter is `required` if it has no default value. `type` is the string repre
 
 ### 5.8 PDVFile and PDVNote Classes
 
-`PDVFile` is a base class for tree nodes backed by on-disk files that are not data or scripts. `PDVNote` is its subclass for markdown notes.
+`PDVFile` is a base class for tree nodes backed by on-disk files that are not data or scripts. Subclasses include `PDVNote`, `PDVGui`, `PDVNamelist`, and `PDVLib`.
+
+**PDVFile** attributes (inherited by all subclasses):
+- `uuid`: 12-hex-character UUID identifying this node's storage directory (see §6.3)
+- `filename`: original filename including extension (e.g. `"fit.py"`, `"mesh.h5"`)
+- `source_rel_path`: optional path relative to the owning module's root (see §5.13); `None` for non-module files
+- `resolve_path(working_dir?)`: returns the absolute file path `<working_dir>/tree/<uuid>/<filename>`
 
 **PDVNote** attributes:
-- `relative_path`: path of the `.md` file relative to the working directory
+- `uuid`, `filename` (inherited from `PDVFile`)
 - `title`: optional display title
 - `preview()`: returns the title, or the first non-empty line of the file, or `"Markdown note"` as fallback
 
-Notes are created via `pdv.note.register` (app → kernel) which creates a `PDVNote` instance and attaches it to the tree. The `.md` file itself lives in `<workingDir>/tree/<path>/` and is read/written directly by the main process via `note:read` / `note:save` IPC channels — no kernel round-trip is needed for content editing. On project save, the kernel serializes the note entry to `tree-index.json` and the main process copies the `.md` file into the save directory. On project load, the `.md` file is copied back from the save directory to the working directory and re-registered as a `PDVNote` in the tree.
+Notes are created via `pdv.note.register` (app → kernel) which creates a `PDVNote` instance and attaches it to the tree. The `.md` file itself lives in `<workingDir>/tree/<uuid>/<filename>` and is read/written directly by the main process via `note:read` / `note:save` IPC channels — no kernel round-trip is needed for content editing. On project save, the kernel serializes the note entry to `tree-index.json` and the main process copies the `.md` file into the save directory. On project load, the `.md` file is copied back from the save directory to the working directory and re-registered as a `PDVNote` in the tree.
 
 ### 5.9 PDVModule Class
 
@@ -642,7 +648,7 @@ Projects track in-session modules via an `origin: "in_session"` field on the `Pr
 `PDVGui` is a subclass of `PDVFile`. It represents a GUI definition file (`.gui.json`) that describes a module's user interface — inputs, actions, and layout.
 
 Attributes:
-- `relative_path` (inherited from `PDVFile`): path to the `.gui.json` file relative to the working directory
+- `uuid`, `filename` (inherited from `PDVFile`): UUID-based storage identity (§6.3)
 - `module_id` (read-only): the owning module's ID, or `None` for standalone project GUIs
 
 `preview()` returns `"GUI"`.
@@ -654,7 +660,7 @@ Created by the `pdv.gui.register` handler. For module GUIs, the `.gui.json` file
 `PDVNamelist` is a subclass of `PDVFile`. It represents a simulation namelist file that can be parsed and edited through the namelist editor widget.
 
 Attributes:
-- `relative_path` (inherited from `PDVFile`): path to the namelist file relative to the working directory
+- `uuid`, `filename` (inherited from `PDVFile`): UUID-based storage identity (§6.3)
 - `format` (read-only): one of `"fortran"`, `"toml"`, or `"auto"` (auto-detected from file content)
 - `module_id` (read-only): the owning module's ID, or `None` for standalone namelists
 
@@ -667,18 +673,18 @@ The namelist file is parsed and written by dedicated comm handlers (`pdv.namelis
 `PDVLib` is a subclass of `PDVFile`. It represents a Python library file provided by a module's `lib/` directory that is importable by scripts and entry points.
 
 Attributes:
-- `relative_path` (inherited from `PDVFile`): path to the `.py` file relative to the working directory
+- `uuid`, `filename` (inherited from `PDVFile`): UUID-based storage identity (§6.3)
 - `source_rel_path` (inherited from `PDVFile`): path relative to the owning module's root, e.g. `"lib/helpers.py"`. Set for module-owned libs; `None` for project-level libs. Used by §5.13's save-time sync.
 - `module_id` (read-only): the owning module's ID, or `None`
 
 `preview()` returns `"Library (<filename>)"`.
 
 **Module lib/ convention**: Module developers place importable `.py` files in `<module-root>/lib/`. When a v4 module is imported into a project, the main process:
-1. Reads `module-index.json` and copies each `local_file`-backed entry (including libs under `lib/`) into the working directory under `<alias>/<relative_path>`.
-2. Sends `pdv.module.register` with the remapped `module_index` so the kernel reconstructs the subtree and creates `PDVLib` nodes via `load_tree_index`.
-3. Sends `pdv.modules.setup` with `lib_dir: "<workdir>/<alias>/lib"`. The kernel adds that directory to `sys.path` so scripts can `import helpers` etc.
+1. Reads `module-index.json`, assigns each file-backed entry a fresh UUID, and copies each file into the working directory under `tree/<uuid>/<filename>`.
+2. Sends `pdv.module.register` with the remapped `module_index` (carrying UUIDs) so the kernel reconstructs the subtree and creates `PDVLib` nodes via `load_tree_index`.
+3. Sends `pdv.modules.setup`. The kernel walks each `PDVModule` subtree, collects the parent directory of every `PDVLib` descendant (`<workdir>/tree/<uuid>/`), and adds each to `sys.path` so scripts can `import helpers` etc.
 
-In-session modules (workflow B) follow the same convention: `tree:createLib` writes new `.py` files under `<workdir>/<alias>/lib/`, sets `source_rel_path = "lib/<filename>"`, and §7's `pdv-module.json` writer stamps `lib_dir: "lib"` so the next project load's `setupModuleNamespaces` injects the path automatically.
+In-session modules (workflow B) follow the same convention: `tree:createLib` writes new `.py` files under `<workdir>/tree/<uuid>/<filename>`, sets `source_rel_path = "lib/<filename>"`, and §7's `pdv-module.json` writer stamps `lib_dir: "lib"` so the next project load's `setupModuleNamespaces` injects the path automatically.
 
 **Live lib reload**: Before every `script:run` on a module-owned script, the main process fires a `pdv.module.reload_libs` preflight (§3.4). The kernel walks `sys.modules`, finds modules whose `__file__` sits under `<workdir>/<alias>/lib/`, and `importlib.reload()`s them so edits take effect without restarting the kernel. Reload failures are captured per-module and never block the script run itself — broken libs surface at import time inside the user's own traceback. The handler uses `os.path.realpath` on both sides of the prefix comparison so macOS's `/var` → `/private/var` symlink doesn't defeat the path match.
 
@@ -729,16 +735,20 @@ The working directory is a temporary directory created by the Electron main proc
 
 **Creation**: The main process calls `fs.mkdtemp()` (or equivalent) to create a uniquely named directory in the OS temporary directory. The path is passed to the kernel in the `pdv.init` message.
 
-**Structure**:
+**Structure** (UUID-based — see §6.3):
 ```
 /tmp/pdv-<uuid>/
     tree/
-        data/         ← data files written during the session (npy, parquet, etc.)
-        scripts/      ← script .py files for the current session
-        results/      ← result files produced by scripts
+        a1b2c3d4e5f6/     ← each file-backed node gets its own UUID directory
+            fit_model.py
+        f7e8d9c0b1a2/
+            ch1.npy
+        ...
     .pdv-work/
         autosave/     ← reserved for future autosave feature
 ```
+
+File-backed tree nodes (scripts, notes, GUIs, namelists, libs, data files) each get a unique 12-hex-character UUID directory under `tree/`. The tree path is decoupled from the filesystem path — renaming or moving a tree node does not require renaming or copying files on disk. See §6.3 for the full UUID storage design.
 
 **Lifecycle**: Created at kernel startup. Deleted on clean shutdown. If the app crashes, the directory is left on disk but is not recovered (crash recovery is out of scope for alpha).
 
@@ -750,7 +760,7 @@ A persistent, user-chosen directory that stores a complete saved snapshot of a P
 
 **Created when**: The user explicitly performs File → Save Project (or Save As). Never created automatically.
 
-**Structure** (human-readable, mirrors tree hierarchy):
+**Structure** (UUID-based — see §6.3):
 ```
 my-project/
     project.json              ← project manifest (owned by Electron main process)
@@ -768,15 +778,14 @@ my-project/
             lib/
                 n_pendulum.py
             gui.json
-    tree/
-        data/
-            waveforms/
-                ch1.npy
-                ch2.npy
-        scripts/
-            analysis/
-                fit_model.py
-        results/
+    tree/                     ← UUID-indexed file storage (§6.3)
+        a1b2c3d4e5f6/
+            ch1.npy
+        b2c3d4e5f6a7/
+            ch2.npy
+        c3d4e5f6a7b8/
+            fit_model.py
+        d4e5f6a7b8c9/
             fit_output.parquet
 ```
 
@@ -831,7 +840,28 @@ Each `modules/<id>/` subdirectory is maintained authoritatively by `project:save
 
 **`code-cells.json` schema**: Written by the Electron main process during save. Contains tab code and active tab ID.
 
-### 6.3 Lazy Loading from Save to Working Directory
+### 6.3 UUID-Based File Storage
+
+All file-backed tree nodes use UUID-based paths, decoupling the tree hierarchy from the filesystem layout. This is the single most important storage invariant in the codebase.
+
+**Design**: Each file-backed node (scripts, notes, GUIs, namelists, libs, data files) receives a 12-hex-character UUID at creation time. The backing file lives at `<dir>/tree/<uuid>/<filename>`, where `<dir>` is the working directory during a session or the save directory on disk.
+
+**Why UUIDs**: Tree operations (rename, move) become O(1) metadata updates — no file copies or renames on disk. Duplicate is the only tree mutation that creates a new file (with a fresh UUID). This eliminates a class of bugs around path escaping, collision, and stale references that plagued the earlier path-mirroring design.
+
+**UUID generation**: `generate_node_uuid()` in `environment.py` produces a 12-character hex string from UUID4. Short enough to be human-glanceable in logs and directory listings.
+
+**Path resolution**: `PDVFile.resolve_path(working_dir)` computes `<working_dir>/tree/<uuid>/<filename>`. The `uuid_tree_path()` helper in `environment.py` does the same for non-PDVFile data nodes during serialization.
+
+**File copying**: All file copy operations in the Python kernel use `smart_copy()` (in `environment.py`), which attempts copy-on-write cloning before falling back to a regular copy:
+1. Python 3.14+ `pathlib.Path.copy()` — OS-level CoW on APFS, btrfs, XFS, ZFS
+2. `reflink_copy.reflink_or_copy()` — optional dependency (`pip install pdv-python[copy]`), Rust-backed
+3. `shutil.copy2()` — universal fallback
+
+**Orphan cleanup**: Data nodes (ndarray, DataFrame, custom-serialized objects, pickle) receive a fresh UUID on every save because the in-memory value has no stable identity. After writing `tree-index.json`, the save handler purges any `tree/<uuid>/` directories not referenced in the new index. File-backed PDV nodes (scripts, notes, libs, etc.) reuse their UUID across saves and are never purged.
+
+**Invariant**: Every file under `tree/` must have a corresponding entry in `tree-index.json`. Files without an index entry are orphans and may be deleted. The kernel never traverses the `tree/` directory at load time — it reads `tree-index.json` and uses UUIDs to locate files.
+
+### 6.4 Lazy Loading from Save to Working Directory
 
 When a user accesses a tree node whose data is in the save directory but not yet in the working directory, the kernel:
 1. Reads the appropriate file from the save directory
@@ -842,7 +872,7 @@ When a user accesses a tree node whose data is in the save directory but not yet
 
 Files are only written to the working directory when data is newly created or modified in the current session.
 
-### 6.4 User Preferences Directory (`~/.PDV`)
+### 6.5 User Preferences Directory (`~/.PDV`)
 
 Renderer-facing preferences and UI persistence are stored in a dedicated user
 directory managed by the main process:
@@ -969,8 +999,8 @@ Each node in `tree-index.json` is produced by `serialization.serialize_node()`. 
 | `storage` | object | Describes where the data lives. See below. |
 | `metadata` | object | Type-specific metadata. Always contains at least `"preview"`. |
 
-**Storage object** — one of two backends:
-- File-backed: `{ "backend": "local_file", "relative_path": "tree/.../file.ext", "format": "<format>" }`
+**Storage object** — one of three backends:
+- File-backed: `{ "backend": "local_file", "uuid": "<12-hex-uuid>", "filename": "<name.ext>", "format": "<format>" }` — file lives at `tree/<uuid>/<filename>` (§6.3)
 - Inline: `{ "backend": "inline", "format": "<format>", "value": <json-value> }`
 - Folder: `{ "backend": "none", "format": "none" }`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,3 +108,21 @@ Every `.ts` file in `electron/main/` must have:
 - A JSDoc file header describing purpose, responsibilities, and what the file does NOT do
 - JSDoc on every exported function and class with `@param`, `@returns`, `@throws`
 - No unguarded `any` types
+
+---
+
+## PR Review Checklist
+
+When reviewing a pull request (including via `/review`), check every item below in addition to standard code-quality review:
+
+- [ ] **IPC single source of truth** — All IPC channel names and types are defined in `ipc.ts`. No new strings introduced in preload, index.ts, or renderer code.
+- [ ] **Process boundary respected** — Renderer imports types from `types/pdv.d.ts`, never from `../../main/ipc`. Renderer never accesses Node.js APIs or the filesystem directly.
+- [ ] **No tree state caching in main** — The main process does not cache or duplicate tree data. The kernel's `PDVTree` remains the sole authority.
+- [ ] **Script execution path** — No Python or Julia code strings in the renderer. Script execution goes through `window.pdv.script.run()`.
+- [ ] **Theme CSS variables** — No hardcoded hex colors (`#fff`, `#007acc`) or `rgb(...)` literals. All colors use `var(--token)` from `themes.ts`. New tokens added to `themes.ts` with per-theme values if needed.
+- [ ] **Preload bridge completeness** — Any new IPC channel exposed to the renderer has a corresponding method in `preload.ts` under `window.pdv`.
+- [ ] **Comm protocol consistency** — New or changed comm messages between main and kernel follow the `pdv.*` protocol defined in `pdv-protocol.ts`.
+- [ ] **Script signature** — New or modified PDV scripts define `run(pdv_tree: dict, **user_params) -> dict`.
+- [ ] **Version parity** — If either `electron/package.json` or `pdv-python/pyproject.toml` version was bumped, both were bumped to the same value.
+- [ ] **JSDoc coverage** — New or modified exports in `electron/main/` have JSDoc with `@param`, `@returns`, `@throws`. No unguarded `any` types introduced.
+- [ ] **Documentation updated** — If the PR changes architecture, adds new IPC channels, modifies the comm protocol, introduces new tree node types, or alters any behavior described in `ARCHITECTURE.md` or `PLANNED_FEATURES.md`, those documents have been updated to match.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A desktop environment for computational and experimental physics analysis. PDV combines a tabbed code editor, an execution console, and a persistent, typed data hierarchy, the **Tree**, that lives inside a language kernel. The Tree is what separates PDV from a Jupyter notebook: it is a navigable, save/load-able data structure that persists across sessions, giving you structured data management and reproducible analysis workflows.
 
-**Status**: Alpha (`v0.0.11`) — under active development.
+**Status**: Alpha (`v0.0.12`) — under active development.
 
 ![PDV screenshot](docs/assets/screenshot.png)
 

--- a/electron/main/auto-updater.ts
+++ b/electron/main/auto-updater.ts
@@ -124,7 +124,7 @@ export function initAutoUpdater(win: BrowserWindow, configStore: ConfigStore): v
   autoUpdater.autoDownload = false;
   // Install on quit so the next launch uses the new version.
   autoUpdater.autoInstallOnAppQuit = true;
-  // Include prerelease tags (e.g. v0.0.11-alpha1) since the app is still in alpha.
+  // Include prerelease tags (e.g. v0.0.12-alpha1) since the app is still in alpha.
   autoUpdater.allowPrerelease = true;
 
   // -- Event wiring ----------------------------------------------------------

--- a/electron/main/comm-router.ts
+++ b/electron/main/comm-router.ts
@@ -284,6 +284,7 @@ export class CommRouter {
     return new Promise<PDVMessage>((resolve, reject) => {
       const createTimer = (): ReturnType<typeof setTimeout> =>
         setTimeout(() => {
+          console.error(`[CommRouter] TIMEOUT type=${type} msg_id=${msgId} after ${timeoutMs}ms (pending: ${this.pending.size})`);
           if (keepAliveHandler) this.offPush(keepAlivePushType!, keepAliveHandler);
           this.pending.delete(msgId);
           reject(new PDVCommTimeoutError(`PDV request timed out: ${type}`, type));

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -1385,19 +1385,8 @@ describe("Step 5 IPC handlers", () => {
 
     expect(result.success).toBe(true);
     expect(result.alias).toBe("toy");
-    // Working-dir scaffolding created for scripts/lib/plots.
-    expect(mocks.fsMkdir).toHaveBeenCalledWith(
-      expect.stringMatching(/toy\/scripts$/),
-      { recursive: true },
-    );
-    expect(mocks.fsMkdir).toHaveBeenCalledWith(
-      expect.stringMatching(/toy\/lib$/),
-      { recursive: true },
-    );
-    expect(mocks.fsMkdir).toHaveBeenCalledWith(
-      expect.stringMatching(/toy\/plots$/),
-      { recursive: true },
-    );
+    // No alias-based scaffolding — UUID dirs are created when individual
+    // nodes (scripts, libs, etc.) are added via tree:create* handlers.
     expect(commRouter.request).toHaveBeenCalledWith(
       PDVMessageType.MODULE_CREATE_EMPTY,
       expect.objectContaining({

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -308,6 +308,7 @@ function setup() {
     }),
     createWorkingDir: vi.fn(async () => "/tmp/pdv-test"),
     deleteWorkingDir: vi.fn(async () => undefined),
+    clearCachedKernelResults: vi.fn(),
   } as unknown as ProjectManager;
 
   const configState: PDVConfig = {

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -841,7 +841,8 @@ describe("Step 5 IPC handlers", () => {
       expect.objectContaining({
         parent_path: "scripts",
         name: "analysis",
-        relative_path: expect.stringMatching(/analysis\.py$/),
+        uuid: expect.stringMatching(/^[0-9a-f]{12}$/),
+        filename: "analysis.py",
         language: "python",
       })
     );
@@ -877,7 +878,8 @@ describe("Step 5 IPC handlers", () => {
         name: "hello",
         module_id: "toy",
         source_rel_path: "scripts/hello.py",
-        relative_path: expect.stringMatching(/toy\/scripts\/hello\.py$/),
+        uuid: expect.stringMatching(/^[0-9a-f]{12}$/),
+        filename: "hello.py",
       }),
     );
   });
@@ -903,7 +905,7 @@ describe("Step 5 IPC handlers", () => {
     };
 
     expect(result.success).toBe(true);
-    expect(result.libPath).toMatch(/toy\/lib\/helpers\.py$/);
+    expect(result.libPath).toMatch(/helpers\.py$/);
     expect(result.treePath).toBe("toy.lib.helpers");
 
     const fileRegisterCalls = (commRouter.request as unknown as ReturnType<typeof vi.fn>).mock.calls
@@ -914,6 +916,7 @@ describe("Step 5 IPC handlers", () => {
       expect.objectContaining({
         tree_path: "toy.lib",
         filename: "helpers.py",
+        uuid: expect.stringMatching(/^[0-9a-f]{12}$/),
         node_type: "lib",
         module_id: "toy",
         source_rel_path: "lib/helpers.py",
@@ -952,7 +955,8 @@ describe("Step 5 IPC handlers", () => {
       expect.objectContaining({
         parent_path: "notes",
         name: "derivation",
-        relative_path: expect.stringMatching(/derivation\.md$/),
+        uuid: expect.stringMatching(/^[0-9a-f]{12}$/),
+        filename: "derivation.md",
       })
     );
     expect(result.success).toBe(true);
@@ -1331,12 +1335,11 @@ describe("Step 5 IPC handlers", () => {
         module_index: expect.arrayContaining([
           expect.objectContaining({
             id: "scripts.run",
-            // Option A: module-owned files live under
-            // <workdir>/tree/<alias>/<src_rel_path> so the stored
-            // relative_path gains the canonical ``tree/`` prefix.
+            uuid: expect.stringMatching(/^[0-9a-f]{12}$/),
             storage: expect.objectContaining({
               backend: "local_file",
-              relative_path: path.join("tree", "demo-module", "scripts/run.py"),
+              uuid: expect.stringMatching(/^[0-9a-f]{12}$/),
+              filename: "run.py",
             }),
           }),
         ]),

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -615,7 +615,8 @@ describe("Step 5 IPC handlers", () => {
     const { commRouter, webContentsSend } = setup();
     registerCommPushForwarding(
       { webContents: { send: webContentsSend } } as unknown as BrowserWindow,
-      commRouter
+      commRouter,
+      { cacheKernelSaveResults: vi.fn() } as unknown as ProjectManager,
     );
 
     const onPushCalls = (commRouter.onPush as unknown as ReturnType<typeof vi.fn>)

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -495,13 +495,16 @@ describe("Step 5 IPC handlers", () => {
   });
 
   it("script:edit spawns the configured external editor process", async () => {
-    const { configStore } = setup();
+    const { configStore, commRouter } = setup();
     (configStore.getAll as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       showPrivateVariables: false,
       showModuleVariables: false,
       showCallableVariables: false,
       editorCommand: "code",
     });
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      { payload: { path: "/tmp/script.py", file_path: "/tmp/script.py" } }
+    );
 
     const edit = getHandler(IPC.script.edit);
     await edit({}, "kernel-1", "/tmp/script.py");
@@ -518,13 +521,16 @@ describe("Step 5 IPC handlers", () => {
 
   if (process.platform === "darwin") {
     it("script:edit launches terminal editors through Terminal.app on macOS", async () => {
-      const { configStore } = setup();
+      const { configStore, commRouter } = setup();
       (configStore.getAll as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
         showPrivateVariables: false,
         showModuleVariables: false,
         showCallableVariables: false,
         pythonEditorCmd: "nvim {}",
       });
+      (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+        { payload: { path: "/tmp/script.py", file_path: "/tmp/script.py" } }
+      );
 
       const edit = getHandler(IPC.script.edit);
       await edit({}, "kernel-1", "/tmp/script.py");

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -281,31 +281,6 @@ function sanitizeScriptName(scriptName: string, language: "python" | "julia" = "
   return withExt.replace(/[\\/]/g, "_");
 }
 
-function resolveScriptPath(
-  kernelId: string,
-  scriptPath: string,
-  kernelWorkingDirs: Map<string, string>,
-  language: "python" | "julia" = "python"
-): string {
-  if (path.isAbsolute(scriptPath)) {
-    return scriptPath;
-  }
-  const workingDir = kernelWorkingDirs.get(kernelId);
-  if (!workingDir) {
-    throw new Error(`Kernel working directory not initialized: ${kernelId}`);
-  }
-  if (scriptPath.includes("/") || scriptPath.includes("\\")) {
-    return path.join(workingDir, scriptPath);
-  }
-  const parts = scriptPath.split(".").filter(Boolean);
-  if (parts.length === 0) {
-    throw new Error("Invalid script path");
-  }
-  const ext = language === "julia" ? ".jl" : ".py";
-  const leaf = parts[parts.length - 1];
-  return path.join(workingDir, ...parts.slice(0, -1), `${leaf}${ext}`);
-}
-
 /**
  * Write a script stub if the file does not already exist.
  *
@@ -580,7 +555,6 @@ export function registerIpcHandlers(
     sanitizeScriptName,
     ensureScriptFile,
     ensureLibFile,
-    resolveScriptPath,
     buildEditorSpawn,
     resolveEditorSpawn,
   });

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -33,7 +33,7 @@ import { ModuleManager } from "./module-manager";
 import {
   bindProjectModulesToTree,
 } from "./module-runtime";
-import { ProjectManager, type ProjectModuleImport } from "./project-manager";
+import { ProjectManager, type ProjectModuleImport, type ModuleOwnedFile, type ModuleManifestBundle } from "./project-manager";
 import { ConfigStore } from "./config";
 import { registerAppStateIpcHandlers } from "./ipc-register-app-state";
 import { registerGuiEditorIpcHandlers } from "./ipc-register-gui-editor";
@@ -629,7 +629,7 @@ export function registerIpcHandlers(
 
   registerEnvironmentIpcHandlers(win, configStore);
 
-  registerCommPushForwarding(win, commRouter, moduleWindowManager, guiEditorWindowManager, guiViewerWindowManager);
+  registerCommPushForwarding(win, commRouter, projectManager, moduleWindowManager, guiEditorWindowManager, guiViewerWindowManager);
 
   /**
    * Reset all in-session state. Called whenever the renderer reloads so that
@@ -707,6 +707,7 @@ function registerEnvironmentIpcHandlers(win: BrowserWindow, configStore: ConfigS
 export function registerCommPushForwarding(
   win: BrowserWindow,
   commRouter: CommRouter,
+  projectManager: ProjectManager,
   moduleWindowManager?: ModuleWindowManager,
   guiEditorWindowManager?: GuiEditorWindowManager,
   guiViewerWindowManager?: GuiViewerWindowManager
@@ -737,6 +738,7 @@ export function registerCommPushForwarding(
   ): void => {
     const handler = (msg: PDVMessage): void => {
       const payload = msg.payload as { save_dir?: string };
+      console.log(`[forwardAsMenuAction] received push ${type} → forwarding as ${action} (path=${payload.save_dir ?? "none"})`);
       win.webContents.send(IPC.push.menuAction, { action, path: payload.save_dir });
     };
     commRouter.onPush(type, handler);
@@ -745,6 +747,31 @@ export function registerCommPushForwarding(
   forwardAsMenuAction(PDVMessageType.PROJECT_SAVE_REQUEST, "project:save");
   forwardAsMenuAction(PDVMessageType.PROJECT_SAVE_AS_REQUEST, "project:saveAs");
   forwardAsMenuAction(PDVMessageType.PROJECT_OPEN_REQUEST, "project:openRecent");
+
+  // Kernel-initiated save (pdv.save_project()) — tree is already serialized.
+  // Cache the results so ProjectManager.save() skips the comm round-trip
+  // (which would deadlock while the kernel shell is still executing user code).
+  {
+    const handler = (msg: PDVMessage): void => {
+      const payload = msg.payload as Record<string, unknown>;
+      const saveDir = payload.save_dir as string | undefined;
+      if (!saveDir) return;
+      console.log(`[save_completed] kernel serialized tree to ${saveDir}, caching results`);
+      projectManager.cacheKernelSaveResults(saveDir, {
+        checksum: (payload.checksum as string) ?? "",
+        nodeCount: (payload.node_count as number) ?? 0,
+        moduleOwnedFiles: Array.isArray(payload.module_owned_files)
+          ? (payload.module_owned_files as unknown as ModuleOwnedFile[])
+          : [],
+        moduleManifests: Array.isArray(payload.module_manifests)
+          ? (payload.module_manifests as unknown as ModuleManifestBundle[])
+          : [],
+      });
+      win.webContents.send(IPC.push.menuAction, { action: "project:save", path: saveDir });
+    };
+    commRouter.onPush(PDVMessageType.PROJECT_SAVE_COMPLETED, handler);
+    pushSubscriptions.push({ commRouter, type: PDVMessageType.PROJECT_SAVE_COMPLETED, handler });
+  }
 }
 
 /**

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -753,6 +753,24 @@ export function registerCommPushForwarding(
   subscribe(PDVMessageType.TREE_CHANGED, IPC.push.treeChanged, true);
   subscribe(PDVMessageType.PROJECT_LOADED, IPC.push.projectLoaded);
   subscribe(PDVMessageType.PROGRESS, IPC.push.progress);
+
+  // Kernel-initiated project operations — forward as menu actions so the
+  // renderer drives the full save/load workflow (including code-cell
+  // serialization and UI state updates).
+  const forwardAsMenuAction = (
+    type: string,
+    action: "project:save" | "project:saveAs" | "project:openRecent",
+  ): void => {
+    const handler = (msg: PDVMessage): void => {
+      const payload = msg.payload as { save_dir?: string };
+      win.webContents.send(IPC.push.menuAction, { action, path: payload.save_dir });
+    };
+    commRouter.onPush(type, handler);
+    pushSubscriptions.push({ commRouter, type, handler });
+  };
+  forwardAsMenuAction(PDVMessageType.PROJECT_SAVE_REQUEST, "project:save");
+  forwardAsMenuAction(PDVMessageType.PROJECT_SAVE_AS_REQUEST, "project:saveAs");
+  forwardAsMenuAction(PDVMessageType.PROJECT_OPEN_REQUEST, "project:openRecent");
 }
 
 /**

--- a/electron/main/integration.test.ts
+++ b/electron/main/integration.test.ts
@@ -4,6 +4,7 @@
  * @slow — Spawns a real Python kernel and verifies PDV comm traffic.
  */
 
+import { randomUUID } from "crypto";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as fs from "fs/promises";
 import * as os from "os";
@@ -11,6 +12,10 @@ import * as path from "path";
 import { KernelManager } from "./kernel-manager";
 import { CommRouter } from "./comm-router";
 import { PDVMessage, PDVMessageType, getAppVersion, setAppVersion } from "./pdv-protocol";
+
+function generateNodeUuid(): string {
+  return randomUUID().replace(/-/g, "").slice(0, 12);
+}
 
 const PYTHON_PACKAGE_DIR = path.resolve(__dirname, "../../pdv-python");
 const TEST_PYTHON_EXECUTABLE = process.env.PYTHON_PATH ?? "python3";
@@ -309,11 +314,11 @@ describe("@slow Cross-boundary integration (Python + Electron)", { timeout: 120_
   });
 
   it("send pdv.script.register -> script node appears and tree.changed is pushed", async () => {
-    const scriptsDir = await fs.mkdtemp(path.join(os.tmpdir(), "pdv-int-script-"));
-    tempDirs.push(scriptsDir);
-    const scriptPath = path.join(scriptsDir, "fit_model.py");
+    const nodeUuid = generateNodeUuid();
+    const scriptDir = path.join(initialWorkingDir, "tree", nodeUuid);
+    await fs.mkdir(scriptDir, { recursive: true });
     await fs.writeFile(
-      scriptPath,
+      path.join(scriptDir, "fit_model.py"),
       "def run(pdv_tree: dict, x: int = 1):\n    return {'x2': x * 2}\n",
       "utf8"
     );
@@ -322,7 +327,8 @@ describe("@slow Cross-boundary integration (Python + Electron)", { timeout: 120_
     const response = await router.request(PDVMessageType.SCRIPT_REGISTER, {
       parent_path: "scripts.analysis",
       name: "fit_model",
-      relative_path: scriptPath,
+      uuid: nodeUuid,
+      filename: "fit_model.py",
       language: "python",
     });
     expect(response.status).toBe("ok");
@@ -345,12 +351,13 @@ describe("@slow Cross-boundary integration (Python + Electron)", { timeout: 120_
     expect(scriptNode?.type).toBe("script");
   });
 
-  it("pdv.script.params returns params on demand for relative-path scripts", async () => {
-    // Write a script with parameters into the working directory
-    const scriptRelDir = path.join(initialWorkingDir, "scripts");
-    await fs.mkdir(scriptRelDir, { recursive: true });
+  const solveUuid = generateNodeUuid();
+
+  it("pdv.script.params returns params on demand for UUID-based scripts", async () => {
+    const solveDir = path.join(initialWorkingDir, "tree", solveUuid);
+    await fs.mkdir(solveDir, { recursive: true });
     await fs.writeFile(
-      path.join(scriptRelDir, "solve.py"),
+      path.join(solveDir, "solve.py"),
       [
         "def run(pdv_tree: dict, n: int = 3, dt: float = 0.01, method: str = 'rk4'):",
         "    return {'result': n}",
@@ -359,12 +366,12 @@ describe("@slow Cross-boundary integration (Python + Electron)", { timeout: 120_
       "utf8"
     );
 
-    // Register the script with a relative path (relative to working_dir)
     const changedPromise = waitForPush(router, PDVMessageType.TREE_CHANGED);
     const response = await router.request(PDVMessageType.SCRIPT_REGISTER, {
       parent_path: "scripts",
       name: "solve",
-      relative_path: "scripts/solve.py",
+      uuid: solveUuid,
+      filename: "solve.py",
       language: "python",
     });
     expect(response.status).toBe("ok");
@@ -390,7 +397,7 @@ describe("@slow Cross-boundary integration (Python + Electron)", { timeout: 120_
 
   it("pdv.script.params reflects file edits without re-registering", async () => {
     // The script from the previous test already exists — edit it to add a param
-    const scriptPath = path.join(initialWorkingDir, "scripts", "solve.py");
+    const scriptPath = path.join(initialWorkingDir, "tree", solveUuid, "solve.py");
     await fs.writeFile(
       scriptPath,
       [

--- a/electron/main/integration.test.ts
+++ b/electron/main/integration.test.ts
@@ -4,18 +4,13 @@
  * @slow — Spawns a real Python kernel and verifies PDV comm traffic.
  */
 
-import { randomUUID } from "crypto";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { KernelManager } from "./kernel-manager";
 import { CommRouter } from "./comm-router";
-import { PDVMessage, PDVMessageType, getAppVersion, setAppVersion } from "./pdv-protocol";
-
-function generateNodeUuid(): string {
-  return randomUUID().replace(/-/g, "").slice(0, 12);
-}
+import { PDVMessage, PDVMessageType, generateNodeUuid, getAppVersion, setAppVersion } from "./pdv-protocol";
 
 const PYTHON_PACKAGE_DIR = path.resolve(__dirname, "../../pdv-python");
 const TEST_PYTHON_EXECUTABLE = process.env.PYTHON_PATH ?? "python3";

--- a/electron/main/ipc-register-kernels.ts
+++ b/electron/main/ipc-register-kernels.ts
@@ -207,6 +207,7 @@ export function registerKernelIpcHandlers(
     startMutex = new Promise<void>((r) => { release = r; });
     try {
       await cleanupKernelWorkingDir(projectManager, kernelManager, kernelId, kernelWorkingDirs, crashHandlers);
+      projectManager.clearCachedKernelResults();
       await kernelManager.stop(kernelId);
       if (getActiveKernelId() === kernelId) {
         setActiveKernelId(null);

--- a/electron/main/ipc-register-modules.ts
+++ b/electron/main/ipc-register-modules.ts
@@ -280,22 +280,6 @@ export function registerModulesIpcHandlers(
           error: "No running kernel — start one before creating a module.",
         };
       }
-      const workingDir = kernelWorkingDirs.get(activeKernelId);
-
-      // Seed working-dir scaffolding under the canonical
-      // ``<workdir>/tree/<alias>/{scripts,lib,plots}/`` layout so
-      // subsequent ``tree:createScript`` / ``tree:createLib`` hits land
-      // at paths that match where ``bindImportedModule`` would have
-      // placed an imported v4 module's files — see the Option A
-      // canonical-layout fix and ARCHITECTURE.md §6.1/§6.2.
-      if (workingDir) {
-        for (const child of ["scripts", "lib", "plots"]) {
-          await fs.mkdir(path.join(workingDir, "tree", baseAlias, child), {
-            recursive: true,
-          });
-        }
-      }
-
       const language =
         request.language ??
         (activeManifest?.language as "python" | "julia" | undefined) ??

--- a/electron/main/ipc-register-project.ts
+++ b/electron/main/ipc-register-project.ts
@@ -239,73 +239,81 @@ export function registerProjectIpcHandlers(
     getInterpreterPath,
   } = options;
 
+  // Serialize concurrent saves so a rapid second call waits for the first to
+  // finish rather than racing on the filesystem and kernel shell channel.
+  let activeSave: Promise<unknown> = Promise.resolve();
+  let saveSeq = 0;
+
   ipcMain.handle(
     IPC.project.save,
     async (_event, saveDir: string, codeCells: unknown, projectName?: string) => {
-      // Validate at the IPC boundary so the error path is reported to the
-      // renderer with a clean stack, rather than a mid-save filesystem error.
       assertCodeCellData(codeCells);
-      const saveResult = await projectManager.save(saveDir, codeCells, {
-        language: getActiveKernelLanguage(),
-        interpreterPath: getInterpreterPath(),
-        projectName,
-      });
+      const seq = ++saveSeq;
+      console.log(`[project:save] IPC received seq=${seq} saveDir=${saveDir}`);
 
-      // Merge pending in-memory module imports/settings into the on-disk manifest.
-      const pendingModuleImports = getPendingModuleImports();
-      const pendingModuleSettings = getPendingModuleSettings();
-      if (pendingModuleImports.length > 0 || Object.keys(pendingModuleSettings).length > 0) {
-        // Copy pending module contents into the project-local modules directory.
-        for (const pendingModule of pendingModuleImports) {
-          const installPath = await moduleManager.getModuleInstallPath(pendingModule.module_id);
-          if (installPath) {
-            const dest = path.join(saveDir, "modules", pendingModule.module_id);
-            await fs.mkdir(path.join(saveDir, "modules"), { recursive: true });
-            // Overwrites any existing copy from a previous import (intentional).
-            await fs.cp(installPath, dest, { recursive: true });
-          }
-        }
-        await runSerializedProjectManifestMutation(saveDir, async () => {
-          const manifest = await ProjectManager.readManifest(saveDir);
-          const mergedManifest = {
-            ...manifest,
-            modules: [...manifest.modules, ...pendingModuleImports],
-            module_settings: { ...manifest.module_settings, ...pendingModuleSettings },
-          };
-          await ProjectManager.saveManifest(saveDir, mergedManifest);
+      const doSave = async (): Promise<{ checksum: string; nodeCount: number; projectName?: string }> => {
+        console.log(`[project:save] seq=${seq} starting (was queued behind previous save)`);
+        const saveResult = await projectManager.save(saveDir, codeCells, {
+          language: getActiveKernelLanguage(),
+          interpreterPath: getInterpreterPath(),
+          projectName,
         });
-        setPendingModuleImports([]);
-        setPendingModuleSettings({});
-      }
 
-      // NOTE: file-backed nodes are already copied to saveDir/tree/ by the
-      // Python serializer (serialize_node writes directly to save_dir).
-      // No additional copy step is needed here.
+        const pendingModuleImports = getPendingModuleImports();
+        const pendingModuleSettings = getPendingModuleSettings();
+        if (pendingModuleImports.length > 0 || Object.keys(pendingModuleSettings).length > 0) {
+          for (const pendingModule of pendingModuleImports) {
+            const installPath = await moduleManager.getModuleInstallPath(pendingModule.module_id);
+            if (installPath) {
+              const dest = path.join(saveDir, "modules", pendingModule.module_id);
+              await fs.mkdir(path.join(saveDir, "modules"), { recursive: true });
+              await fs.cp(installPath, dest, { recursive: true });
+            }
+          }
+          await runSerializedProjectManifestMutation(saveDir, async () => {
+            const manifest = await ProjectManager.readManifest(saveDir);
+            const mergedManifest = {
+              ...manifest,
+              modules: [...manifest.modules, ...pendingModuleImports],
+              module_settings: { ...manifest.module_settings, ...pendingModuleSettings },
+            };
+            await ProjectManager.saveManifest(saveDir, mergedManifest);
+          });
+          setPendingModuleImports([]);
+          setPendingModuleSettings({});
+        }
 
-      // Mirror edited working-dir copies of module-owned files back into
-      // <saveDir>/modules/<id>/<source_rel_path>. See ARCHITECTURE.md §5.13
-      // and the #140 module editing workflow plan §3.
-      // TODO(#182): propagate deletions — if a module-owned file was removed
-      // from the tree, the pristine copy under <saveDir>/modules/<id>/ is
-      // left behind. Safe lacuna for now; fix alongside the GitHub push flow.
-      await syncModuleOwnedFilesToSaveDir(saveDir, saveResult.moduleOwnedFiles);
-      // Now that the file contents are in place, stamp pdv-module.json and
-      // module-index.json for every module in the tree so a fresh project
-      // reload can rebind them via the existing v4 bind path. See plan §7.
-      await writeModuleManifestsToSaveDir(saveDir, saveResult.moduleManifests, moduleManager);
+        // NOTE: file-backed nodes are already copied to saveDir/tree/ by the
+        // Python serializer (serialize_node writes directly to save_dir).
+        // No additional copy step is needed here.
 
-      setActiveProjectDir(saveDir);
-      await refreshProjectModuleHealth(saveDir);
+        // Mirror edited working-dir copies of module-owned files back into
+        // <saveDir>/modules/<id>/<source_rel_path>. See ARCHITECTURE.md §5.13
+        // and the #140 module editing workflow plan §3.
+        // TODO(#182): propagate deletions — if a module-owned file was removed
+        // from the tree, the pristine copy under <saveDir>/modules/<id>/ is
+        // left behind. Safe lacuna for now; fix alongside the GitHub push flow.
+        await syncModuleOwnedFilesToSaveDir(saveDir, saveResult.moduleOwnedFiles);
+        await writeModuleManifestsToSaveDir(saveDir, saveResult.moduleManifests, moduleManager);
 
-      // Read back the project name from the manifest (may have been preserved from prior save).
-      let savedProjectName: string | undefined;
-      try {
-        const manifest = await ProjectManager.readManifest(saveDir);
-        savedProjectName = manifest.project_name;
-      } catch {
-        // Non-blocking
-      }
-      return { checksum: saveResult.checksum, nodeCount: saveResult.nodeCount, projectName: savedProjectName };
+        setActiveProjectDir(saveDir);
+        await refreshProjectModuleHealth(saveDir);
+
+        let savedProjectName: string | undefined;
+        try {
+          const manifest = await ProjectManager.readManifest(saveDir);
+          savedProjectName = manifest.project_name;
+        } catch {
+          // Non-blocking
+        }
+        console.log(`[project:save] seq=${seq} DONE`);
+        return { checksum: saveResult.checksum, nodeCount: saveResult.nodeCount, projectName: savedProjectName };
+      };
+
+      // Chain behind any in-flight save so they never overlap.
+      const queued = activeSave.then(doSave, doSave);
+      activeSave = queued.catch(() => {});
+      return queued;
     }
   );
 

--- a/electron/main/ipc-register-project.ts
+++ b/electron/main/ipc-register-project.ts
@@ -127,14 +127,62 @@ async function syncModuleOwnedFilesToSaveDir(
  * @param bundles - Per-module manifest bundles from the save response.
  * @returns Nothing.
  */
+async function readManifestOnlyFields(
+  moduleDir: string,
+  moduleId: string,
+  moduleManager: ModuleManager,
+): Promise<{ entryPoint?: string; defaultGui?: string }> {
+  // Try the project-local manifest first (written by a previous save that
+  // already had the fix, or copied from the global store on first import).
+  try {
+    const raw = await fs.readFile(path.join(moduleDir, "pdv-module.json"), "utf8");
+    const existing = JSON.parse(raw) as Record<string, unknown>;
+    const entryPoint = typeof existing.entry_point === "string" ? existing.entry_point : undefined;
+    const defaultGui = typeof existing.default_gui === "string" ? existing.default_gui : undefined;
+    if (entryPoint || defaultGui) return { entryPoint, defaultGui };
+  } catch {
+    // No existing project-local manifest — fall through to installed source.
+  }
+
+  // Fallback: read from the globally installed or bundled module. Covers
+  // projects saved before this fix was in place, where the project-local
+  // pdv-module.json was overwritten without these fields.
+  try {
+    const installPath = await moduleManager.resolveModuleDir(moduleId, null);
+    if (installPath && installPath !== moduleDir) {
+      const raw = await fs.readFile(path.join(installPath, "pdv-module.json"), "utf8");
+      const source = JSON.parse(raw) as Record<string, unknown>;
+      return {
+        entryPoint: typeof source.entry_point === "string" ? source.entry_point : undefined,
+        defaultGui: typeof source.default_gui === "string" ? source.default_gui : undefined,
+      };
+    }
+  } catch {
+    // Module not installed globally — best-effort.
+  }
+
+  return {};
+}
+
 async function writeModuleManifestsToSaveDir(
   saveDir: string,
   bundles: ModuleManifestBundle[] | undefined,
+  moduleManager: ModuleManager,
 ): Promise<void> {
   if (!bundles || bundles.length === 0) return;
   for (const bundle of bundles) {
     if (!bundle.module_id) continue;
     const moduleDir = path.join(saveDir, "modules", bundle.module_id);
+
+    // Preserve entry_point and default_gui — these are set during module
+    // import/install and are not tracked in the kernel tree, so the
+    // kernel-side _collect_module_manifests cannot emit them. Without them,
+    // project load cannot import custom serializers (entry_point) or
+    // display the module in the activity bar (default_gui).
+    const { entryPoint, defaultGui } = await readManifestOnlyFields(
+      moduleDir, bundle.module_id, moduleManager,
+    );
+
     try {
       await writeModuleManifest(moduleDir, {
         id: bundle.module_id,
@@ -143,6 +191,8 @@ async function writeModuleManifestsToSaveDir(
         description: bundle.description,
         language: bundle.language,
         dependencies: bundle.dependencies,
+        entryPoint,
+        defaultGui,
         // Default lib_dir for the v4 manifest. Kept for external tooling
         // that reads the on-disk manifest; the TS/kernel setup path no
         // longer consumes this field — the kernel walker in
@@ -242,7 +292,7 @@ export function registerProjectIpcHandlers(
       // Now that the file contents are in place, stamp pdv-module.json and
       // module-index.json for every module in the tree so a fresh project
       // reload can rebind them via the existing v4 bind path. See plan §7.
-      await writeModuleManifestsToSaveDir(saveDir, saveResult.moduleManifests);
+      await writeModuleManifestsToSaveDir(saveDir, saveResult.moduleManifests, moduleManager);
 
       setActiveProjectDir(saveDir);
       await refreshProjectModuleHealth(saveDir);

--- a/electron/main/ipc-register-project.ts
+++ b/electron/main/ipc-register-project.ts
@@ -316,7 +316,7 @@ export function registerProjectIpcHandlers(
       const workingDir = kernelWorkingDirs.get(activeKernelId);
       if (workingDir) {
         const win = getMainWindow();
-        await copyFilesForLoad(saveDir, workingDir, win ? (current, total) => {
+        const failedPaths = await copyFilesForLoad(saveDir, workingDir, win ? (current, total) => {
           win.webContents.send(IPC.push.progress, {
             operation: "load",
             phase: "Copying files",
@@ -324,6 +324,12 @@ export function registerProjectIpcHandlers(
             total,
           });
         } : undefined);
+        if (failedPaths.length > 0) {
+          console.warn(
+            `[pdv] load: ${failedPaths.length} file(s) could not be copied from save directory:`,
+            failedPaths,
+          );
+        }
       }
     }
 

--- a/electron/main/ipc-register-project.ts
+++ b/electron/main/ipc-register-project.ts
@@ -249,10 +249,10 @@ export function registerProjectIpcHandlers(
     async (_event, saveDir: string, codeCells: unknown, projectName?: string) => {
       assertCodeCellData(codeCells);
       const seq = ++saveSeq;
-      console.log(`[project:save] IPC received seq=${seq} saveDir=${saveDir}`);
+      console.debug(`[project:save] IPC received seq=${seq} saveDir=${saveDir}`);
 
       const doSave = async (): Promise<{ checksum: string; nodeCount: number; projectName?: string }> => {
-        console.log(`[project:save] seq=${seq} starting (was queued behind previous save)`);
+        console.debug(`[project:save] seq=${seq} starting (was queued behind previous save)`);
         const saveResult = await projectManager.save(saveDir, codeCells, {
           language: getActiveKernelLanguage(),
           interpreterPath: getInterpreterPath(),
@@ -306,7 +306,7 @@ export function registerProjectIpcHandlers(
         } catch {
           // Non-blocking
         }
-        console.log(`[project:save] seq=${seq} DONE`);
+        console.debug(`[project:save] seq=${seq} DONE`);
         return { checksum: saveResult.checksum, nodeCount: saveResult.nodeCount, projectName: savedProjectName };
       };
 

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -12,22 +12,16 @@
  */
 
 import { spawn } from "child_process";
-import { randomUUID } from "crypto";
 import { ipcMain } from "electron";
 import * as fs from "fs/promises";
 import * as path from "path";
-
-/** Generate a 12-hex-character node UUID matching the Python side. */
-function generateNodeUuid(): string {
-  return randomUUID().replace(/-/g, "").slice(0, 12);
-}
 
 import type { CommRouter } from "./comm-router";
 import type { QueryRouter } from "./query-router";
 import type { ConfigStore, PDVConfig } from "./config";
 import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNodeResult, type TreeCreateNoteResult, type TreeCreateScriptResult, type TreeDuplicateResult, type TreeMoveResult, type TreeRenameResult } from "./ipc";
 import type { KernelManager } from "./kernel-manager";
-import { PDVMessageType, type PDVFileRegisterPayload } from "./pdv-protocol";
+import { PDVMessageType, generateNodeUuid, type PDVFileRegisterPayload } from "./pdv-protocol";
 import type { ProjectManager } from "./project-manager";
 
 interface RegisterTreeNamespaceScriptIpcHandlersOptions {
@@ -63,12 +57,6 @@ interface RegisterTreeNamespaceScriptIpcHandlersOptions {
     language: "python" | "julia",
     moduleAlias: string,
   ) => Promise<void>;
-  resolveScriptPath: (
-    kernelId: string,
-    scriptPath: string,
-    kernelWorkingDirs: Map<string, string>,
-    language?: "python" | "julia"
-  ) => string;
   buildEditorSpawn: (
     cmdString: string | undefined,
     filePath: string
@@ -232,7 +220,6 @@ export function registerTreeNamespaceScriptIpcHandlers(
     sanitizeScriptName,
     ensureScriptFile,
     ensureLibFile,
-    resolveScriptPath,
     buildEditorSpawn,
     resolveEditorSpawn,
   } = options;
@@ -656,30 +643,15 @@ export function registerTreeNamespaceScriptIpcHandlers(
   ipcMain.handle(IPC.script.edit, async (_event, kernelId: string, scriptPath: string) => {
     const config = readConfig(configStore);
 
-    // Resolve the file path — try the kernel comm first (handles all
-    // PDVFile types including lib/namelist), fall back to the legacy
-    // tree-path-to-filesystem derivation for plain scripts.
-    // TODO: remove legacy for beta.
-    let resolvedPath: string | undefined;
-    try {
-      const response = await queryRequest(
-        PDVMessageType.TREE_RESOLVE_FILE,
-        { path: scriptPath }
-      );
-      const filePath = (response.payload as Record<string, unknown> | undefined)?.file_path;
-      if (typeof filePath === "string" && filePath.length > 0) {
-        resolvedPath = filePath;
-      }
-    } catch {
-      // Comm failed — fall through to legacy resolution
-      // TODO: remove this fallback, this silently ignores all errors.
+    const response = await queryRequest(
+      PDVMessageType.TREE_RESOLVE_FILE,
+      { path: scriptPath }
+    );
+    const filePath = (response.payload as Record<string, unknown> | undefined)?.file_path;
+    if (typeof filePath !== "string" || filePath.length === 0) {
+      return { success: false, error: `Could not resolve file path for "${scriptPath}".` };
     }
-    if (!resolvedPath) {
-      const kernel = kernelManager.getKernel(kernelId);
-      const language = kernel?.language ?? "python";
-      resolvedPath = resolveScriptPath(kernelId, scriptPath, kernelWorkingDirs, language);
-      console.warn(`[pdv] Falling back to legacy script path resolution for "${scriptPath}" → "${resolvedPath}"`);
-    }
+    const resolvedPath = filePath;
 
     const isJulia = resolvedPath.endsWith(".jl");
     const cmdString = isJulia ? config.juliaEditorCmd : config.pythonEditorCmd;

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -296,6 +296,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
         moduleId = moduleInfo.moduleAlias;
       }
 
+      const treePath = targetPath ? `${targetPath}.${scriptNodeName}` : scriptNodeName;
       await commRouter.request(PDVMessageType.SCRIPT_REGISTER, {
         parent_path: targetPath,
         name: scriptNodeName,
@@ -305,7 +306,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
         module_id: moduleId,
         source_rel_path: sourceRelPath,
       });
-      return { success: true, scriptPath };
+      return { success: true, scriptPath, treePath };
     }
   );
 

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -12,9 +12,15 @@
  */
 
 import { spawn } from "child_process";
+import { randomUUID } from "crypto";
 import { ipcMain } from "electron";
 import * as fs from "fs/promises";
 import * as path from "path";
+
+/** Generate a 12-hex-character node UUID matching the Python side. */
+function generateNodeUuid(): string {
+  return randomUUID().replace(/-/g, "").slice(0, 12);
+}
 
 import type { CommRouter } from "./comm-router";
 import type { QueryRouter } from "./query-router";
@@ -300,48 +306,29 @@ export function registerTreeNamespaceScriptIpcHandlers(
       const safeName = sanitizeScriptName(scriptName, language);
       const scriptNodeName = path.parse(safeName).name;
 
-      // Every file-backed tree node lives under the canonical
-      // ``<workdir>/tree/...`` subdirectory so the in-memory
-      // ``relative_path`` matches what ``serialize_node`` emits at save
-      // time and what ``copyFilesForLoad`` mirrors on reload. The
-      // pre-Option-A layout that dropped the ``tree/`` prefix for
-      // ``tree:createScript`` produced a rel-path drift across
-      // save/load (see the #140 PR's follow-up discussion on the
-      // checksum fix). Module-owned files also get the prefix via
-      // ``analyseModuleTarget``.
       const knownAliases = await getKnownModuleAliases();
       const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
 
-      let scriptsDir: string;
+      const nodeUuid = generateNodeUuid();
+      const scriptDir = path.join(workingDir, "tree", nodeUuid);
+      await fs.mkdir(scriptDir, { recursive: true });
+      const scriptPath = path.join(scriptDir, safeName);
+      await ensureScriptFile(scriptPath, language);
+
       let sourceRelPath: string | undefined;
       let moduleId: string | undefined;
       if (moduleInfo) {
-        scriptsDir = path.join(workingDir, ...moduleInfo.workingDirSegments);
         sourceRelPath = moduleInfo.sourceRelDir
           ? `${moduleInfo.sourceRelDir}/${safeName}`
           : safeName;
         moduleId = moduleInfo.moduleAlias;
-      } else {
-        scriptsDir = path.join(
-          workingDir,
-          "tree",
-          ...targetPath.split(".").filter(Boolean),
-        );
       }
-      await fs.mkdir(scriptsDir, { recursive: true });
-      const scriptPath = path.join(scriptsDir, safeName);
-      await ensureScriptFile(scriptPath, language);
 
-      // Register with a workdir-relative path so the in-memory
-      // ``relative_path`` matches the ``tree-index.json`` entry post
-      // save/load. ``scriptPath`` (absolute) is still returned to the
-      // renderer because the external-editor spawn needs an absolute
-      // path.
-      const registeredRelPath = path.relative(workingDir, scriptPath);
       await commRouter.request(PDVMessageType.SCRIPT_REGISTER, {
         parent_path: targetPath,
         name: scriptNodeName,
-        relative_path: registeredRelPath,
+        uuid: nodeUuid,
+        filename: safeName,
         language,
         module_id: moduleId,
         source_rel_path: sourceRelPath,
@@ -367,9 +354,11 @@ export function registerTreeNamespaceScriptIpcHandlers(
         kernelWorkingDirs.set(kernelId, workingDir);
       }
       const safeName = noteName.trim().replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_-]/g, "");
-      const noteDir = path.join(workingDir, "tree", ...targetPath.split(".").filter(Boolean));
+      const nodeUuid = generateNodeUuid();
+      const noteFilename = safeName + ".md";
+      const noteDir = path.join(workingDir, "tree", nodeUuid);
       await fs.mkdir(noteDir, { recursive: true });
-      const notePath = path.join(noteDir, safeName + ".md");
+      const notePath = path.join(noteDir, noteFilename);
 
       // Create the .md file if it doesn't exist
       try {
@@ -379,13 +368,11 @@ export function registerTreeNamespaceScriptIpcHandlers(
       }
 
       const treePath = targetPath ? `${targetPath}.${safeName}` : safeName;
-      // Register with a workdir-relative path so the in-memory
-      // ``relative_path`` matches what ``serialize_node`` emits at save
-      // time (see the Option A canonical-layout commit).
       await commRouter.request(PDVMessageType.NOTE_REGISTER, {
         parent_path: targetPath,
         name: safeName,
-        relative_path: path.relative(workingDir, notePath),
+        uuid: nodeUuid,
+        filename: noteFilename,
       });
       return { success: true, notePath, treePath };
     }
@@ -412,28 +399,23 @@ export function registerTreeNamespaceScriptIpcHandlers(
         return { success: false, error: "GUI name must contain at least one alphanumeric character" };
       }
 
-      // Every file-backed node lives under ``<workdir>/tree/...`` so the
-      // in-memory ``relative_path`` stays stable across save/load.
-      // ``analyseModuleTarget`` already bakes the ``tree/`` prefix into
-      // its ``workingDirSegments`` result for module-owned targets.
       const knownAliases = await getKnownModuleAliases();
       const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
 
+      const nodeUuid = generateNodeUuid();
       const guiFilename = safeName + ".gui.json";
-      let guiDir: string;
+      const guiDir = path.join(workingDir, "tree", nodeUuid);
+      await fs.mkdir(guiDir, { recursive: true });
+      const guiPath = path.join(guiDir, guiFilename);
+
       let sourceRelPath: string | undefined;
       let moduleId: string | null = null;
       if (moduleInfo) {
-        guiDir = path.join(workingDir, ...moduleInfo.workingDirSegments);
         sourceRelPath = moduleInfo.sourceRelDir
           ? `${moduleInfo.sourceRelDir}/${guiFilename}`
           : guiFilename;
         moduleId = moduleInfo.moduleAlias;
-      } else {
-        guiDir = path.join(workingDir, "tree", ...targetPath.split(".").filter(Boolean));
       }
-      await fs.mkdir(guiDir, { recursive: true });
-      const guiPath = path.join(guiDir, guiFilename);
 
       const defaultManifest = {
         has_gui: true,
@@ -452,7 +434,8 @@ export function registerTreeNamespaceScriptIpcHandlers(
       await commRouter.request(PDVMessageType.GUI_REGISTER, {
         parent_path: targetPath,
         name: safeName,
-        relative_path: path.relative(workingDir, guiPath),
+        uuid: nodeUuid,
+        filename: guiFilename,
         module_id: moduleId,
         source_rel_path: sourceRelPath,
       });
@@ -504,7 +487,8 @@ export function registerTreeNamespaceScriptIpcHandlers(
         };
       }
 
-      const libDir = path.join(workingDir, ...moduleInfo.workingDirSegments);
+      const nodeUuid = generateNodeUuid();
+      const libDir = path.join(workingDir, "tree", nodeUuid);
       await fs.mkdir(libDir, { recursive: true });
       const libPath = path.join(libDir, filename);
       await ensureLibFile(libPath, language, moduleInfo.moduleAlias);
@@ -516,6 +500,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
       await commRouter.request(PDVMessageType.FILE_REGISTER, {
         tree_path: targetPath,
         filename,
+        uuid: nodeUuid,
         node_type: "lib",
         name: stem,
         module_id: moduleInfo.moduleAlias,
@@ -552,12 +537,8 @@ export function registerTreeNamespaceScriptIpcHandlers(
       const workingDir = kernelWorkingDirs.get(kernelId);
       if (!workingDir) throw new Error(`Working dir not initialized: ${kernelId}`);
 
-      // File-backed nodes live under the canonical ``<workdir>/tree/...``
-      // subdirectory so the in-memory ``relative_path`` matches what
-      // ``serialize_node`` writes at save time and what
-      // ``copyFilesForLoad`` mirrors on reload.
-      const segments = targetTreePath.split(".").filter(Boolean);
-      const destDir = path.join(workingDir, "tree", ...segments);
+      const nodeUuid = generateNodeUuid();
+      const destDir = path.join(workingDir, "tree", nodeUuid);
       await fs.mkdir(destDir, { recursive: true });
       const destPath = path.join(destDir, filename);
       await fs.copyFile(sourcePath, destPath);
@@ -565,6 +546,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
       await commRouter.request(PDVMessageType.FILE_REGISTER, {
         tree_path: targetTreePath,
         filename,
+        uuid: nodeUuid,
         node_type: nodeType,
       } satisfies PDVFileRegisterPayload);
 
@@ -749,16 +731,15 @@ export function registerTreeNamespaceScriptIpcHandlers(
     IPC.note.save,
     async (_event, kernelId: string, treePath: string, content: string) => {
       try {
-        const workingDir = kernelWorkingDirs.get(kernelId);
-        if (!workingDir) throw new Error(`Working dir not initialized: ${kernelId}`);
-        const segments = treePath.split(".").filter(Boolean);
-        const lastSeg = segments.pop();
-        if (!lastSeg) throw new Error("Invalid tree path");
-        const noteDir = segments.length > 0
-          ? path.join(workingDir, "tree", ...segments)
-          : path.join(workingDir, "tree");
-        const filePath = path.join(noteDir, lastSeg + ".md");
-        await fs.mkdir(noteDir, { recursive: true });
+        const response = await queryRequest(
+          PDVMessageType.TREE_RESOLVE_FILE,
+          { path: treePath }
+        );
+        const filePath = (response.payload as Record<string, unknown> | undefined)?.file_path;
+        if (typeof filePath !== "string" || !filePath) {
+          throw new Error(`Could not resolve file path for note at "${treePath}"`);
+        }
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
         await fs.writeFile(filePath, content, "utf-8");
         return { success: true };
       } catch (err) {
@@ -771,15 +752,14 @@ export function registerTreeNamespaceScriptIpcHandlers(
     IPC.note.read,
     async (_event, kernelId: string, treePath: string) => {
       try {
-        const workingDir = kernelWorkingDirs.get(kernelId);
-        if (!workingDir) throw new Error(`Working dir not initialized: ${kernelId}`);
-        const segments = treePath.split(".").filter(Boolean);
-        const lastSeg = segments.pop();
-        if (!lastSeg) throw new Error("Invalid tree path");
-        const noteDir = segments.length > 0
-          ? path.join(workingDir, "tree", ...segments)
-          : path.join(workingDir, "tree");
-        const filePath = path.join(noteDir, lastSeg + ".md");
+        const response = await queryRequest(
+          PDVMessageType.TREE_RESOLVE_FILE,
+          { path: treePath }
+        );
+        const filePath = (response.payload as Record<string, unknown> | undefined)?.file_path;
+        if (typeof filePath !== "string" || !filePath) {
+          throw new Error(`Could not resolve file path for note at "${treePath}"`);
+        }
         const content = await fs.readFile(filePath, "utf-8");
         return { success: true, content };
       } catch (err) {

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -21,7 +21,7 @@ import type { QueryRouter } from "./query-router";
 import type { ConfigStore, PDVConfig } from "./config";
 import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNodeResult, type TreeCreateNoteResult, type TreeCreateScriptResult, type TreeDuplicateResult, type TreeMoveResult, type TreeRenameResult } from "./ipc";
 import type { KernelManager } from "./kernel-manager";
-import { PDVMessageType, generateNodeUuid, type PDVFileRegisterPayload } from "./pdv-protocol";
+import { PDVMessageType, generateNodeUuid, resolveNodeDir, resolveNodePath, type PDVFileRegisterPayload } from "./pdv-protocol";
 import type { ProjectManager } from "./project-manager";
 
 interface RegisterTreeNamespaceScriptIpcHandlersOptions {
@@ -282,9 +282,8 @@ export function registerTreeNamespaceScriptIpcHandlers(
       const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
 
       const nodeUuid = generateNodeUuid();
-      const scriptDir = path.join(workingDir, "tree", nodeUuid);
-      await fs.mkdir(scriptDir, { recursive: true });
-      const scriptPath = path.join(scriptDir, safeName);
+      const scriptPath = resolveNodePath(workingDir, nodeUuid, safeName);
+      await fs.mkdir(resolveNodeDir(workingDir, nodeUuid), { recursive: true });
       await ensureScriptFile(scriptPath, language);
 
       let sourceRelPath: string | undefined;
@@ -329,9 +328,8 @@ export function registerTreeNamespaceScriptIpcHandlers(
       const safeName = noteName.trim().replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_-]/g, "");
       const nodeUuid = generateNodeUuid();
       const noteFilename = safeName + ".md";
-      const noteDir = path.join(workingDir, "tree", nodeUuid);
-      await fs.mkdir(noteDir, { recursive: true });
-      const notePath = path.join(noteDir, noteFilename);
+      const notePath = resolveNodePath(workingDir, nodeUuid, noteFilename);
+      await fs.mkdir(resolveNodeDir(workingDir, nodeUuid), { recursive: true });
 
       // Create the .md file if it doesn't exist
       try {
@@ -377,9 +375,8 @@ export function registerTreeNamespaceScriptIpcHandlers(
 
       const nodeUuid = generateNodeUuid();
       const guiFilename = safeName + ".gui.json";
-      const guiDir = path.join(workingDir, "tree", nodeUuid);
-      await fs.mkdir(guiDir, { recursive: true });
-      const guiPath = path.join(guiDir, guiFilename);
+      const guiPath = resolveNodePath(workingDir, nodeUuid, guiFilename);
+      await fs.mkdir(resolveNodeDir(workingDir, nodeUuid), { recursive: true });
 
       let sourceRelPath: string | undefined;
       let moduleId: string | null = null;
@@ -461,9 +458,8 @@ export function registerTreeNamespaceScriptIpcHandlers(
       }
 
       const nodeUuid = generateNodeUuid();
-      const libDir = path.join(workingDir, "tree", nodeUuid);
-      await fs.mkdir(libDir, { recursive: true });
-      const libPath = path.join(libDir, filename);
+      const libPath = resolveNodePath(workingDir, nodeUuid, filename);
+      await fs.mkdir(resolveNodeDir(workingDir, nodeUuid), { recursive: true });
       await ensureLibFile(libPath, language, moduleInfo.moduleAlias);
 
       const sourceRelPath = moduleInfo.sourceRelDir
@@ -511,9 +507,8 @@ export function registerTreeNamespaceScriptIpcHandlers(
       if (!workingDir) throw new Error(`Working dir not initialized: ${kernelId}`);
 
       const nodeUuid = generateNodeUuid();
-      const destDir = path.join(workingDir, "tree", nodeUuid);
-      await fs.mkdir(destDir, { recursive: true });
-      const destPath = path.join(destDir, filename);
+      const destPath = resolveNodePath(workingDir, nodeUuid, filename);
+      await fs.mkdir(resolveNodeDir(workingDir, nodeUuid), { recursive: true });
       await fs.copyFile(sourcePath, destPath);
 
       await commRouter.request(PDVMessageType.FILE_REGISTER, {

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -95,23 +95,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  *   file authored here (e.g. ``targetPath = "toy.scripts.helpers"``
  *   inside module ``toy`` yields ``sourceRelDir = "scripts/helpers"``).
  *   Empty when the target equals the module root.
- * - ``workingDirSegments`` — the filesystem path segments relative to
- *   the kernel working directory, *including* the canonical ``tree/``
- *   subdirectory prefix. Module-owned files live at
- *   ``<workdir>/tree/<alias>/<rest>`` so the on-disk layout matches
- *   what ``serialize_node`` produces at save time, which keeps
- *   ``relative_path`` stable across save/load cycles. The forthcoming
- *   UUID-based storage redesign will replace the content of the
- *   per-node rel path but keep this single-canonical-layout contract.
- *
- * Returns ``null`` when ``targetPath`` is not inside any known module,
- * in which case the caller routes through the standard ``tree/<path>``
- * layout for project-level files.
+ * Returns ``null`` when ``targetPath`` is not inside any known module.
  */
 function analyseModuleTarget(
   targetPath: string,
   knownAliases: Set<string>,
-): { moduleAlias: string; sourceRelDir: string; workingDirSegments: string[] } | null {
+): { moduleAlias: string; sourceRelDir: string } | null {
   const segments = targetPath.split(".").filter(Boolean);
   if (segments.length === 0) return null;
   const [alias, ...rest] = segments;
@@ -119,10 +108,6 @@ function analyseModuleTarget(
   return {
     moduleAlias: alias,
     sourceRelDir: rest.join("/"),
-    // TODO(UUID): replace with ``["tree", "<uuid>"]`` once the UUID-
-    // based file storage redesign lands — the tree-path-to-filesystem
-    // mapping goes away and file locations become identity-stable.
-    workingDirSegments: ["tree", alias, ...rest],
   };
 }
 

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -403,6 +403,8 @@ export interface TreeCreateScriptResult {
   error?: string;
   /** Absolute path to the created script file. */
   scriptPath?: string;
+  /** Dot-separated tree path of the created script node. */
+  treePath?: string;
 }
 
 /**

--- a/electron/main/module-runtime.ts
+++ b/electron/main/module-runtime.ts
@@ -300,42 +300,37 @@ export async function bindImportedModule(
 
   const moduleIndex = await moduleManager.readModuleIndex(installPath);
 
-  // Copy each local_file backend file to
-  // ``<workdir>/tree/<alias>/<relative_path>`` and build a remapped
-  // index with updated ``relative_paths``. The ``tree/`` prefix is the
-  // canonical working-dir/save-dir subdir for file-backed nodes
-  // (ARCHITECTURE.md §6.1/§6.2): ``serialize_node`` writes there,
-  // ``copyFilesForLoad`` mirrors from there, and the Option A fix in
-  // the #140 PR aligns every file-backed-node creation path on the
-  // same layout so in-memory ``relative_path`` stays stable across
-  // save/load cycles.
+  // Copy each local_file backend file to ``<workdir>/tree/<uuid>/<filename>``
+  // and build a remapped index with UUID-based storage. Each file gets a
+  // fresh UUID so its path is independent of the tree structure.
   //
-  // Each remapped entry also carries ``source_rel_path`` — the
-  // original module-rooted rel-path (e.g. ``scripts/run.py``) — so
-  // the save-time sync step (§3) can mirror working-dir edits back
-  // into ``<saveDir>/modules/<id>/<source_rel_path>``.
-  //
-  // TODO(UUID): once the UUID-based file storage redesign lands this
-  // layout becomes ``tree/<uuid>/<filename>``; source_rel_path is
-  // unaffected because it is intentionally tree-path-agnostic.
+  // Each remapped entry also carries ``source_rel_path`` — the original
+  // module-rooted rel-path (e.g. ``scripts/run.py``) — so the save-time
+  // sync step can mirror working-dir edits back into
+  // ``<saveDir>/modules/<id>/<source_rel_path>``.
+  const { randomUUID } = await import("crypto");
   const remappedIndex = await Promise.all(
     moduleIndex.map(async (node) => {
       const nodeAny = node as unknown as Record<string, unknown>;
       const storage = nodeAny.storage as Record<string, unknown> | undefined;
       if (!storage || storage.backend !== "local_file") return node;
-      const relPath = typeof storage.relative_path === "string" ? storage.relative_path : "";
-      if (!relPath || !workingDir) return node;
 
-      const srcPath = path.join(installPath, relPath);
-      const destRelPath = path.join("tree", importedModule.alias, relPath);
-      const destPath = path.join(workingDir, destRelPath);
+      const origRelPath = typeof storage.relative_path === "string" ? storage.relative_path : "";
+      const origFilename = typeof storage.filename === "string" ? storage.filename : "";
+      const filename = origFilename || path.basename(origRelPath);
+      if (!filename || !workingDir) return node;
+
+      const nodeUuid = randomUUID().replace(/-/g, "").slice(0, 12);
+      const srcPath = path.join(installPath, origRelPath || path.join(String(storage.uuid ?? ""), filename));
+      const destPath = path.join(workingDir, "tree", nodeUuid, filename);
       await fs.mkdir(path.dirname(destPath), { recursive: true });
       await fs.copyFile(srcPath, destPath);
 
       return {
         ...node,
-        storage: { ...storage, relative_path: destRelPath },
-        source_rel_path: relPath,
+        uuid: nodeUuid,
+        storage: { ...storage, uuid: nodeUuid, filename },
+        source_rel_path: origRelPath || filename,
       };
     }),
   );

--- a/electron/main/module-runtime.ts
+++ b/electron/main/module-runtime.ts
@@ -12,7 +12,6 @@
  * - Executing module actions.
  */
 
-import { randomUUID } from "crypto";
 import * as fs from "fs/promises";
 import * as path from "path";
 
@@ -20,7 +19,7 @@ import { CommRouter } from "./comm-router";
 import type { ModuleInputValue } from "./ipc";
 import { KernelManager } from "./kernel-manager";
 import { ModuleManager } from "./module-manager";
-import { PDVMessageType } from "./pdv-protocol";
+import { PDVMessageType, generateNodeUuid } from "./pdv-protocol";
 import { ProjectManager, type ProjectModuleImport } from "./project-manager";
 
 /**
@@ -320,7 +319,7 @@ export async function bindImportedModule(
       const filename = origFilename || path.basename(origRelPath);
       if (!filename || !workingDir) return node;
 
-      const nodeUuid = randomUUID().replace(/-/g, "").slice(0, 12);
+      const nodeUuid = generateNodeUuid();
       const srcPath = path.join(installPath, origRelPath || path.join(String(storage.uuid ?? ""), filename));
       const destPath = path.join(workingDir, "tree", nodeUuid, filename);
       await fs.mkdir(path.dirname(destPath), { recursive: true });

--- a/electron/main/module-runtime.ts
+++ b/electron/main/module-runtime.ts
@@ -12,6 +12,7 @@
  * - Executing module actions.
  */
 
+import { randomUUID } from "crypto";
 import * as fs from "fs/promises";
 import * as path from "path";
 
@@ -308,7 +309,6 @@ export async function bindImportedModule(
   // module-rooted rel-path (e.g. ``scripts/run.py``) — so the save-time
   // sync step can mirror working-dir edits back into
   // ``<saveDir>/modules/<id>/<source_rel_path>``.
-  const { randomUUID } = await import("crypto");
   const remappedIndex = await Promise.all(
     moduleIndex.map(async (node) => {
       const nodeAny = node as unknown as Record<string, unknown>;

--- a/electron/main/module-runtime.ts
+++ b/electron/main/module-runtime.ts
@@ -19,7 +19,7 @@ import { CommRouter } from "./comm-router";
 import type { ModuleInputValue } from "./ipc";
 import { KernelManager } from "./kernel-manager";
 import { ModuleManager } from "./module-manager";
-import { PDVMessageType, generateNodeUuid } from "./pdv-protocol";
+import { PDVMessageType, generateNodeUuid, resolveNodePath } from "./pdv-protocol";
 import { ProjectManager, type ProjectModuleImport } from "./project-manager";
 
 /**
@@ -321,7 +321,7 @@ export async function bindImportedModule(
 
       const nodeUuid = generateNodeUuid();
       const srcPath = path.join(installPath, origRelPath || path.join(String(storage.uuid ?? ""), filename));
-      const destPath = path.join(workingDir, "tree", nodeUuid, filename);
+      const destPath = resolveNodePath(workingDir, nodeUuid, filename);
       await fs.mkdir(path.dirname(destPath), { recursive: true });
       await fs.copyFile(srcPath, destPath);
 

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -97,6 +97,8 @@ export const PDVMessageType = {
   PROGRESS: "pdv.progress",
   /** Kernel → app (push). Kernel requests the app to save the current project. */
   PROJECT_SAVE_REQUEST: "pdv.project.save_request",
+  /** Kernel → app (push). Tree already serialized by kernel; app finishes the save. */
+  PROJECT_SAVE_COMPLETED: "pdv.project.save_completed",
   /** Kernel → app (push). Kernel requests the app to save-as to a new directory. */
   PROJECT_SAVE_AS_REQUEST: "pdv.project.save_as_request",
   /** Kernel → app (push). Kernel requests the app to open a project from a directory. */

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -385,6 +385,8 @@ export interface PDVFileRegisterPayload {
   tree_path: string;
   /** Physical filename with extension (e.g. "input.nml"). */
   filename: string;
+  /** 12-hex-character UUID for the node's storage directory. */
+  uuid?: string;
   /** Node type classification for the file. */
   node_type: "namelist" | "lib" | "file";
   /** Optional explicit tree node name. When omitted the kernel derives it from filename. */

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -79,6 +79,12 @@ export const PDVMessageType = {
   PROJECT_SAVE_RESPONSE: "pdv.project.save.response",
   /** Kernel → app (push). Progress update during save/load operations. */
   PROGRESS: "pdv.progress",
+  /** Kernel → app (push). Kernel requests the app to save the current project. */
+  PROJECT_SAVE_REQUEST: "pdv.project.save_request",
+  /** Kernel → app (push). Kernel requests the app to save-as to a new directory. */
+  PROJECT_SAVE_AS_REQUEST: "pdv.project.save_as_request",
+  /** Kernel → app (push). Kernel requests the app to open a project from a directory. */
+  PROJECT_OPEN_REQUEST: "pdv.project.open_request",
 
   // Tree
   /** App → kernel. Request tree nodes at a given path. */

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -17,6 +17,22 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars -- payload interfaces document the protocol schema (ARCHITECTURE.md §3.4) */
 
+import { randomUUID } from "crypto";
+
+// ---------------------------------------------------------------------------
+// UUID generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a 12-hex-character node UUID matching the Python side
+ * (`pdv.environment.generate_node_uuid`).
+ *
+ * @returns A 12-character lowercase hex string derived from UUID4.
+ */
+export function generateNodeUuid(): string {
+  return randomUUID().replace(/-/g, "").slice(0, 12);
+}
+
 // ---------------------------------------------------------------------------
 // Protocol version
 // ---------------------------------------------------------------------------

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -18,9 +18,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars -- payload interfaces document the protocol schema (ARCHITECTURE.md §3.4) */
 
 import { randomUUID } from "crypto";
+import * as path from "path";
 
 // ---------------------------------------------------------------------------
-// UUID generation
+// UUID generation & path resolution
 // ---------------------------------------------------------------------------
 
 /**
@@ -31,6 +32,32 @@ import { randomUUID } from "crypto";
  */
 export function generateNodeUuid(): string {
   return randomUUID().replace(/-/g, "").slice(0, 12);
+}
+
+/**
+ * Resolve a tree node's backing file to an absolute path.
+ *
+ * Mirrors `PDVFile.resolve_path()` on the Python side and
+ * `uuid_tree_path()` in `pdv.environment`.
+ *
+ * @param workingDir - Absolute path to the working (or save) directory.
+ * @param nodeUuid - 12-hex-character node UUID.
+ * @param filename - Original filename including extension.
+ * @returns Absolute path: `<workingDir>/tree/<nodeUuid>/<filename>`.
+ */
+export function resolveNodePath(workingDir: string, nodeUuid: string, filename: string): string {
+  return path.join(workingDir, "tree", nodeUuid, filename);
+}
+
+/**
+ * Resolve a tree node's storage directory.
+ *
+ * @param workingDir - Absolute path to the working (or save) directory.
+ * @param nodeUuid - 12-hex-character node UUID.
+ * @returns Absolute path: `<workingDir>/tree/<nodeUuid>`.
+ */
+export function resolveNodeDir(workingDir: string, nodeUuid: string): string {
+  return path.join(workingDir, "tree", nodeUuid);
 }
 
 // ---------------------------------------------------------------------------

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -420,16 +420,6 @@ export interface PDVNamespaceInspectPayload {
 // Script message payloads
 // ---------------------------------------------------------------------------
 
-/** Payload for pdv.script.register (app → kernel). */
-export interface PDVScriptRegisterPayload {
-  /** Dot-separated path where the script node should appear in the tree. */
-  tree_path: string;
-  /** Relative path to the script file from the project root. */
-  relative_path: string;
-  /** If true, re-register an already-registered script (reload). */
-  reload?: boolean;
-}
-
 /** Payload for pdv.file.register (app → kernel). */
 export interface PDVFileRegisterPayload {
   /** Dot-path of the parent node; empty string for root. */

--- a/electron/main/project-file-sync.ts
+++ b/electron/main/project-file-sync.ts
@@ -14,6 +14,8 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 
+import { resolveNodePath } from "./pdv-protocol";
+
 /** Matches a valid 12-hex-character node UUID. */
 const UUID_RE = /^[0-9a-f]{12}$/;
 
@@ -85,9 +87,8 @@ export async function copyFilesForLoad(
   const failedPaths: string[] = [];
   for (let i = 0; i < total; i++) {
     const { uuid, filename, treePath } = entries[i];
-    const relativePath = path.join("tree", uuid, filename);
-    const src = path.join(saveDir, relativePath);
-    const dest = path.join(workingDir, relativePath);
+    const src = resolveNodePath(saveDir, uuid, filename);
+    const dest = resolveNodePath(workingDir, uuid, filename);
     await fs.mkdir(path.dirname(dest), { recursive: true });
     await fs.copyFile(src, dest).catch((error) => {
       console.warn(`[pdv] load: could not copy ${src}`, error);

--- a/electron/main/project-file-sync.ts
+++ b/electron/main/project-file-sync.ts
@@ -19,12 +19,13 @@ import * as path from "path";
  */
 interface FileBackedEntry {
   treePath: string;
-  relativePath: string;
+  uuid: string;
+  filename: string;
 }
 
 /**
  * Read tree-index.json from a directory and return entries that have a
- * `storage.relative_path` (i.e. file-backed nodes).
+ * `storage.uuid` and `storage.filename` (i.e. file-backed nodes).
  *
  * @param dir - Directory containing tree-index.json.
  * @returns Array of file-backed node descriptors.
@@ -39,15 +40,17 @@ async function readFileBackedEntries(dir: string): Promise<FileBackedEntry[]> {
         const storage = entry.storage as Record<string, unknown> | undefined;
         return (
           storage?.backend === "local_file" &&
-          typeof storage?.relative_path === "string" &&
-          (storage.relative_path as string).length > 0
+          typeof storage?.uuid === "string" &&
+          typeof storage?.filename === "string" &&
+          (storage.uuid as string).length > 0
         );
       })
       .map((entry) => {
         const storage = entry.storage as Record<string, unknown>;
         return {
           treePath: String(entry.path ?? ""),
-          relativePath: storage.relative_path as string,
+          uuid: storage.uuid as string,
+          filename: storage.filename as string,
         };
       });
   } catch (error) {
@@ -77,7 +80,8 @@ export async function copyFilesForLoad(
   const entries = await readFileBackedEntries(saveDir);
   const total = entries.length;
   for (let i = 0; i < total; i++) {
-    const { relativePath } = entries[i];
+    const { uuid, filename } = entries[i];
+    const relativePath = path.join("tree", uuid, filename);
     const src = path.join(saveDir, relativePath);
     const dest = path.join(workingDir, relativePath);
     await fs.mkdir(path.dirname(dest), { recursive: true });

--- a/electron/main/project-file-sync.ts
+++ b/electron/main/project-file-sync.ts
@@ -14,6 +14,9 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 
+/** Matches a valid 12-hex-character node UUID. */
+const UUID_RE = /^[0-9a-f]{12}$/;
+
 /**
  * One file-backed tree entry resolved from `tree-index.json`.
  */
@@ -42,7 +45,7 @@ async function readFileBackedEntries(dir: string): Promise<FileBackedEntry[]> {
           storage?.backend === "local_file" &&
           typeof storage?.uuid === "string" &&
           typeof storage?.filename === "string" &&
-          (storage.uuid as string).length > 0
+          UUID_RE.test(storage.uuid as string)
         );
       })
       .map((entry) => {
@@ -76,20 +79,23 @@ export async function copyFilesForLoad(
   saveDir: string,
   workingDir: string,
   onProgress?: (current: number, total: number) => void
-): Promise<void> {
+): Promise<string[]> {
   const entries = await readFileBackedEntries(saveDir);
   const total = entries.length;
+  const failedPaths: string[] = [];
   for (let i = 0; i < total; i++) {
-    const { uuid, filename } = entries[i];
+    const { uuid, filename, treePath } = entries[i];
     const relativePath = path.join("tree", uuid, filename);
     const src = path.join(saveDir, relativePath);
     const dest = path.join(workingDir, relativePath);
     await fs.mkdir(path.dirname(dest), { recursive: true });
     await fs.copyFile(src, dest).catch((error) => {
       console.warn(`[pdv] load: could not copy ${src}`, error);
+      failedPaths.push(treePath);
     });
     if (onProgress && (i % 5 === 0 || i === total - 1)) {
       onProgress(i + 1, total);
     }
   }
+  return failedPaths;
 }

--- a/electron/main/project-manager.ts
+++ b/electron/main/project-manager.ts
@@ -269,6 +269,7 @@ export class ProjectManager {
    * @param codeCells - The current code-cell state from the renderer.
    * @throws {PDVCommError} When the kernel responds with status='error'.
    */
+
   /**
    * Pre-computed kernel serialization results, keyed by saveDir.
    *
@@ -302,6 +303,16 @@ export class ProjectManager {
     this._cachedKernelResults.set(saveDir, results);
   }
 
+  /**
+   * Drop any cached kernel serialization results.
+   *
+   * Called on kernel stop so stale entries from abandoned
+   * Python-initiated saves don't survive into a new session.
+   */
+  clearCachedKernelResults(): void {
+    this._cachedKernelResults.clear();
+  }
+
   async save(
     saveDir: string,
     codeCells: CodeCellData,
@@ -328,14 +339,14 @@ export class ProjectManager {
 
     if (cached) {
       this._cachedKernelResults.delete(saveDir);
-      console.log(`[ProjectManager.save] using cached kernel results for ${saveDir}`);
+      console.debug(`[ProjectManager.save] using cached kernel results for ${saveDir}`);
       ({ checksum, nodeCount, moduleOwnedFiles, moduleManifests } = cached);
     } else {
-      console.log(`[ProjectManager.save] sending pdv.project.save comm (+${(performance.now() - t0).toFixed(0)}ms)`);
+      console.debug(`[ProjectManager.save] sending pdv.project.save comm (+${(performance.now() - t0).toFixed(0)}ms)`);
       const response = await this.commRouter.request(PDVMessageType.PROJECT_SAVE, {
         save_dir: saveDir,
       }, { keepAlivePushType: PDVMessageType.PROGRESS });
-      console.log(`[ProjectManager.save] kernel responded (+${(performance.now() - t0).toFixed(0)}ms)`);
+      console.debug(`[ProjectManager.save] kernel responded (+${(performance.now() - t0).toFixed(0)}ms)`);
 
       const payload = response.payload as {
         checksum?: string;
@@ -388,7 +399,7 @@ export class ProjectManager {
       JSON.stringify(manifest, null, 2),
       "utf8"
     );
-    console.log(`[ProjectManager.save] DONE (+${(performance.now() - t0).toFixed(0)}ms)`);
+    console.debug(`[ProjectManager.save] DONE (+${(performance.now() - t0).toFixed(0)}ms)`);
 
     return { checksum, nodeCount, moduleOwnedFiles, moduleManifests };
   }

--- a/electron/main/project-manager.ts
+++ b/electron/main/project-manager.ts
@@ -269,6 +269,39 @@ export class ProjectManager {
    * @param codeCells - The current code-cell state from the renderer.
    * @throws {PDVCommError} When the kernel responds with status='error'.
    */
+  /**
+   * Pre-computed kernel serialization results, keyed by saveDir.
+   *
+   * Populated by the ``pdv.project.save_completed`` push handler when
+   * the kernel serializes the tree synchronously (Python-initiated saves).
+   * Consumed once by the next ``save()`` call for the same directory.
+   */
+  private readonly _cachedKernelResults = new Map<string, {
+    checksum: string;
+    nodeCount: number;
+    moduleOwnedFiles: ModuleOwnedFile[];
+    moduleManifests: ModuleManifestBundle[];
+  }>();
+
+  /**
+   * Cache kernel serialization results from a ``pdv.project.save_completed``
+   * push so the next ``save()`` call can skip the comm round-trip.
+   *
+   * @param saveDir - Absolute path the kernel serialized to.
+   * @param results - Serialization outputs from the kernel.
+   */
+  cacheKernelSaveResults(
+    saveDir: string,
+    results: {
+      checksum: string;
+      nodeCount: number;
+      moduleOwnedFiles: ModuleOwnedFile[];
+      moduleManifests: ModuleManifestBundle[];
+    },
+  ): void {
+    this._cachedKernelResults.set(saveDir, results);
+  }
+
   async save(
     saveDir: string,
     codeCells: CodeCellData,
@@ -279,44 +312,53 @@ export class ProjectManager {
     moduleOwnedFiles: ModuleOwnedFile[];
     moduleManifests: ModuleManifestBundle[];
   }> {
-    // Validate before any on-disk mutation: a nullish or malformed payload
-    // here used to clobber a project's saved tabs (audit #5).
     assertCodeCellData(codeCells);
 
-    // Ensure the save directory exists (creates it when the user enters a new project name
-    // via the Save As dialog, so the folder hasn't been created yet).
+    const t0 = performance.now();
+
     await fs.mkdir(saveDir, { recursive: true });
 
-    // Step 1 — send pdv.project.save comm; throws PDVCommError on error status.
-    // Use progress pushes as keep-alive to prevent timeout during large saves.
-    const response = await this.commRouter.request(PDVMessageType.PROJECT_SAVE, {
-      save_dir: saveDir,
-    }, { keepAlivePushType: PDVMessageType.PROGRESS });
+    // Use cached results from a kernel-initiated save (pdv.save_project())
+    // to avoid the comm round-trip that deadlocks while the shell is busy.
+    const cached = this._cachedKernelResults.get(saveDir);
+    let checksum: string;
+    let nodeCount: number;
+    let moduleOwnedFiles: ModuleOwnedFile[];
+    let moduleManifests: ModuleManifestBundle[];
 
-    const payload = response.payload as {
-      checksum?: string;
-      node_count?: number;
-      module_owned_files?: ModuleOwnedFile[];
-      module_manifests?: ModuleManifestBundle[];
-    };
-    const checksum = payload.checksum ?? "";
-    const nodeCount = payload.node_count ?? 0;
-    const moduleOwnedFiles = Array.isArray(payload.module_owned_files)
-      ? payload.module_owned_files
-      : [];
-    const moduleManifests = Array.isArray(payload.module_manifests)
-      ? payload.module_manifests
-      : [];
+    if (cached) {
+      this._cachedKernelResults.delete(saveDir);
+      console.log(`[ProjectManager.save] using cached kernel results for ${saveDir}`);
+      ({ checksum, nodeCount, moduleOwnedFiles, moduleManifests } = cached);
+    } else {
+      console.log(`[ProjectManager.save] sending pdv.project.save comm (+${(performance.now() - t0).toFixed(0)}ms)`);
+      const response = await this.commRouter.request(PDVMessageType.PROJECT_SAVE, {
+        save_dir: saveDir,
+      }, { keepAlivePushType: PDVMessageType.PROGRESS });
+      console.log(`[ProjectManager.save] kernel responded (+${(performance.now() - t0).toFixed(0)}ms)`);
 
-    // Step 2 — write code-cells.json.
+      const payload = response.payload as {
+        checksum?: string;
+        node_count?: number;
+        module_owned_files?: ModuleOwnedFile[];
+        module_manifests?: ModuleManifestBundle[];
+      };
+      checksum = payload.checksum ?? "";
+      nodeCount = payload.node_count ?? 0;
+      moduleOwnedFiles = Array.isArray(payload.module_owned_files)
+        ? payload.module_owned_files
+        : [];
+      moduleManifests = Array.isArray(payload.module_manifests)
+        ? payload.module_manifests
+        : [];
+    }
+
     await fs.writeFile(
       path.join(saveDir, "code-cells.json"),
       JSON.stringify(codeCells, null, 2),
       "utf8"
     );
 
-    // Step 3 — write project.json (only after both kernel and app state are flushed).
-    // Preserve existing module imports and settings from a prior manifest if present.
     let existingModules: ProjectModuleImport[] = [];
     let existingModuleSettings: Record<string, Record<string, unknown>> = {};
     let projectName = options?.projectName;
@@ -324,7 +366,6 @@ export class ProjectManager {
       const existing = await ProjectManager.readManifest(saveDir);
       existingModules = existing.modules;
       existingModuleSettings = existing.module_settings;
-      // Preserve existing project_name unless a new one is explicitly provided.
       if (projectName === undefined) {
         projectName = existing.project_name;
       }
@@ -347,6 +388,7 @@ export class ProjectManager {
       JSON.stringify(manifest, null, 2),
       "utf8"
     );
+    console.log(`[ProjectManager.save] DONE (+${(performance.now() - t0).toFixed(0)}ms)`);
 
     return { checksum, nodeCount, moduleOwnedFiles, moduleManifests };
   }

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "physics-data-viewer",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "author": {
     "name": "Matthew Pharr",

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -1307,9 +1307,9 @@ const App: React.FC = () => {
               const result = await window.pdv.tree.createScript(currentKernelId, createScriptTarget, name);
               if (!result.success) {
                 setLastError(result.error);
-              } else if (result.scriptPath) {
+              } else if (result.treePath) {
                 setTreeRefreshToken((t) => t + 1);
-                await window.pdv.script.edit(currentKernelId, result.scriptPath);
+                await window.pdv.script.edit(currentKernelId, result.treePath);
               }
             } catch (error) {
               setLastError(error instanceof Error ? error.message : String(error));

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -771,7 +771,6 @@ const App: React.FC = () => {
       setLastDuration(result.duration);
     }
     setNamespaceRefreshToken((prev) => prev + 1);
-    setTreeRefreshToken((prev) => prev + 1);
     setScriptDialog(null);
   };
 
@@ -853,7 +852,6 @@ const App: React.FC = () => {
     } finally {
       setIsExecuting(false);
       setNamespaceRefreshToken((prev) => prev + 1);
-      setTreeRefreshToken((prev) => prev + 1);
     }
   }, [currentKernelId, kernelStatus]);
 

--- a/electron/renderer/src/app/useProjectWorkflow.ts
+++ b/electron/renderer/src/app/useProjectWorkflow.ts
@@ -105,7 +105,7 @@ export function useProjectWorkflow(options: UseProjectWorkflowOptions) {
     }
     // If Save As is requested or no project is open yet, show the SaveAs dialog
     // instead of the native directory picker.
-    if (options?.saveAs || (!options?.directory && !currentProjectDir)) {
+    if (!options?.directory && (options?.saveAs || !currentProjectDir)) {
       setShowSaveAsDialog(true);
       // Returns false — not an error. The dialog will invoke handleSaveProject
       // again with { directory, projectName } once the user confirms.
@@ -226,11 +226,11 @@ export function useProjectWorkflow(options: UseProjectWorkflowOptions) {
       // project:open and project:openRecent are handled in App's menu listener
       // so they can route through openProjectFromWelcome when the kernel isn't ready.
       if (payload.action === 'project:save') {
-        void handleSaveProject();
+        void handleSaveProject(payload.path ? { directory: payload.path } : undefined);
         return;
       }
       if (payload.action === 'project:saveAs') {
-        void handleSaveProject({ saveAs: true });
+        void handleSaveProject({ saveAs: true, directory: payload.path });
       }
     });
     return () => unsubscribe();

--- a/electron/renderer/src/components/Tree/ContextMenu.test.tsx
+++ b/electron/renderer/src/components/Tree/ContextMenu.test.tsx
@@ -66,7 +66,8 @@ describe('ContextMenu', () => {
       />,
     );
     expect(screen.getByRole('button', { name: /Open.*Double-click/ })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /Open in external editor/ })).toBeTruthy();
+    // "Open in external editor" is disabled pending file-watcher support
+    expect(screen.queryByRole('button', { name: /Open in external editor/ })).toBeNull();
     expect(screen.queryByRole('button', { name: /^Create new script/ })).toBeNull();
   });
 

--- a/electron/renderer/src/components/Tree/context-menu-actions.test.ts
+++ b/electron/renderer/src/components/Tree/context-menu-actions.test.ts
@@ -66,10 +66,11 @@ describe('getMenuEntries', () => {
     expect(deleteAction?.disabled).toBe(false);
   });
 
-  it('includes edit (open in external editor) for markdown nodes', () => {
+  // TODO: re-enable after adding file-watcher to detect external edits
+  it('includes open for markdown nodes (external editor disabled pending file-watcher)', () => {
     const ids = actionIds('markdown');
     expect(ids).toContain('open_note');
-    expect(ids).toContain('edit');
+    expect(ids).not.toContain('edit');
   });
 
   it('includes separators between sections', () => {

--- a/electron/renderer/src/components/Tree/index.tsx
+++ b/electron/renderer/src/components/Tree/index.tsx
@@ -222,19 +222,37 @@ export const Tree: React.FC<TreeProps> = ({ kernelId, disabled = false, refreshT
 
           // Read current nodes via ref to avoid stale closure.
           const parentNode = parentPath === '' ? null : findNode(nodesRef.current, parentPath);
-          let children: TreeNodeData[];
+          let freshChildren: TreeNodeData[];
           if (parentPath === '') {
-            children = await treeService.getRootNodes(kernelId, { force: true });
+            freshChildren = await treeService.getRootNodes(kernelId, { force: true });
           } else if (parentNode) {
-            children = await treeService.getChildren(parentNode, kernelId, { force: true });
+            freshChildren = await treeService.getChildren(parentNode, kernelId, { force: true });
           } else {
             continue;
           }
 
+          // Merge fresh children with existing ones to preserve expansion
+          // state. Fresh nodes from the API have isExpanded=false and no
+          // children; existing expanded nodes carry both.
+          const existingParent = parentPath === ''
+            ? nodesRef.current[0]
+            : findNode(nodesRef.current, parentPath);
+          const existingChildren = existingParent?.children ?? [];
+          const existingMap = new Map<string, TreeNodeData>();
+          for (const c of existingChildren) existingMap.set(c.path, c);
+
+          const mergedChildren = freshChildren.map((fresh) => {
+            const existing = existingMap.get(fresh.path);
+            if (existing?.isExpanded && existing.children) {
+              return { ...fresh, isExpanded: true, children: existing.children };
+            }
+            return fresh;
+          });
+
           if (parentPath === '') {
-            setNodes((prev) => updateNodeImmut(prev, '', (n) => ({ ...n, children })));
+            setNodes((prev) => updateNodeImmut(prev, '', (n) => ({ ...n, children: mergedChildren })));
           } else {
-            setNodes((prev) => updateNodeImmut(prev, parentPath, (n) => ({ ...n, children, isExpanded: true })));
+            setNodes((prev) => updateNodeImmut(prev, parentPath, (n) => ({ ...n, children: mergedChildren, isExpanded: true })));
           }
         }
       };

--- a/electron/renderer/src/styles/title-bar.css
+++ b/electron/renderer/src/styles/title-bar.css
@@ -99,6 +99,6 @@
 }
 
 .title-bar-window-button--close:hover {
-  background: #c42b1c;
-  color: #ffffff;
+  background: var(--danger);
+  color: var(--text-on-danger);
 }

--- a/electron/renderer/src/themes.ts
+++ b/electron/renderer/src/themes.ts
@@ -37,6 +37,8 @@ export const CSS_VAR_GROUPS: { label: string; vars: { key: string; label: string
       { key: 'warning',         label: 'Warning' },
       { key: 'warning-hover',   label: 'Warning Hover' },
       { key: 'success',         label: 'Success' },
+      { key: 'danger',          label: 'Danger' },
+      { key: 'text-on-danger',  label: 'Text on Danger' },
     ],
   },
 ];
@@ -68,6 +70,8 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
       'warning':      '#dcdcaa',
       'warning-hover':'#e4e4b4',
       'success':      '#4ec9b0',
+      'danger':       '#c42b1c',
+      'text-on-danger':'#ffffff',
     },
   },
   {
@@ -89,6 +93,8 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
       'warning':      '#bf8803',
       'warning-hover':'#a67702',
       'success':      '#16825d',
+      'danger':       '#c42b1c',
+      'text-on-danger':'#ffffff',
     },
   },
   {
@@ -110,6 +116,8 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
       'warning':      '#e6db74',
       'warning-hover':'#f0e68c',
       'success':      '#a6e22e',
+      'danger':       '#f92672',
+      'text-on-danger':'#272822',
     },
   },
   {
@@ -131,6 +139,8 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
       'warning':      '#996800',
       'warning-hover':'#7a5300',
       'success':      '#008e00',
+      'danger':       '#c42b1c',
+      'text-on-danger':'#ffffff',
     },
   },
   {
@@ -152,6 +162,8 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
       'warning':      '#ffd60a',
       'warning-hover':'#ffe54c',
       'success':      '#32d74b',
+      'danger':       '#c42b1c',
+      'text-on-danger':'#ffffff',
     },
   },
   {
@@ -173,6 +185,8 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
       'warning':      '#cca700',
       'warning-hover':'#d4af00',
       'success':      '#4ec9b0',
+      'danger':       '#c42b1c',
+      'text-on-danger':'#ffffff',
     },
   },
   {
@@ -194,6 +208,8 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
       'warning':      '#bf8803',
       'warning-hover':'#a67702',
       'success':      '#2ea043',
+      'danger':       '#c42b1c',
+      'text-on-danger':'#ffffff',
     },
   },
 ];

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -692,7 +692,7 @@ export interface PDVApi {
       kernelId: string,
       targetPath: string,
       scriptName: string
-    ): Promise<{ success: boolean; error?: string; scriptPath?: string }>;
+    ): Promise<{ success: boolean; error?: string; scriptPath?: string; treePath?: string }>;
     createNote(
       kernelId: string,
       targetPath: string,

--- a/examples/modules/N-pendulum-julia/pdv-module.json
+++ b/examples/modules/N-pendulum-julia/pdv-module.json
@@ -9,7 +9,7 @@
   "lib_dir": "lib",
   "default_gui": "gui.json",
   "compatibility": {
-    "pdv_min": "0.0.11",
+    "pdv_min": "0.0.12",
     "pdv_max": "99.0.0",
     "julia": ">=1.10"
   },

--- a/examples/modules/N-pendulum/pdv-module.json
+++ b/examples/modules/N-pendulum/pdv-module.json
@@ -9,7 +9,7 @@
   "lib_dir": "lib",
   "default_gui": "gui.json",
   "compatibility": {
-    "pdv_min": "0.0.11",
+    "pdv_min": "0.0.12",
     "pdv_max": "99.0.0",
     "python": ">=3.10,<3.14",
     "python_min": "3.10.0",

--- a/pdv-python/pdv/__init__.py
+++ b/pdv-python/pdv/__init__.py
@@ -62,7 +62,58 @@ __all__ = [
     "register_serializer",
     "log",
     "__version__",
+    # PDVApp methods — surfaced at module level so that Jedi autocomplete
+    # works when it resolves ``pdv`` as the package instead of the injected
+    # PDVApp instance (the two share the same name).
+    "save",
+    "save_project",
+    "save_project_as",
+    "open_project",
+    "add_file",
+    "new_note",
+    "help",
+    "working_dir",
 ]
+
+
+def _get_app() -> "PDVApp | None":
+    """Return the bootstrapped PDVApp instance, or None."""
+    import pdv.comms as _comms  # noqa: PLC0415
+
+    ip = _comms._ip
+    if ip is None:
+        return None
+    app = ip.user_ns.get("pdv")
+    from pdv.namespace import PDVApp  # noqa: PLC0415
+
+    return app if isinstance(app, PDVApp) else None
+
+
+_APP_ATTRS: set[str] | None = None
+
+
+def _app_attr_names() -> set[str]:
+    global _APP_ATTRS  # noqa: PLW0603
+    if _APP_ATTRS is None:
+        from pdv.namespace import PDVApp  # noqa: PLC0415
+
+        _APP_ATTRS = {n for n in dir(PDVApp) if not n.startswith("_")}
+    return _APP_ATTRS
+
+
+def __getattr__(name: str):
+    if name in _app_attr_names():
+        app = _get_app()
+        if app is not None:
+            return getattr(app, name)
+        raise RuntimeError(
+            f"pdv.{name}() requires a running PDV kernel (bootstrap has not run)"
+        )
+    raise AttributeError(f"module 'pdv' has no attribute {name!r}")
+
+
+def __dir__():
+    return list(set(globals().keys()) | _app_attr_names())
 
 
 def log(*args, **kwargs) -> None:

--- a/pdv-python/pdv/environment.py
+++ b/pdv-python/pdv/environment.py
@@ -24,6 +24,9 @@ ARCHITECTURE.md §6.1 (working directory), §6.2 (save directory)
 from __future__ import annotations
 
 import os
+import shutil
+import uuid as _uuid_mod
+from pathlib import Path
 
 from pdv.errors import PDVPathError
 
@@ -191,3 +194,80 @@ def ensure_parent(path: str) -> str:
     """
     os.makedirs(os.path.dirname(path), exist_ok=True)
     return path
+
+
+# ---------------------------------------------------------------------------
+# UUID-based file storage helpers
+# ---------------------------------------------------------------------------
+
+
+def generate_node_uuid() -> str:
+    """Generate a 12-hex-character UUID for a tree node.
+
+    Returns
+    -------
+    str
+        A 12-character lowercase hex string derived from UUID4.
+    """
+    return _uuid_mod.uuid4().hex[:12]
+
+
+def uuid_tree_path(working_dir: str, node_uuid: str, filename: str) -> str:
+    """Compute the absolute filesystem path for a UUID-based tree node file.
+
+    Parameters
+    ----------
+    working_dir : str
+        Absolute path to the working directory (or save directory).
+    node_uuid : str
+        The node's 12-hex-char UUID.
+    filename : str
+        The original filename including extension (e.g. ``'fit.py'``).
+
+    Returns
+    -------
+    str
+        Absolute path: ``<working_dir>/tree/<node_uuid>/<filename>``.
+
+    Example
+    -------
+    >>> uuid_tree_path('/tmp/pdv-abc', 'a1b2c3d4e5f6', 'ch1.npy')
+    '/tmp/pdv-abc/tree/a1b2c3d4e5f6/ch1.npy'
+    """
+    return os.path.join(working_dir, "tree", node_uuid, filename)
+
+
+def smart_copy(src: str, dst: str) -> None:
+    """Copy a file using the fastest available method.
+
+    Attempts copy-on-write cloning first, falling back to a regular copy.
+
+    1. Python 3.14+ ``pathlib.Path.copy()`` (OS-level CoW on APFS, btrfs,
+       XFS, ZFS, etc.).
+    2. ``reflink_copy.reflink_or_copy()`` (optional dependency, Rust-backed).
+    3. ``shutil.copy2()`` (universal fallback, preserves metadata).
+
+    Parent directories of *dst* are created automatically.
+
+    Parameters
+    ----------
+    src : str
+        Absolute path to the source file.
+    dst : str
+        Absolute path to the destination file.
+    """
+    ensure_parent(dst)
+
+    if hasattr(Path, "copy"):
+        Path(src).copy(Path(dst))
+        return
+
+    try:
+        from reflink_copy import reflink_or_copy  # noqa: PLC0415
+
+        reflink_or_copy(src, dst)
+        return
+    except ImportError:
+        pass
+
+    shutil.copy2(src, dst)

--- a/pdv-python/pdv/environment.py
+++ b/pdv-python/pdv/environment.py
@@ -237,8 +237,23 @@ def uuid_tree_path(working_dir: str, node_uuid: str, filename: str) -> str:
     return os.path.join(working_dir, "tree", node_uuid, filename)
 
 
+def _file_xxh3(path: str) -> bytes:
+    """Return the xxh3_128 digest of a file's contents."""
+    import xxhash  # noqa: PLC0415
+
+    h = xxhash.xxh3_128()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            h.update(chunk)
+    return h.digest()
+
+
 def smart_copy(src: str, dst: str) -> None:
     """Copy a file using the fastest available method.
+
+    If *dst* already exists and is byte-identical to *src* (verified via
+    xxh3_128), the copy is skipped. If *dst* exists but differs, it is
+    replaced.
 
     Attempts copy-on-write cloning first, falling back to a regular copy.
 
@@ -257,6 +272,11 @@ def smart_copy(src: str, dst: str) -> None:
         Absolute path to the destination file.
     """
     ensure_parent(dst)
+
+    if os.path.exists(dst):
+        if os.path.getsize(src) == os.path.getsize(dst) and _file_xxh3(src) == _file_xxh3(dst):
+            return
+        os.remove(dst)
 
     if hasattr(Path, "copy"):
         Path(src).copy(Path(dst))

--- a/pdv-python/pdv/environment.py
+++ b/pdv-python/pdv/environment.py
@@ -23,12 +23,16 @@ ARCHITECTURE.md §6.1 (working directory), §6.2 (save directory)
 
 from __future__ import annotations
 
+import logging
 import os
+import re
 import shutil
 import uuid as _uuid_mod
 from pathlib import Path
 
 from pdv.errors import PDVPathError
+
+_NODE_UUID_RE = re.compile(r"^[0-9a-f]{12}$")
 
 
 def make_working_dir(base_tmp_dir: str) -> str:
@@ -233,7 +237,16 @@ def uuid_tree_path(working_dir: str, node_uuid: str, filename: str) -> str:
     -------
     >>> uuid_tree_path('/tmp/pdv-abc', 'a1b2c3d4e5f6', 'ch1.npy')
     '/tmp/pdv-abc/tree/a1b2c3d4e5f6/ch1.npy'
+
+    Raises
+    ------
+    ValueError
+        If *node_uuid* or *filename* contain path traversal characters.
     """
+    if ".." in node_uuid or "/" in node_uuid or "\\" in node_uuid:
+        raise ValueError(f"Unsafe node UUID: {node_uuid!r}")
+    if ".." in filename or "/" in filename or "\\" in filename:
+        raise ValueError(f"Unsafe filename: {filename!r}")
     return os.path.join(working_dir, "tree", node_uuid, filename)
 
 
@@ -289,5 +302,10 @@ def smart_copy(src: str, dst: str) -> None:
         return
     except ImportError:
         pass
+    except OSError as exc:
+        logging.getLogger("pdv").warning(
+            "reflink_or_copy failed for %s -> %s: %s; falling back to shutil.copy2",
+            src, dst, exc,
+        )
 
     shutil.copy2(src, dst)

--- a/pdv-python/pdv/environment.py
+++ b/pdv-python/pdv/environment.py
@@ -153,35 +153,6 @@ def path_is_safe(candidate: str, root: str) -> bool:
         return False
 
 
-def working_dir_tree_path(working_dir: str, tree_path: str, extension: str) -> str:
-    """Compute the absolute filesystem path for a tree node's data file.
-
-    Maps a dot-separated tree path to a filesystem path under the working
-    directory's ``tree/`` subdirectory.
-
-    Parameters
-    ----------
-    working_dir : str
-        Absolute path to the working directory.
-    tree_path : str
-        Dot-separated tree path (e.g. ``'data.waveforms.ch1'``).
-    extension : str
-        File extension including the dot (e.g. ``'.npy'``).
-
-    Returns
-    -------
-    str
-        Absolute path for the data file (parent directories are not created
-        by this function).
-
-    Example
-    -------
-    >>> working_dir_tree_path('/tmp/pdv-abc', 'data.waveforms.ch1', '.npy')
-    '/tmp/pdv-abc/tree/data/waveforms/ch1.npy'
-    """
-    parts = tree_path.split(".")
-    return os.path.join(working_dir, "tree", *parts[:-1], parts[-1] + extension)
-
 
 def ensure_parent(path: str) -> str:
     """Create parent directories of ``path`` if they do not exist.

--- a/pdv-python/pdv/handlers/_helpers.py
+++ b/pdv-python/pdv/handlers/_helpers.py
@@ -16,7 +16,7 @@ def validate_register_request(
     msg: dict,
     response_type: str,
     code_prefix: str,
-    required_fields: tuple[str, ...] = ("name", "relative_path"),
+    required_fields: tuple[str, ...] = ("name", "uuid", "filename"),
 ) -> tuple[Any, dict] | None:
     """Validate a ``pdv.<thing>.register`` request and resolve the tree.
 
@@ -36,7 +36,7 @@ def validate_register_request(
         ``f"{code_prefix}.no_tree"``.
     required_fields : tuple of str, optional
         Payload fields that must be present and truthy. Defaults to
-        ``("name", "relative_path")``.
+        ``("name", "uuid", "filename")``.
 
     Returns
     -------

--- a/pdv-python/pdv/handlers/gui.py
+++ b/pdv-python/pdv/handlers/gui.py
@@ -30,7 +30,8 @@ def handle_gui_register(msg: dict) -> None:
         {
             "parent_path": "n_pendulum",
             "name": "gui",
-            "relative_path": "tree/n_pendulum/gui.gui.json",
+            "uuid": "a1b2c3d4e5f6",
+            "filename": "gui.gui.json",
             "module_id": "n_pendulum"
         }
 
@@ -54,12 +55,14 @@ def handle_gui_register(msg: dict) -> None:
     tree, payload = validated
     parent_path = payload.get("parent_path", "")
     name = payload.get("name", "")
-    relative_path = payload.get("relative_path", "")
+    node_uuid = payload.get("uuid", "")
+    filename = payload.get("filename", "")
     module_id = payload.get("module_id")
     source_rel_path = payload.get("source_rel_path")
 
     gui_node = PDVGui(
-        relative_path=relative_path,
+        uuid=node_uuid,
+        filename=filename,
         module_id=module_id,
         source_rel_path=source_rel_path,
     )

--- a/pdv-python/pdv/handlers/modules.py
+++ b/pdv-python/pdv/handlers/modules.py
@@ -516,34 +516,31 @@ def handle_module_reload_libs(msg: dict) -> None:
         except (KeyError, TypeError):
             is_module = False
 
-    # ``<workdir>/tree/<alias>/lib/`` is where bindImportedModule places
-    # lib files for v4 modules. For modules authored in-session
-    # (workflow B), the same convention applies because the empty-
-    # module creation handler seeds the working dir with
-    # ``tree/<uuid>/<filename>``. Every file-backed tree node lives
-    # under the ``tree/`` subdir (ARCHITECTURE.md §6.1/§6.2), keyed
-    # by its UUID so paths are stable across rename/move/save/load.
+    # Collect the realpath'd parent directories of every PDVLib under
+    # this module.  Each lib's resolve_path() computes
+    # ``<working_dir>/tree/<uuid>/<filename>`` — the UUID-based layout
+    # documented in ARCHITECTURE.md §6.1/§6.2.
     #
-    # Use realpath on both sides of the comparison: on macOS, ``/var`` is a
-    # symlink to ``/private/var``, and a module's ``__file__`` can come back
-    # as the un-prefixed form while ``_working_dir`` is the fully-resolved
-    # ``/private/var/...`` path (or vice versa). A literal ``startswith``
-    # check would fail to match files that live at the same physical path.
-    lib_prefix = ""
-    if is_module and working_dir:
-        try:
-            lib_prefix = os.path.realpath(
-                os.path.join(working_dir, "tree", alias, "lib")
-            )
-        except Exception:  # noqa: BLE001
-            lib_prefix = ""
+    # realpath is needed on macOS where ``/var`` → ``/private/var``;
+    # without it a literal startswith check can miss files at the same
+    # physical path.
+    lib_dirs: set[str] = set()
+    if is_module and working_dir and tree is not None:
+        node = tree.get(alias)
+        if node is not None:
+            for lib in _iter_pdv_libs(node):
+                try:
+                    abs_path = lib.resolve_path(working_dir)
+                    lib_dirs.add(
+                        os.path.realpath(os.path.dirname(abs_path))
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
 
     reloaded: list[str] = []
     errors: dict[str, str] = {}
 
-    if lib_prefix:
-        # Snapshot sys.modules — reload() mutates it and we don't want to
-        # iterate over a live dict that grows during traversal.
+    if lib_dirs:
         items = list(sys.modules.items())
         for mod_name, mod in items:
             try:
@@ -556,7 +553,7 @@ def handle_module_reload_libs(msg: dict) -> None:
                 mod_file_abs = os.path.realpath(mod_file)
             except Exception:  # noqa: BLE001
                 continue
-            if not mod_file_abs.startswith(lib_prefix + os.sep):
+            if os.path.dirname(mod_file_abs) not in lib_dirs:
                 continue
             try:
                 importlib.reload(mod)

--- a/pdv-python/pdv/handlers/modules.py
+++ b/pdv-python/pdv/handlers/modules.py
@@ -520,10 +520,9 @@ def handle_module_reload_libs(msg: dict) -> None:
     # lib files for v4 modules. For modules authored in-session
     # (workflow B), the same convention applies because the empty-
     # module creation handler seeds the working dir with
-    # ``tree/<alias>/{scripts,lib,plots}/``. The ``tree/`` prefix is
-    # the canonical working-dir/save-dir subdir documented in
-    # ARCHITECTURE.md §6.1/§6.2 — every file-backed tree node lives
-    # there so ``relative_path`` stays stable across save/load.
+    # ``tree/<uuid>/<filename>``. Every file-backed tree node lives
+    # under the ``tree/`` subdir (ARCHITECTURE.md §6.1/§6.2), keyed
+    # by its UUID so paths are stable across rename/move/save/load.
     #
     # Use realpath on both sides of the comparison: on macOS, ``/var`` is a
     # symlink to ``/private/var``, and a module's ``__file__`` can come back

--- a/pdv-python/pdv/handlers/namelist.py
+++ b/pdv-python/pdv/handlers/namelist.py
@@ -206,16 +206,10 @@ def handle_file_register(msg: dict) -> None:
         )
         return
 
-    # Build relative path: the file is expected under
-    # ``<working_dir>/tree/<tree_path_segments>/<filename>``.
-    # The ``tree/`` prefix is the canonical working-dir/save-dir subdir
-    # for every file-backed tree node (ARCHITECTURE.md §6.1/§6.2) —
-    # ``serialize_node`` writes into it and ``copyFilesForLoad`` mirrors
-    # from it, so keeping the in-memory rel-path prefixed here ensures
-    # the value stays stable across save/load cycles. See the #140 PR's
-    # Option-A canonical-layout fix.
-    segments = tree_path.split(".") if tree_path else []
-    relative_path = os.path.join("tree", *segments, filename)
+    node_uuid = payload.get("uuid", "")
+    if not node_uuid:
+        from pdv.environment import generate_node_uuid  # noqa: PLC0415
+        node_uuid = generate_node_uuid()
 
     # Use explicit name if provided, otherwise derive from filename stem
     if explicit_name:
@@ -232,20 +226,23 @@ def handle_file_register(msg: dict) -> None:
 
     if node_type == "namelist":
         node = PDVNamelist(
-            relative_path=relative_path,
+            uuid=node_uuid,
+            filename=filename,
             format="auto",
             module_id=module_id,
             source_rel_path=source_rel_path,
         )
     elif node_type == "lib":
         node = PDVLib(
-            relative_path=relative_path,
+            uuid=node_uuid,
+            filename=filename,
             module_id=module_id,
             source_rel_path=source_rel_path,
         )
     else:
         node = PDVFile(
-            relative_path=relative_path,
+            uuid=node_uuid,
+            filename=filename,
             source_rel_path=source_rel_path,
         )
 

--- a/pdv-python/pdv/handlers/note.py
+++ b/pdv-python/pdv/handlers/note.py
@@ -30,7 +30,8 @@ def handle_note_register(msg: dict) -> None:
         {
             "parent_path": "notes",
             "name": "introduction",
-            "relative_path": "/path/to/notes/introduction.md"
+            "uuid": "a1b2c3d4e5f6",
+            "filename": "introduction.md"
         }
 
     Response type: ``pdv.note.register.response``
@@ -50,9 +51,10 @@ def handle_note_register(msg: dict) -> None:
     tree, payload = validated
     parent_path = payload.get("parent_path", "")
     name = payload.get("name", "")
-    relative_path = payload.get("relative_path", "")
+    node_uuid = payload.get("uuid", "")
+    filename = payload.get("filename", "")
 
-    note = PDVNote(relative_path=relative_path)
+    note = PDVNote(uuid=node_uuid, filename=filename)
     full_path = f"{parent_path}.{name}" if parent_path else name
     tree[full_path] = note
 

--- a/pdv-python/pdv/handlers/project.py
+++ b/pdv-python/pdv/handlers/project.py
@@ -487,6 +487,8 @@ def _early_module_setup(
         if node_type == "module":
             meta = node.get("metadata", {})
             storage = node.get("storage", {})
+            # Pre-UUID projects stored module_id inside storage.value
+            # rather than metadata; fall back for backwards compat.
             old_meta = storage.get("value", {})
             module_id = meta.get(
                 "module_id", old_meta.get("module_id", "")

--- a/pdv-python/pdv/handlers/project.py
+++ b/pdv-python/pdv/handlers/project.py
@@ -133,6 +133,55 @@ def _collect_nodes(
     return nodes
 
 
+def _purge_orphaned_tree_files(save_dir: str, nodes: list[dict]) -> None:
+    """Remove ``<save_dir>/tree/<uuid>/`` directories not referenced by *nodes*.
+
+    Data nodes (ndarray, DataFrame, custom-serialized objects, etc.) receive a
+    fresh UUID on every save because the value itself has no stable identity.
+    Without cleanup, each save leaves the previous UUID directory behind as an
+    orphan.  This function removes those orphans after ``tree-index.json`` has
+    been written so the save directory doesn't grow unboundedly.
+
+    File-backed PDV nodes (scripts, notes, libs, etc.) reuse their UUID across
+    saves and will always appear in *nodes*, so they are never purged.
+    """
+    import logging  # noqa: PLC0415
+    import os  # noqa: PLC0415
+    import shutil  # noqa: PLC0415
+
+    log = logging.getLogger("pdv")
+
+    tree_dir = os.path.join(save_dir, "tree")
+    if not os.path.isdir(tree_dir):
+        return
+
+    referenced_uuids: set[str] = set()
+    for node in nodes:
+        node_uuid = node.get("uuid", "")
+        if node_uuid:
+            referenced_uuids.add(node_uuid)
+        storage = node.get("storage", {})
+        storage_uuid = storage.get("uuid", "")
+        if storage_uuid:
+            referenced_uuids.add(storage_uuid)
+
+    try:
+        entries = os.listdir(tree_dir)
+    except OSError:
+        return
+
+    for entry in entries:
+        if entry in referenced_uuids:
+            continue
+        orphan_path = os.path.join(tree_dir, entry)
+        if not os.path.isdir(orphan_path):
+            continue
+        try:
+            shutil.rmtree(orphan_path)
+        except OSError as exc:
+            log.debug("Failed to remove orphaned tree dir %s: %s", orphan_path, exc)
+
+
 def _collect_module_owned_files(
     tree: "Any",
     working_dir: str,
@@ -271,11 +320,8 @@ def _collect_module_manifests(tree: "Any") -> list:
     ) -> dict:
         """Build a single module-rooted node descriptor.
 
-        For file-backed children we re-use the file's ``source_rel_path``
-        (set by the bind path / ``tree:create*`` handlers) as the
-        descriptor's ``storage.relative_path``, so on reload the
-        bindImportedModule v4 remap loop can re-prefix it with the new
-        alias.
+        For file-backed children we store ``uuid`` and ``filename`` in
+        the descriptor so the reload path can reconstruct the node.
         """
         kind = detect_kind(value)
         preview = node_preview(value, kind)
@@ -313,12 +359,6 @@ def _collect_module_manifests(tree: "Any") -> list:
             return descriptor
 
         if isinstance(value, PDVFile):
-            # Module-root-relative path is authoritative here — it's the
-            # one we care about on reload. Fall back to the stored
-            # relative_path when ``source_rel_path`` hasn't been set
-            # (shouldn't happen for module-owned files under workflow
-            # A/B, but keep the flow robust).
-            rel_storage = getattr(value, "source_rel_path", None) or value.relative_path
             format_map = {
                 "script": "py_script",
                 "lib": "py_lib",
@@ -328,9 +368,11 @@ def _collect_module_manifests(tree: "Any") -> list:
             }
             storage = {
                 "backend": "local_file",
-                "relative_path": rel_storage,
+                "uuid": value.uuid,
+                "filename": value.filename,
                 "format": format_map.get(kind, "file"),
             }
+            descriptor["uuid"] = value.uuid
             meta: dict = {"preview": preview}
             # Carry the authoring-time ``source_rel_path`` on the
             # descriptor too (for symmetry with how the bind path
@@ -405,6 +447,87 @@ def _collect_module_manifests(tree: "Any") -> list:
             }
         )
     return results
+
+
+def _early_module_setup(
+    nodes: list[dict], save_dir: str, working_dir: str
+) -> None:
+    """Wire module libs into ``sys.path`` and import entry points early.
+
+    Called between Pass 1 (containers) and Pass 2 (leaves) of
+    ``load_tree_index`` during project load. Pass 2 hasn't run yet so
+    ``PDVLib`` objects don't exist in the tree — instead we scan the raw
+    node descriptor list for ``lib`` entries and compute their filesystem
+    paths from uuid + filename directly.
+
+    Entry points are read from ``<save_dir>/modules/<module_id>/pdv-module.json``.
+    Failures are logged but never abort the load — the worst case is the
+    same error the user would have seen before this early-setup path existed.
+    """
+    import importlib  # noqa: PLC0415
+    import json as _json  # noqa: PLC0415
+    import os  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+    import warnings  # noqa: PLC0415
+
+    # Collect module_ids from module-type nodes, and lib paths from lib-type
+    # nodes. A lib node's path prefix tells us which module it belongs to
+    # (e.g. "n_pendulum.lib.n_pendulum" → module alias "n_pendulum").
+    module_ids: dict[str, str] = {}  # alias → module_id
+    lib_dirs: set[str] = set()
+
+    for node in nodes:
+        node_type = node.get("type", "")
+        node_path = node.get("path", "")
+
+        if node_type == "module":
+            meta = node.get("metadata", {})
+            storage = node.get("storage", {})
+            old_meta = storage.get("value", {})
+            module_id = meta.get(
+                "module_id", old_meta.get("module_id", "")
+            )
+            if module_id:
+                module_ids[node_path] = module_id
+
+        elif node_type == "lib":
+            node_uuid = node.get("uuid", node.get("storage", {}).get("uuid", ""))
+            filename = node.get("storage", {}).get("filename", "")
+            if node_uuid and filename and working_dir:
+                lib_file = os.path.join(working_dir, "tree", node_uuid, filename)
+                parent_dir = os.path.dirname(lib_file)
+                if parent_dir:
+                    lib_dirs.add(parent_dir)
+
+    # Wire lib directories into sys.path.
+    for lib_dir in lib_dirs:
+        if lib_dir not in sys.path:
+            sys.path.insert(1, lib_dir)
+
+    # Import entry points for each module.
+    for alias, module_id in module_ids.items():
+        manifest_path = os.path.join(
+            save_dir, "modules", module_id, "pdv-module.json"
+        )
+        if not os.path.isfile(manifest_path):
+            continue
+        try:
+            with open(manifest_path, "r", encoding="utf-8") as fh:
+                manifest = _json.load(fh)
+        except Exception:  # noqa: BLE001
+            continue
+
+        entry_point = manifest.get("entry_point")
+        if not entry_point:
+            continue
+
+        try:
+            importlib.import_module(entry_point)
+        except Exception as exc:  # noqa: BLE001
+            warnings.warn(
+                f"Early module setup: failed to import entry point "
+                f"'{entry_point}' for module '{module_id}': {exc}"
+            )
 
 
 def handle_project_load(msg: dict) -> None:
@@ -496,12 +619,18 @@ def handle_project_load(msg: dict) -> None:
                 },
             )
 
+    def _setup_modules_before_leaves() -> None:
+        """Import module entry points so custom serializers are registered
+        before Pass 2 deserializes data nodes."""
+        _early_module_setup(nodes, save_dir, working_dir)
+
     load_tree_index(
         tree,
         nodes,
         on_progress=_emit_load_progress,
         conflict_strategy="replace",
         working_dir=working_dir,
+        between_passes=_setup_modules_before_leaves,
     )
 
     os.chdir(os.path.expanduser("~"))
@@ -615,6 +744,8 @@ def handle_project_save(msg: dict) -> None:
     with open(tmp_path, "w", encoding="utf-8") as fh:
         fh.write(index_data)
     os.replace(tmp_path, index_path)
+
+    _purge_orphaned_tree_files(save_dir, nodes)
 
     from pdv.checksum import tree_checksum  # noqa: PLC0415
 

--- a/pdv-python/pdv/handlers/project.py
+++ b/pdv-python/pdv/handlers/project.py
@@ -658,6 +658,96 @@ def handle_project_load(msg: dict) -> None:
     )
 
 
+def serialize_tree_to_dir(
+    tree: "Any",
+    save_dir: str,
+    *,
+    on_progress: "Callable[[str, int, int], None] | None" = None,
+) -> dict:
+    """Serialize the in-memory tree to *save_dir* and return save metadata.
+
+    Writes data files and ``tree-index.json``, purges orphaned UUID
+    directories, and computes the tree checksum. This is the core
+    serialization logic shared by ``handle_project_save`` (comm path)
+    and ``PDVApp.save_project`` (direct Python call path).
+
+    Parameters
+    ----------
+    tree : PDVTree
+        Root tree to serialize.
+    save_dir : str
+        Absolute path to the project save directory.
+    on_progress : callable, optional
+        ``(phase, current, total)`` callback for UI progress reporting.
+
+    Returns
+    -------
+    dict
+        ``{"node_count", "checksum", "module_owned_files", "module_manifests"}``.
+
+    Raises
+    ------
+    Exception
+        Propagates serialization, I/O, and checksum errors to the caller.
+    """
+    import json  # noqa: PLC0415
+    import os  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+    import time  # noqa: PLC0415
+
+    t0 = time.monotonic()
+
+    def _log(phase: str) -> None:
+        elapsed = time.monotonic() - t0
+        print(f"[project.save] {phase} ({elapsed:.3f}s)", file=sys.stderr, flush=True)
+
+    os.makedirs(os.path.join(save_dir, "tree"), exist_ok=True)
+
+    working_dir = tree._working_dir or save_dir
+    total = _count_nodes(tree)
+    _log(f"counted {total} nodes")
+
+    def _emit_progress(current: int) -> None:
+        if current % 5 == 0 or current == total:
+            if on_progress is not None:
+                on_progress("Serializing", current, total)
+
+    nodes = _collect_nodes(
+        tree,
+        save_dir,
+        working_dir=working_dir,
+        on_progress=_emit_progress,
+    )
+    _log(f"collected {len(nodes)} node descriptors")
+
+    index_data = json.dumps(nodes, indent=2, default=str)
+    index_path = os.path.join(save_dir, "tree-index.json")
+    tmp_path = index_path + ".tmp"
+    with open(tmp_path, "w", encoding="utf-8") as fh:
+        fh.write(index_data)
+    os.replace(tmp_path, index_path)
+    _log("wrote tree-index.json")
+
+    _purge_orphaned_tree_files(save_dir, nodes)
+    _log("purged orphans")
+
+    from pdv.checksum import tree_checksum  # noqa: PLC0415
+
+    checksum = tree_checksum(tree)
+    _log("computed checksum")
+
+    module_owned_files = _collect_module_owned_files(tree, working_dir)
+    module_manifests = _collect_module_manifests(tree)
+    _log("DONE")
+
+    return {
+        "node_count": len(nodes),
+        "checksum": checksum,
+        "module_owned_files": module_owned_files,
+        "module_manifests": module_manifests,
+    }
+
+
 def handle_project_save(msg: dict) -> None:
     """Handle the ``pdv.project.save`` message.
 
@@ -682,9 +772,6 @@ def handle_project_save(msg: dict) -> None:
     msg : dict
         Parsed PDV message envelope.
     """
-    import json
-    import os
-
     from pdv.comms import get_pdv_tree, send_error, send_message  # noqa: PLC0415
 
     msg_id = msg.get("msg_id")
@@ -700,8 +787,6 @@ def handle_project_save(msg: dict) -> None:
         )
         return
 
-    os.makedirs(os.path.join(save_dir, "tree"), exist_ok=True)
-
     tree = get_pdv_tree()
     if tree is None:
         send_error(
@@ -712,30 +797,19 @@ def handle_project_save(msg: dict) -> None:
         )
         return
 
-    working_dir = tree._working_dir or save_dir
-
-    total = _count_nodes(tree)
-
-    def _emit_save_progress(current: int) -> None:
-        if current % 5 == 0 or current == total:
-            send_message(
-                "pdv.progress",
-                {
-                    "operation": "save",
-                    "phase": "Serializing",
-                    "current": current,
-                    "total": total,
-                },
-            )
+    def _progress(phase: str, current: int, total: int) -> None:
+        send_message(
+            "pdv.progress",
+            {"operation": "save", "phase": phase, "current": current, "total": total},
+        )
 
     try:
-        nodes = _collect_nodes(
-            tree,
-            save_dir,
-            working_dir=working_dir,
-            on_progress=_emit_save_progress,
-        )
+        results = serialize_tree_to_dir(tree, save_dir, on_progress=_progress)
     except Exception as exc:  # noqa: BLE001
+        import sys  # noqa: PLC0415
+        import traceback  # noqa: PLC0415
+        print(f"[project.save] FAILED: {exc}", file=sys.stderr, flush=True)
+        traceback.print_exc(file=sys.stderr)
         send_error(
             "pdv.project.save.response",
             "project.serialization_error",
@@ -744,35 +818,9 @@ def handle_project_save(msg: dict) -> None:
         )
         return
 
-    index_data = json.dumps(nodes, indent=2, default=str)
-    index_path = os.path.join(save_dir, "tree-index.json")
-    tmp_path = index_path + ".tmp"
-    with open(tmp_path, "w", encoding="utf-8") as fh:
-        fh.write(index_data)
-    os.replace(tmp_path, index_path)
-
-    _purge_orphaned_tree_files(save_dir, nodes)
-
-    from pdv.checksum import tree_checksum  # noqa: PLC0415
-
-    checksum = tree_checksum(tree)
-
-    # Enumerate module-owned files so the main process can mirror their
-    # working-dir contents back into <saveDir>/modules/<id>/<source_rel_path>.
-    # See ARCHITECTURE.md §5.13 and the #140 workflow plan §3.
-    module_owned_files = _collect_module_owned_files(tree, working_dir)
-    # Collect per-module manifests for writing pdv-module.json +
-    # module-index.json into <saveDir>/modules/<id>/. See plan §7.
-    module_manifests = _collect_module_manifests(tree)
-
     send_message(
         "pdv.project.save.response",
-        {
-            "node_count": len(nodes),
-            "checksum": checksum,
-            "module_owned_files": module_owned_files,
-            "module_manifests": module_manifests,
-        },
+        results,
         in_reply_to=msg_id,
     )
 

--- a/pdv-python/pdv/handlers/project.py
+++ b/pdv-python/pdv/handlers/project.py
@@ -149,6 +149,8 @@ def _purge_orphaned_tree_files(save_dir: str, nodes: list[dict]) -> None:
     import os  # noqa: PLC0415
     import shutil  # noqa: PLC0415
 
+    from pdv.environment import _NODE_UUID_RE  # noqa: PLC0415
+
     log = logging.getLogger("pdv")
 
     tree_dir = os.path.join(save_dir, "tree")
@@ -172,6 +174,8 @@ def _purge_orphaned_tree_files(save_dir: str, nodes: list[dict]) -> None:
 
     for entry in entries:
         if entry in referenced_uuids:
+            continue
+        if not _NODE_UUID_RE.match(entry):
             continue
         orphan_path = os.path.join(tree_dir, entry)
         if not os.path.isdir(orphan_path):
@@ -442,7 +446,7 @@ def _collect_module_manifests(tree: "Any") -> list:
                 "version": value.version,
                 "description": getattr(value, "description", ""),
                 "language": getattr(value, "language", "python"),
-                "dependencies": list(getattr(value, "_dependencies", []) or []),
+                "dependencies": list(value.dependencies),
                 "entries": entries,
             }
         )
@@ -466,9 +470,9 @@ def _early_module_setup(
     """
     import importlib  # noqa: PLC0415
     import json as _json  # noqa: PLC0415
+    import logging  # noqa: PLC0415
     import os  # noqa: PLC0415
     import sys  # noqa: PLC0415
-    import warnings  # noqa: PLC0415
 
     # Collect module_ids from module-type nodes, and lib paths from lib-type
     # nodes. A lib node's path prefix tells us which module it belongs to
@@ -521,12 +525,14 @@ def _early_module_setup(
         if not entry_point:
             continue
 
+        log = logging.getLogger("pdv")
         try:
             importlib.import_module(entry_point)
         except Exception as exc:  # noqa: BLE001
-            warnings.warn(
-                f"Early module setup: failed to import entry point "
-                f"'{entry_point}' for module '{module_id}': {exc}"
+            log.warning(
+                "Early module setup: failed to import entry point "
+                "'%s' for module '%s': %s",
+                entry_point, module_id, exc,
             )
 
 

--- a/pdv-python/pdv/handlers/project.py
+++ b/pdv-python/pdv/handlers/project.py
@@ -498,7 +498,9 @@ def _early_module_setup(
             node_uuid = node.get("uuid", node.get("storage", {}).get("uuid", ""))
             filename = node.get("storage", {}).get("filename", "")
             if node_uuid and filename and working_dir:
-                lib_file = os.path.join(working_dir, "tree", node_uuid, filename)
+                from pdv.environment import uuid_tree_path  # noqa: PLC0415
+
+                lib_file = uuid_tree_path(working_dir, node_uuid, filename)
                 parent_dir = os.path.dirname(lib_file)
                 if parent_dir:
                     lib_dirs.add(parent_dir)

--- a/pdv-python/pdv/handlers/script.py
+++ b/pdv-python/pdv/handlers/script.py
@@ -32,7 +32,8 @@ def handle_script_register(msg: dict) -> None:
         {
             "parent_path": "scripts.analysis",
             "name": "fit_model",
-            "relative_path": "tree/scripts/analysis/fit_model.py",
+            "uuid": "a1b2c3d4e5f6",
+            "filename": "fit_model.py",
             "language": "python"
         }
 
@@ -53,13 +54,15 @@ def handle_script_register(msg: dict) -> None:
     tree, payload = validated
     parent_path = payload.get("parent_path", "")
     name = payload.get("name", "")
-    relative_path = payload.get("relative_path", "")
+    node_uuid = payload.get("uuid", "")
+    filename = payload.get("filename", "")
     language = payload.get("language", "python")
     source_rel_path = payload.get("source_rel_path")
     module_id = payload.get("module_id", "")
 
     script = PDVScript(
-        relative_path=relative_path,
+        uuid=node_uuid,
+        filename=filename,
         language=language,
         module_id=module_id,
         source_rel_path=source_rel_path,

--- a/pdv-python/pdv/handlers/tree.py
+++ b/pdv-python/pdv/handlers/tree.py
@@ -24,7 +24,6 @@ def _relocate_files(
     working_dir: str,
     *,
     copy: bool = False,
-    filename: str | None = None,
 ) -> None:
     """Duplicate backing files for all PDVFile nodes in *value*.
 

--- a/pdv-python/pdv/handlers/tree.py
+++ b/pdv-python/pdv/handlers/tree.py
@@ -13,7 +13,6 @@ ARCHITECTURE.md §3.4 (tree messages), §7 (tree data model)
 from __future__ import annotations
 
 import os
-import shutil
 
 from pdv.handlers import register
 
@@ -27,17 +26,19 @@ def _relocate_files(
     copy: bool = False,
     filename: str | None = None,
 ) -> None:
-    """Move or copy backing files for all PDVFile nodes in *value*.
+    """Duplicate backing files for all PDVFile nodes in *value*.
 
-    Recursively walks dicts so that container moves/duplicates also
-    relocate every file-backed descendant.  Updates each node's
-    ``_relative_path`` in place to reflect the new tree location.
+    With UUID-based storage, rename/move is a no-op (the file path is
+    independent of the tree path). Only ``copy=True`` (duplicate) needs
+    to create a new file — the duplicate gets a fresh UUID.
+
+    Recursively walks dicts so that container duplicates also handle
+    every file-backed descendant.
     """
     from pdv.tree import PDVFile  # noqa: PLC0415
 
     if isinstance(value, PDVFile):
-        _relocate_single_file(value, new_tree_path, working_dir,
-                              copy=copy, filename=filename)
+        _relocate_single_file(value, working_dir, copy=copy)
     elif isinstance(value, dict):
         for key in list(dict.keys(value)):
             child = dict.__getitem__(value, key)
@@ -49,43 +50,33 @@ def _relocate_files(
 
 def _relocate_single_file(
     file_node: object,
-    new_tree_path: str,
     working_dir: str,
     *,
     copy: bool = False,
-    filename: str | None = None,
 ) -> None:
-    """Move or copy one backing file and update its ``_relative_path``.
+    """Handle file relocation for a single PDVFile node.
 
-    *filename* overrides the destination filename.  When ``None``, the
-    new filename is derived from the last segment of *new_tree_path*
-    plus the original file extension.
+    With UUID-based storage, rename/move requires no file system
+    operation — the backing file path is independent of the tree path.
+
+    For duplicates (``copy=True``), a new UUID is assigned and the
+    backing file is copied to the new UUID directory.
     """
+    from pdv.environment import generate_node_uuid, smart_copy, uuid_tree_path  # noqa: PLC0415
     from pdv.tree import PDVFile  # noqa: PLC0415
+
     if not isinstance(file_node, PDVFile):
         raise TypeError(f"Expected PDVFile, got {type(file_node).__name__}")
 
+    if not copy:
+        return
+
     old_abs = file_node.resolve_path(working_dir)
-
-    if filename:
-        new_filename = filename
-    else:
-        _, ext = os.path.splitext(os.path.basename(file_node.relative_path))
-        new_key = new_tree_path.split(".")[-1]
-        new_filename = new_key + ext
-
-    new_parts = new_tree_path.split(".")
-    new_rel = os.path.join("tree", *new_parts[:-1], new_filename)
-    new_abs = os.path.join(working_dir, new_rel)
-
-    if os.path.exists(old_abs) and old_abs != new_abs:
-        os.makedirs(os.path.dirname(new_abs), exist_ok=True)
-        if copy:
-            shutil.copy2(old_abs, new_abs)
-        else:
-            shutil.move(old_abs, new_abs)
-
-    file_node._relative_path = new_rel
+    new_uuid = generate_node_uuid()
+    new_abs = uuid_tree_path(working_dir, new_uuid, file_node.filename)
+    if os.path.exists(old_abs):
+        smart_copy(old_abs, new_abs)
+    file_node._uuid = new_uuid
 
 
 def handle_tree_list(msg: dict) -> None:

--- a/pdv-python/pdv/namespace.py
+++ b/pdv-python/pdv/namespace.py
@@ -7,7 +7,9 @@ This module provides:
   namespace. Blocks reassignment of ``pdv_tree`` and ``pdv``.
 
 - :class:`PDVApp`: the ``pdv`` object injected into the namespace.
-  Exposes ``pdv.save()``, ``pdv.help()`` to users.
+  Exposes ``pdv.save()``, ``pdv.save_project()``,
+  ``pdv.save_project_as()``, ``pdv.open_project()``,
+  ``pdv.help()`` to users.
 
 - :func:`pdv_namespace`: returns a snapshot of the current kernel
   namespace for display in the Namespace panel, excluding PDV internals
@@ -127,15 +129,86 @@ class PDVApp:
     def save(self) -> None:
         """Trigger a project save. Equivalent to File -> Save in the UI.
 
-        Sends a ``pdv.project.save`` comm message to the app. The app
+        Sends a ``pdv.project.save_request`` push to the app. The app
         will prompt for a save location if no project is currently open.
         """
         try:
             from pdv.comms import send_message  # noqa: PLC0415
 
-            send_message("pdv.project.save", {})
+            send_message("pdv.project.save_request", {})
         except RuntimeError:
             print("PDV: No comm channel open. Cannot trigger save.")
+
+    def save_project(self, path: str | None = None) -> None:
+        """Save the current project to a directory.
+
+        Sends a request to the app to perform a full project save
+        (tree serialization, code cells, manifest). Equivalent to
+        File -> Save with an explicit directory.
+
+        Parameters
+        ----------
+        path : str or None
+            Absolute or ``~``-prefixed path to the project directory.
+            If None, saves to the current project location (equivalent
+            to :meth:`save`).
+        """
+        try:
+            import os  # noqa: PLC0415
+
+            from pdv.comms import send_message  # noqa: PLC0415
+
+            if path is not None:
+                resolved = os.path.realpath(os.path.expanduser(path))
+                send_message("pdv.project.save_request", {"save_dir": resolved})
+            else:
+                send_message("pdv.project.save_request", {})
+        except RuntimeError:
+            print("PDV: No comm channel open. Cannot trigger save.")
+
+    def save_project_as(self, path: str) -> None:
+        """Save the project to a new directory (Save As).
+
+        Like :meth:`save_project`, but the given path becomes the new
+        active project directory. Equivalent to File -> Save As with
+        an explicit directory.
+
+        Parameters
+        ----------
+        path : str
+            Absolute or ``~``-prefixed path to the new project directory.
+        """
+        try:
+            import os  # noqa: PLC0415
+
+            from pdv.comms import send_message  # noqa: PLC0415
+
+            resolved = os.path.realpath(os.path.expanduser(path))
+            send_message("pdv.project.save_as_request", {"save_dir": resolved})
+        except RuntimeError:
+            print("PDV: No comm channel open. Cannot trigger save.")
+
+    def open_project(self, path: str) -> None:
+        """Open a project from a directory.
+
+        Sends a request to the app to load the project at the given
+        path. The current tree and code cells will be replaced with
+        the contents of the loaded project.
+
+        Parameters
+        ----------
+        path : str
+            Absolute or ``~``-prefixed path to the project directory.
+        """
+        try:
+            import os  # noqa: PLC0415
+
+            from pdv.comms import send_message  # noqa: PLC0415
+
+            resolved = os.path.realpath(os.path.expanduser(path))
+            send_message("pdv.project.open_request", {"save_dir": resolved})
+        except RuntimeError:
+            print("PDV: No comm channel open. Cannot open project.")
 
     def add_file(self, source_path: str) -> "PDVFile":
         """Import an arbitrary file into the tree as a :class:`PDVFile`.
@@ -261,6 +334,9 @@ class PDVApp:
                 "  pdv_tree.run_script('path') — run a script node\n"
                 "  pdv.working_dir   — Path to the session working dir (for data files)\n"
                 "  pdv.save()        — save the project\n"
+                "  pdv.save_project('path')    — save project to a directory\n"
+                "  pdv.save_project_as('path') — save project to a new directory (Save As)\n"
+                "  pdv.open_project('path')    — open a project from a directory\n"
                 "  pdv.add_file('path/to/file') — import a file into the tree\n"
                 "  pdv.new_note('path', title='My Note') — create a markdown note\n"
                 "  pdv.help('pdv_tree') — help on a specific topic\n"

--- a/pdv-python/pdv/namespace.py
+++ b/pdv-python/pdv/namespace.py
@@ -137,6 +137,69 @@ class PDVApp:
         except RuntimeError:
             print("PDV: No comm channel open. Cannot trigger save.")
 
+    def add_file(self, source_path: str) -> "PDVFile":
+        """Import an arbitrary file into the tree as a :class:`PDVFile`.
+
+        Eagerly copies the source file into the session working directory
+        under a fresh UUID-based storage path. The returned node is not
+        yet attached to the tree — assign it at the desired tree path::
+
+            mesh = pdv.add_file("~/Downloads/mesh.h5")
+            pdv_tree["simulation.mesh"] = mesh
+
+        If the returned node is never assigned to the tree, the copied
+        file is cleaned up when the kernel's temp working dir is wiped
+        at session end.
+
+        Parameters
+        ----------
+        source_path : str
+            Filesystem path to the source file. ``~`` is expanded.
+
+        Returns
+        -------
+        PDVFile
+            A new file-backed node wrapping the imported file.
+
+        Raises
+        ------
+        FileNotFoundError
+            If ``source_path`` does not exist.
+        ValueError
+            If ``source_path`` is not a regular file.
+        PDVError
+            If no kernel working directory is available (the kernel has
+            not yet received ``pdv.init``).
+        """
+        import os  # noqa: PLC0415
+
+        from pdv.comms import get_pdv_tree  # noqa: PLC0415
+        from pdv.environment import (  # noqa: PLC0415
+            generate_node_uuid,
+            smart_copy,
+            uuid_tree_path,
+        )
+        from pdv.tree import PDVFile  # noqa: PLC0415
+
+        resolved = os.path.realpath(os.path.expanduser(source_path))
+        if not os.path.exists(resolved):
+            raise FileNotFoundError(f"Source file not found: {source_path}")
+        if not os.path.isfile(resolved):
+            raise ValueError(f"Source path is not a file: {source_path}")
+
+        tree = get_pdv_tree()
+        working_dir = getattr(tree, "_working_dir", None) if tree is not None else None
+        if not working_dir:
+            raise PDVError(
+                "pdv.add_file is not available: kernel has not received pdv.init"
+            )
+
+        filename = os.path.basename(resolved)
+        node_uuid = generate_node_uuid()
+        dest = uuid_tree_path(working_dir, node_uuid, filename)
+        smart_copy(resolved, dest)
+        return PDVFile(uuid=node_uuid, filename=filename)
+
     def new_note(self, path: str, title: str | None = None) -> None:
         """Create a markdown note in the tree.
 
@@ -198,6 +261,7 @@ class PDVApp:
                 "  pdv_tree.run_script('path') — run a script node\n"
                 "  pdv.working_dir   — Path to the session working dir (for data files)\n"
                 "  pdv.save()        — save the project\n"
+                "  pdv.add_file('path/to/file') — import a file into the tree\n"
                 "  pdv.new_note('path', title='My Note') — create a markdown note\n"
                 "  pdv.help('pdv_tree') — help on a specific topic\n"
             )

--- a/pdv-python/pdv/namespace.py
+++ b/pdv-python/pdv/namespace.py
@@ -142,36 +142,55 @@ class PDVApp:
     def save_project(self, path: str | None = None) -> None:
         """Save the current project to a directory.
 
-        Sends a request to the app to perform a full project save
-        (tree serialization, code cells, manifest). Equivalent to
-        File -> Save with an explicit directory.
+        Serializes the tree synchronously (avoiding a comm round-trip
+        that would deadlock while the kernel shell is busy), then sends
+        a ``pdv.project.save_completed`` push so the app can write the
+        remaining manifest and code-cell files.
 
         Parameters
         ----------
         path : str or None
             Absolute or ``~``-prefixed path to the project directory.
-            If None, saves to the current project location (equivalent
-            to :meth:`save`).
+            If None, saves to the current project location (falls back
+            to :meth:`save` if no project is open).
         """
         try:
             import os  # noqa: PLC0415
 
-            from pdv.comms import send_message  # noqa: PLC0415
+            from pdv.comms import get_pdv_tree, send_message  # noqa: PLC0415
 
+            tree = get_pdv_tree()
+            if tree is None:
+                print("PDV: Tree is not initialized. Cannot save.")
+                return
+
+            save_dir: str | None = None
             if path is not None:
-                resolved = os.path.realpath(os.path.expanduser(path))
-                send_message("pdv.project.save_request", {"save_dir": resolved})
+                save_dir = os.path.realpath(os.path.expanduser(path))
             else:
+                save_dir = getattr(tree, "_save_dir", None)
+
+            if not save_dir:
                 send_message("pdv.project.save_request", {})
+                return
+
+            from pdv.handlers.project import serialize_tree_to_dir  # noqa: PLC0415
+
+            results = serialize_tree_to_dir(tree, save_dir)
+            send_message(
+                "pdv.project.save_completed",
+                {"save_dir": save_dir, **results},
+            )
         except RuntimeError:
             print("PDV: No comm channel open. Cannot trigger save.")
+        except Exception as exc:  # noqa: BLE001
+            print(f"PDV: save_project failed: {exc}")
 
     def save_project_as(self, path: str) -> None:
         """Save the project to a new directory (Save As).
 
         Like :meth:`save_project`, but the given path becomes the new
-        active project directory. Equivalent to File -> Save As with
-        an explicit directory.
+        active project directory.
 
         Parameters
         ----------
@@ -181,12 +200,26 @@ class PDVApp:
         try:
             import os  # noqa: PLC0415
 
-            from pdv.comms import send_message  # noqa: PLC0415
+            from pdv.comms import get_pdv_tree, send_message  # noqa: PLC0415
+
+            tree = get_pdv_tree()
+            if tree is None:
+                print("PDV: Tree is not initialized. Cannot save.")
+                return
 
             resolved = os.path.realpath(os.path.expanduser(path))
-            send_message("pdv.project.save_as_request", {"save_dir": resolved})
+
+            from pdv.handlers.project import serialize_tree_to_dir  # noqa: PLC0415
+
+            results = serialize_tree_to_dir(tree, resolved)
+            send_message(
+                "pdv.project.save_completed",
+                {"save_dir": resolved, **results},
+            )
         except RuntimeError:
             print("PDV: No comm channel open. Cannot trigger save.")
+        except Exception as exc:  # noqa: BLE001
+            print(f"PDV: save_project_as failed: {exc}")
 
     def open_project(self, path: str) -> None:
         """Open a project from a directory.
@@ -343,6 +376,17 @@ class PDVApp:
             )
         else:
             print(f"PDV help for topic '{topic}' is not yet implemented.")
+
+    def __getattr__(self, name: str) -> Any:
+        import sys  # noqa: PLC0415
+
+        pdv_module = sys.modules.get("pdv")
+        if pdv_module is not None:
+            try:
+                return getattr(pdv_module, name)
+            except (AttributeError, RuntimeError):
+                pass
+        raise AttributeError(f"'PDVApp' object has no attribute {name!r}")
 
     def __repr__(self) -> str:
         return "<PDV app object — type pdv.help() for usage>"

--- a/pdv-python/pdv/namespace.py
+++ b/pdv-python/pdv/namespace.py
@@ -162,22 +162,21 @@ class PDVApp:
             print("PDV: Tree is not initialized. Cannot create note.")
             return
 
+        from pdv.environment import ensure_parent, generate_node_uuid, uuid_tree_path  # noqa: PLC0415
+
         working_dir = getattr(tree, "_working_dir", None) or "."
         segments = path.split(".")
-        file_dir = (
-            os.path.join(working_dir, *segments[:-1])
-            if len(segments) > 1
-            else working_dir
-        )
-        os.makedirs(file_dir, exist_ok=True)
-        file_path = os.path.join(file_dir, segments[-1] + ".md")
+        filename = segments[-1] + ".md"
+        node_uuid = generate_node_uuid()
+        file_path = uuid_tree_path(working_dir, node_uuid, filename)
+        ensure_parent(file_path)
 
         if not os.path.exists(file_path):
             with open(file_path, "w", encoding="utf-8") as fh:
                 if title:
                     fh.write(f"# {title}\n")
 
-        note = PDVNote(relative_path=file_path, title=title)
+        note = PDVNote(uuid=node_uuid, filename=filename, title=title)
         tree[path] = note
         print(f"Created note at '{path}'")
 

--- a/pdv-python/pdv/serialization.py
+++ b/pdv-python/pdv/serialization.py
@@ -70,6 +70,7 @@ FORMAT_GUI_JSON = "gui_json"
 FORMAT_MODULE_META = "module_meta"
 FORMAT_NAMELIST = "namelist"
 FORMAT_PY_LIB = "py_lib"
+FORMAT_FILE = "file"
 
 
 def _parquet_engine() -> str:
@@ -433,6 +434,20 @@ def serialize_node(
         }
         return descriptor
 
+    if kind == KIND_FILE:
+        source_path = value.resolve_path(_source_dir)
+        if not os.path.exists(source_path):
+            raise PDVSerializationError(f"File not found: {source_path}")
+        node_uuid = value.uuid
+        node_filename = value.filename
+        dest_path = uuid_tree_path(working_dir, node_uuid, node_filename)
+        if os.path.abspath(source_path) != os.path.abspath(dest_path):
+            smart_copy(source_path, dest_path)
+        descriptor["uuid"] = node_uuid
+        descriptor["storage"] = _file_storage(node_uuid, node_filename, FORMAT_FILE)
+        descriptor["metadata"] = {"preview": preview}
+        return descriptor
+
     if kind == KIND_NDARRAY:
         import numpy as np  # noqa: PLC0415
 
@@ -760,6 +775,10 @@ def deserialize_node(storage_ref: dict, save_dir: str, *, trusted: bool = False)
             with open(abs_path, "rb") as fh:
                 return fh.read()
 
+        if fmt == FORMAT_FILE:
+            with open(abs_path, "rb") as fh:
+                return fh.read()
+
         if fmt == FORMAT_PICKLE:
             if not trusted:
                 raise PDVSerializationError(
@@ -811,6 +830,8 @@ def node_preview(value: Any, kind: str) -> str:
             return value.preview() if hasattr(value, "preview") else kind
         if kind in (KIND_SCRIPT, KIND_MARKDOWN):
             return value.preview() if hasattr(value, "preview") else kind
+        if kind == KIND_FILE:
+            return value.preview() if hasattr(value, "preview") else "file"
         if kind == KIND_SCALAR:
             return str(value)[:100]
         if kind == KIND_TEXT:

--- a/pdv-python/pdv/serialization.py
+++ b/pdv-python/pdv/serialization.py
@@ -303,9 +303,13 @@ def serialize_node(
     import json
     import os
     import pickle
-    import shutil
 
-    from pdv.environment import ensure_parent, working_dir_tree_path  # noqa: PLC0415
+    from pdv.environment import (  # noqa: PLC0415
+        ensure_parent,
+        generate_node_uuid,
+        smart_copy,
+        uuid_tree_path,
+    )
     from pdv.tree import PDVFile, PDVScript, PDVLib, PDVGui, PDVNote  # noqa: PLC0415
 
     # File extension and format for each PDVFile subclass
@@ -315,6 +319,14 @@ def serialize_node(
         KIND_GUI: (".gui.json", FORMAT_GUI_JSON),
         KIND_LIB: (".py", FORMAT_PY_LIB),
     }
+
+    def _file_storage(node_uuid: str, filename: str, fmt: str) -> dict:
+        return {
+            "backend": "local_file",
+            "uuid": node_uuid,
+            "filename": filename,
+            "format": fmt,
+        }
 
     _source_dir = source_dir or working_dir
 
@@ -371,35 +383,17 @@ def serialize_node(
 
     # -- PDVFile subclasses (PDVScript, PDVNote, future file types) -----------
     if kind in _FILE_KIND_MAP:
-        ext, fmt = _FILE_KIND_MAP[kind]
+        _ext, fmt = _FILE_KIND_MAP[kind]
         source_path = value.resolve_path(_source_dir)  # type: ignore[union-attr]
         if not os.path.exists(source_path):
             raise PDVSerializationError(f"File not found: {source_path}")
-        if isinstance(value, PDVLib):
-            # Lib files keep their original filename so that the Python import
-            # name stays consistent (e.g. n_pendulum.py → import n_pendulum).
-            # working_dir_tree_path would derive the name from the tree key,
-            # which has been mangled (n_pendulum_py).
-            if os.path.isabs(value.relative_path):
-                rel_path = os.path.relpath(source_path, _source_dir)
-            else:
-                rel_path = value.relative_path
-            # Copy lib file to save dir so it persists with the project
-            dest_path = os.path.join(working_dir, rel_path)
-            if os.path.abspath(source_path) != os.path.abspath(dest_path):
-                ensure_parent(dest_path)
-                shutil.copy2(source_path, dest_path)
-        else:
-            file_path = working_dir_tree_path(working_dir, tree_path, ext)
-            ensure_parent(file_path)
-            if os.path.abspath(source_path) != os.path.abspath(file_path):
-                shutil.copy2(source_path, file_path)
-            rel_path = os.path.relpath(file_path, working_dir)
-        descriptor["storage"] = {
-            "backend": "local_file",
-            "relative_path": rel_path,
-            "format": fmt,
-        }
+        node_uuid = value.uuid  # type: ignore[union-attr]
+        node_filename = value.filename  # type: ignore[union-attr]
+        dest_path = uuid_tree_path(working_dir, node_uuid, node_filename)
+        if os.path.abspath(source_path) != os.path.abspath(dest_path):
+            smart_copy(source_path, dest_path)
+        descriptor["uuid"] = node_uuid
+        descriptor["storage"] = _file_storage(node_uuid, node_filename, fmt)
         # Build type-specific metadata
         meta: dict[str, Any] = {"preview": preview}
         if isinstance(value, PDVScript):
@@ -421,20 +415,16 @@ def serialize_node(
         return descriptor
 
     if kind == KIND_NAMELIST:
-        ext = os.path.splitext(value.relative_path)[1] or ".nml"
         source_path = value.resolve_path(_source_dir)
         if not os.path.exists(source_path):
             raise PDVSerializationError(f"File not found: {source_path}")
-        file_path = working_dir_tree_path(working_dir, tree_path, ext)
-        ensure_parent(file_path)
-        if os.path.abspath(source_path) != os.path.abspath(file_path):
-            shutil.copy2(source_path, file_path)
-        rel_path = os.path.relpath(file_path, working_dir)
-        descriptor["storage"] = {
-            "backend": "local_file",
-            "relative_path": rel_path,
-            "format": FORMAT_NAMELIST,
-        }
+        node_uuid = value.uuid
+        node_filename = value.filename
+        dest_path = uuid_tree_path(working_dir, node_uuid, node_filename)
+        if os.path.abspath(source_path) != os.path.abspath(dest_path):
+            smart_copy(source_path, dest_path)
+        descriptor["uuid"] = node_uuid
+        descriptor["storage"] = _file_storage(node_uuid, node_filename, FORMAT_NAMELIST)
         descriptor["metadata"] = {
             "module_id": value.module_id,
             "namelist_format": value.format,
@@ -446,15 +436,13 @@ def serialize_node(
     if kind == KIND_NDARRAY:
         import numpy as np  # noqa: PLC0415
 
-        file_path = working_dir_tree_path(working_dir, tree_path, ".npy")
+        node_uuid = generate_node_uuid()
+        filename = key + ".npy"
+        file_path = uuid_tree_path(working_dir, node_uuid, filename)
         ensure_parent(file_path)
         np.save(file_path, value)
-        rel_path = os.path.relpath(file_path, working_dir)
-        descriptor["storage"] = {
-            "backend": "local_file",
-            "relative_path": rel_path,
-            "format": FORMAT_NPY,
-        }
+        descriptor["uuid"] = node_uuid
+        descriptor["storage"] = _file_storage(node_uuid, filename, FORMAT_NPY)
         descriptor["metadata"] = {
             "shape": list(value.shape),
             "dtype": str(value.dtype),
@@ -464,15 +452,13 @@ def serialize_node(
         return descriptor
 
     if kind in (KIND_DATAFRAME, KIND_SERIES):
-        file_path = working_dir_tree_path(working_dir, tree_path, ".parquet")
+        node_uuid = generate_node_uuid()
+        filename = key + ".parquet"
+        file_path = uuid_tree_path(working_dir, node_uuid, filename)
         ensure_parent(file_path)
         _write_parquet(value, file_path)
-        rel_path = os.path.relpath(file_path, working_dir)
-        descriptor["storage"] = {
-            "backend": "local_file",
-            "relative_path": rel_path,
-            "format": FORMAT_PARQUET,
-        }
+        descriptor["uuid"] = node_uuid
+        descriptor["storage"] = _file_storage(node_uuid, filename, FORMAT_PARQUET)
         if kind == KIND_DATAFRAME:
             shape = list(value.shape)  # type: ignore[union-attr]
         else:
@@ -501,16 +487,14 @@ def serialize_node(
                 "value": value,
             }
         else:
-            file_path = working_dir_tree_path(working_dir, tree_path, ".txt")
+            node_uuid = generate_node_uuid()
+            filename = key + ".txt"
+            file_path = uuid_tree_path(working_dir, node_uuid, filename)
             ensure_parent(file_path)
             with open(file_path, "w", encoding="utf-8") as fh:
                 fh.write(value)  # type: ignore[arg-type]
-            rel_path = os.path.relpath(file_path, working_dir)
-            descriptor["storage"] = {
-                "backend": "local_file",
-                "relative_path": rel_path,
-                "format": FORMAT_TXT,
-            }
+            descriptor["uuid"] = node_uuid
+            descriptor["storage"] = _file_storage(node_uuid, filename, FORMAT_TXT)
         descriptor["metadata"] = {"preview": preview}
         return descriptor
 
@@ -551,16 +535,14 @@ def serialize_node(
         )
 
     if kind == KIND_BINARY:
-        file_path = working_dir_tree_path(working_dir, tree_path, ".bin")
+        node_uuid = generate_node_uuid()
+        filename = key + ".bin"
+        file_path = uuid_tree_path(working_dir, node_uuid, filename)
         ensure_parent(file_path)
         with open(file_path, "wb") as fh:
             fh.write(value)  # type: ignore[arg-type]
-        rel_path = os.path.relpath(file_path, working_dir)
-        descriptor["storage"] = {
-            "backend": "local_file",
-            "relative_path": rel_path,
-            "format": "bin",
-        }
+        descriptor["uuid"] = node_uuid
+        descriptor["storage"] = _file_storage(node_uuid, filename, "bin")
         descriptor["metadata"] = {"preview": preview}
         return descriptor
 
@@ -569,7 +551,9 @@ def serialize_node(
 
     custom = _serializers.find_for_value(value)
     if custom is not None:
-        file_path = working_dir_tree_path(working_dir, tree_path, custom.extension)
+        node_uuid = generate_node_uuid()
+        filename = key + custom.extension
+        file_path = uuid_tree_path(working_dir, node_uuid, filename)
         ensure_parent(file_path)
         try:
             custom.save(value, file_path)
@@ -578,12 +562,8 @@ def serialize_node(
                 f"Custom serializer '{custom.class_name}' failed to save "
                 f"value at '{tree_path}': {exc}"
             ) from exc
-        rel_path = os.path.relpath(file_path, working_dir)
-        descriptor["storage"] = {
-            "backend": "local_file",
-            "relative_path": rel_path,
-            "format": custom.format,
-        }
+        descriptor["uuid"] = node_uuid
+        descriptor["storage"] = _file_storage(node_uuid, filename, custom.format)
         descriptor["metadata"] = {
             "preview": preview,
             "python_type": python_type_string(value),
@@ -597,16 +577,14 @@ def serialize_node(
             f"'{tree_path}'. Register a custom serializer with "
             f"pdv.register_serializer(), or pass trusted=True to allow pickle."
         )
-    file_path = working_dir_tree_path(working_dir, tree_path, ".pickle")
+    node_uuid = generate_node_uuid()
+    filename = key + ".pickle"
+    file_path = uuid_tree_path(working_dir, node_uuid, filename)
     ensure_parent(file_path)
     with open(file_path, "wb") as fh:
         pickle.dump(value, fh)
-    rel_path = os.path.relpath(file_path, working_dir)
-    descriptor["storage"] = {
-        "backend": "local_file",
-        "relative_path": rel_path,
-        "format": FORMAT_PICKLE,
-    }
+    descriptor["uuid"] = node_uuid
+    descriptor["storage"] = _file_storage(node_uuid, filename, FORMAT_PICKLE)
     descriptor["metadata"] = {"preview": preview}
     return descriptor
 
@@ -652,19 +630,24 @@ def pickle_fallback_node(tree_path: str, value: Any, working_dir: str) -> dict:
     import os
     import pickle
 
-    from pdv.environment import ensure_parent, working_dir_tree_path  # noqa: PLC0415
+    from pdv.environment import (  # noqa: PLC0415
+        ensure_parent,
+        generate_node_uuid,
+        uuid_tree_path,
+    )
 
-    file_path = working_dir_tree_path(working_dir, tree_path, ".pickle")
+    node_uuid = generate_node_uuid()
+    parts = tree_path.split(".")
+    key = parts[-1]
+    filename = key + ".pickle"
+    file_path = uuid_tree_path(working_dir, node_uuid, filename)
     ensure_parent(file_path)
     with open(file_path, "wb") as fh:
         pickle.dump(value, fh)
-    rel_path = os.path.relpath(file_path, working_dir)
 
     now = (
         datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
     )
-    parts = tree_path.split(".")
-    key = parts[-1]
     parent_path = ".".join(parts[:-1]) if len(parts) > 1 else ""
 
     return {
@@ -673,12 +656,14 @@ def pickle_fallback_node(tree_path: str, value: Any, working_dir: str) -> dict:
         "key": key,
         "parent_path": parent_path,
         "type": KIND_UNKNOWN,
+        "uuid": node_uuid,
         "has_children": False,
         "created_at": now,
         "updated_at": now,
         "storage": {
             "backend": "local_file",
-            "relative_path": rel_path,
+            "uuid": node_uuid,
+            "filename": filename,
             "format": FORMAT_PICKLE,
         },
         "metadata": {
@@ -696,7 +681,8 @@ def deserialize_node(storage_ref: dict, save_dir: str, *, trusted: bool = False)
     ----------
     storage_ref : dict
         Storage reference dict as defined in ARCHITECTURE.md §7.3.
-        Must contain ``backend``, ``relative_path``, and ``format``.
+        Must contain ``backend``, and for ``local_file`` backend:
+        ``uuid``, ``filename``, and ``format``.
     save_dir : str
         Absolute path to the project save directory (or working directory
         for session-local files).
@@ -726,6 +712,8 @@ def deserialize_node(storage_ref: dict, save_dir: str, *, trusted: bool = False)
     import os
     import pickle
 
+    from pdv.environment import uuid_tree_path  # noqa: PLC0415
+
     backend = storage_ref.get("backend", "")
 
     if backend == "none":
@@ -737,8 +725,9 @@ def deserialize_node(storage_ref: dict, save_dir: str, *, trusted: bool = False)
 
     if backend == "local_file":
         fmt = storage_ref.get("format", "")
-        rel_path = storage_ref.get("relative_path", "")
-        abs_path = os.path.join(save_dir, rel_path)
+        node_uuid = storage_ref.get("uuid", "")
+        filename = storage_ref.get("filename", "")
+        abs_path = uuid_tree_path(save_dir, node_uuid, filename)
 
         if not os.path.exists(abs_path):
             raise FileNotFoundError(f"Backing file not found: {abs_path}")

--- a/pdv-python/pdv/tree.py
+++ b/pdv-python/pdv/tree.py
@@ -975,7 +975,10 @@ class PDVTree(dict):
         """Set a value by key or dot-separated path.
 
         Creates intermediate :class:`PDVTree` nodes as needed.
-        Emits a ``pdv.tree.changed`` push notification.
+        Emits a ``pdv.tree.changed`` push notification for the leaf path
+        **and for any intermediate containers that are newly created
+        (or replaced) as a side effect**, so renderers that rely on
+        changed_paths to know what to refetch see every mutation.
 
         Parameters
         ----------
@@ -984,13 +987,35 @@ class PDVTree(dict):
         value : Any
             The value to store.
         """
-        # Determine change_type before modifying
+        parts = _split_dot_path(key)
+
+        # Walk the existing tree to find which prefix paths will be
+        # newly created (or replaced, in the "non-dict intermediate"
+        # branch of set_quiet). Once we hit the first missing/non-dict
+        # segment, every deeper intermediate prefix is also new.
+        added_prefixes: list[str] = []
+        current: dict = self
+        for i in range(len(parts) - 1):
+            part = parts[i]
+            needs_create = not dict.__contains__(current, part) or not isinstance(
+                dict.__getitem__(current, part), dict
+            )
+            if needs_create:
+                for j in range(i, len(parts) - 1):
+                    added_prefixes.append(".".join(parts[: j + 1]))
+                break
+            current = dict.__getitem__(current, part)
+
         try:
             exists = key in self
         except Exception:
             exists = False
         change_type = "updated" if exists else "added"
         self.set_quiet(key, value)
+
+        # Ancestors first so renderers can refresh top-down.
+        for prefix in added_prefixes:
+            self._emit_changed(prefix, "added")
         self._emit_changed(key, change_type)
 
     def __delitem__(self, key: str) -> None:

--- a/pdv-python/pdv/tree.py
+++ b/pdv-python/pdv/tree.py
@@ -8,7 +8,7 @@ This module is the core of the pdv package. It implements:
   notifications on mutation (when a comm is attached).
 
 - :class:`PDVFile`: base class for file-backed tree nodes. Provides shared
-  ``relative_path`` storage and ``resolve_path()`` for consistent path
+  UUID-based storage and ``resolve_path()`` for consistent path
   resolution across all file-backed node types.
 
 - :class:`PDVScript`: a lightweight wrapper for a script file stored as
@@ -208,14 +208,16 @@ class PDVFile:
     """
     Base class for file-backed PDV tree nodes.
 
-    Provides shared ``relative_path`` storage and ``preview()`` interface
+    Provides shared UUID-based file storage and ``preview()`` interface
     used by both :class:`PDVScript` and :class:`PDVNote`, and any future
     file-backed node types (images, data files, etc.).
 
     Parameters
     ----------
-    relative_path : str
-        Path to the backing file (absolute or relative to working dir).
+    uuid : str
+        12-hex-character UUID identifying this node's storage directory.
+    filename : str
+        Original filename including extension (e.g. ``'fit.py'``).
     source_rel_path : str or None
         For module-owned files, the path of this file relative to the
         **module root** (e.g. ``"scripts/run.py"`` or ``"lib/helpers.py"``)
@@ -232,22 +234,33 @@ class PDVFile:
 
     def __init__(
         self,
-        relative_path: str,
+        uuid: str,
+        filename: str,
         source_rel_path: str | None = None,
     ) -> None:
-        self._relative_path = relative_path
+        self._uuid = uuid
+        self._filename = filename
         self._source_rel_path = source_rel_path
 
     @property
-    def relative_path(self) -> str:
-        """Path to the backing file.
+    def uuid(self) -> str:
+        """12-hex-character UUID for this node's storage directory.
 
         Returns
         -------
         str
-            File path (absolute or relative to working dir).
         """
-        return self._relative_path
+        return self._uuid
+
+    @property
+    def filename(self) -> str:
+        """Original filename including extension.
+
+        Returns
+        -------
+        str
+        """
+        return self._filename
 
     @property
     def source_rel_path(self) -> str | None:
@@ -265,24 +278,38 @@ class PDVFile:
     def resolve_path(self, working_dir: str | None = None) -> str:
         """Resolve the backing file to an absolute path.
 
+        Computes ``<working_dir>/tree/<uuid>/<filename>``.
+
         Parameters
         ----------
         working_dir : str or None
-            Working directory to resolve relative paths against. When the
-            stored ``relative_path`` is itself absolute this argument is
-            ignored. When it is relative and ``working_dir`` is falsy, the
-            current process working directory (``os.getcwd()``) is used as
-            a last-resort base so the returned path is always absolute.
+            Working directory (or save directory) containing the
+            ``tree/`` subdirectory. When ``None``, the current session's
+            working directory is obtained from the global ``pdv_tree``.
 
         Returns
         -------
         str
             Absolute file path.
+
+        Raises
+        ------
+        RuntimeError
+            If no working directory is available (no argument and no
+            active session).
         """
-        if os.path.isabs(self._relative_path):
-            return self._relative_path
-        base = working_dir or os.getcwd()
-        return os.path.join(base, self._relative_path)
+        if working_dir is None:
+            from pdv.comms import get_pdv_tree  # noqa: PLC0415
+
+            tree = get_pdv_tree()
+            if tree is not None:
+                working_dir = getattr(tree, "_working_dir", None)
+        if working_dir is None:
+            raise RuntimeError(
+                "Cannot resolve file path: no working directory. "
+                "Pass working_dir explicitly or ensure a PDV session is active."
+            )
+        return os.path.join(working_dir, "tree", self._uuid, self._filename)
 
     def preview(self) -> str:
         """Return a short human-readable preview for the tree panel.
@@ -293,11 +320,11 @@ class PDVFile:
             Preview string. Subclasses should override for domain-specific
             previews.
         """
-        return os.path.basename(self._relative_path)
+        return self._filename
 
     def __repr__(self) -> str:
         cls = type(self).__name__
-        return f"{cls}('{self._relative_path}')"
+        return f"{cls}(uuid='{self._uuid}', filename='{self._filename}')"
 
 
 class PDVScript(PDVFile):
@@ -310,8 +337,10 @@ class PDVScript(PDVFile):
 
     Parameters
     ----------
-    relative_path : str
-        Path of the script file relative to the project root.
+    uuid : str
+        12-hex-character UUID for this node's storage directory.
+    filename : str
+        Script filename including extension (e.g. ``'fit.py'``).
     language : str
         Language of the script. Currently only ``'python'`` is supported.
     doc : str or None
@@ -325,13 +354,14 @@ class PDVScript(PDVFile):
 
     def __init__(
         self,
-        relative_path: str,
+        uuid: str,
+        filename: str,
         language: str = "python",
         doc: str | None = None,
         module_id: str = "",
         source_rel_path: str | None = None,
     ) -> None:
-        super().__init__(relative_path, source_rel_path=source_rel_path)
+        super().__init__(uuid, filename, source_rel_path=source_rel_path)
         self._language = language
         self._doc = doc
         self._module_id = module_id
@@ -501,18 +531,18 @@ class PDVScript(PDVFile):
 
         if not hasattr(module, "run"):
             raise PDVScriptError(
-                f"Script '{self._relative_path}' does not define a run() function"
+                f"Script '{self._filename}' does not define a run() function"
             )
 
         try:
             return module.run(tree, **kwargs)
         except Exception as exc:
             raise PDVScriptError(
-                f"Script '{self._relative_path}' raised during run(): {exc}"
+                f"Script '{self._filename}' raised during run(): {exc}"
             ) from exc
 
     def __repr__(self) -> str:
-        return f"PDVScript('{self._relative_path}', lang='{self._language}')"
+        return f"PDVScript(uuid='{self._uuid}', filename='{self._filename}', lang='{self._language}')"
 
 
 # ---------------------------------------------------------------------------
@@ -529,19 +559,22 @@ class PDVGui(PDVFile):
 
     Parameters
     ----------
-    relative_path : str
-        Path to the ``.gui.json`` file (absolute or relative to working dir).
+    uuid : str
+        12-hex-character UUID for this node's storage directory.
+    filename : str
+        GUI filename (e.g. ``'editor.gui.json'``).
     module_id : str or None
         Module identifier for module-owned GUIs. None for user-created project GUIs.
     """
 
     def __init__(
         self,
-        relative_path: str,
+        uuid: str,
+        filename: str,
         module_id: str | None = None,
         source_rel_path: str | None = None,
     ) -> None:
-        super().__init__(relative_path, source_rel_path=source_rel_path)
+        super().__init__(uuid, filename, source_rel_path=source_rel_path)
         self._module_id = module_id
 
     @property
@@ -567,7 +600,7 @@ class PDVGui(PDVFile):
 
     def __repr__(self) -> str:
         mid = f", module_id='{self._module_id}'" if self._module_id else ""
-        return f"PDVGui('{self._relative_path}'{mid})"
+        return f"PDVGui(uuid='{self._uuid}', filename='{self._filename}'{mid})"
 
 
 class PDVNamelist(PDVFile):
@@ -579,8 +612,10 @@ class PDVNamelist(PDVFile):
 
     Parameters
     ----------
-    relative_path : str
-        Path to the backing namelist file (absolute or relative to working dir).
+    uuid : str
+        12-hex-character UUID for this node's storage directory.
+    filename : str
+        Namelist filename (e.g. ``'solver.nml'``).
     format : str
         Namelist format: ``'fortran'``, ``'toml'``, or ``'auto'`` (detect from extension).
     module_id : str or None
@@ -593,12 +628,13 @@ class PDVNamelist(PDVFile):
 
     def __init__(
         self,
-        relative_path: str,
+        uuid: str,
+        filename: str,
         format: str = "auto",
         module_id: str | None = None,
         source_rel_path: str | None = None,
     ) -> None:
-        super().__init__(relative_path, source_rel_path=source_rel_path)
+        super().__init__(uuid, filename, source_rel_path=source_rel_path)
         self._format = format  # "fortran", "toml", "auto"
         self._module_id = module_id
 
@@ -633,7 +669,7 @@ class PDVNamelist(PDVFile):
 
     def __repr__(self) -> str:
         mid = f", module_id='{self._module_id}'" if self._module_id else ""
-        return f"PDVNamelist('{self._relative_path}', format='{self._format}'{mid})"
+        return f"PDVNamelist(uuid='{self._uuid}', filename='{self._filename}', format='{self._format}'{mid})"
 
 
 class PDVLib(PDVFile):
@@ -646,8 +682,11 @@ class PDVLib(PDVFile):
 
     Parameters
     ----------
-    relative_path : str
-        Path to the ``.py`` file (absolute or relative to working dir).
+    uuid : str
+        12-hex-character UUID for this node's storage directory.
+    filename : str
+        Library filename (e.g. ``'n_pendulum.py'``). Preserved exactly
+        so that ``import n_pendulum`` works.
     module_id : str or None
         Module identifier for the owning module.
 
@@ -658,11 +697,12 @@ class PDVLib(PDVFile):
 
     def __init__(
         self,
-        relative_path: str,
+        uuid: str,
+        filename: str,
         module_id: str | None = None,
         source_rel_path: str | None = None,
     ) -> None:
-        super().__init__(relative_path, source_rel_path=source_rel_path)
+        super().__init__(uuid, filename, source_rel_path=source_rel_path)
         self._module_id = module_id
 
     @property
@@ -682,11 +722,11 @@ class PDVLib(PDVFile):
         -------
         str
         """
-        return f"Library ({os.path.basename(self._relative_path)})"
+        return f"Library ({self._filename})"
 
     def __repr__(self) -> str:
         mid = f", module_id='{self._module_id}'" if self._module_id else ""
-        return f"PDVLib('{self._relative_path}'{mid})"
+        return f"PDVLib(uuid='{self._uuid}', filename='{self._filename}'{mid})"
 
 
 class PDVNote(PDVFile):
@@ -698,8 +738,10 @@ class PDVNote(PDVFile):
 
     Parameters
     ----------
-    relative_path : str
-        Path to the ``.md`` file (absolute or relative to working dir).
+    uuid : str
+        12-hex-character UUID for this node's storage directory.
+    filename : str
+        Note filename (e.g. ``'intro.md'``).
     title : str or None
         Optional title for the note, used as a preview fallback. If None,
         the first non-empty line of the file is used.
@@ -709,8 +751,8 @@ class PDVNote(PDVFile):
     ARCHITECTURE.md §7.2, PLANNED_FEATURES.md Feature 4
     """
 
-    def __init__(self, relative_path: str, title: str | None = None) -> None:
-        super().__init__(relative_path)
+    def __init__(self, uuid: str, filename: str, title: str | None = None) -> None:
+        super().__init__(uuid, filename)
         self._title = title
 
     @property
@@ -737,16 +779,6 @@ class PDVNote(PDVFile):
         """
         if self._title:
             return self._title[:100]
-        try:
-            path = self._relative_path
-            if os.path.exists(path):
-                with open(path, "r", encoding="utf-8") as fh:
-                    for line in fh:
-                        stripped = line.strip().lstrip("#").strip()
-                        if stripped:
-                            return stripped[:100]
-        except Exception:  # noqa: BLE001
-            pass
         return "Markdown note"
 
 

--- a/pdv-python/pdv/tree.py
+++ b/pdv-python/pdv/tree.py
@@ -450,11 +450,11 @@ class PDVScript(PDVFile):
             if isinstance(value, PDVModule) and value.module_id == self._module_id:
                 parent_module = value
                 break
-        if parent_module is None or not parent_module._dependencies:
+        if parent_module is None or not parent_module.dependencies:
             return
 
         missing: list[str] = []
-        for dep in parent_module._dependencies:
+        for dep in parent_module.dependencies:
             name = dep.get("name", "")
             marker = dep.get("marker", "")
             if not name:
@@ -1316,6 +1316,16 @@ class PDVModule(PDVTree):
             ``"python"`` or ``"julia"``.
         """
         return self._language
+
+    @property
+    def dependencies(self) -> list[dict[str, str]]:
+        """Declared module dependencies (read-only).
+
+        Returns
+        -------
+        list[dict[str, str]]
+        """
+        return self._dependencies
 
     @property
     def gui(self) -> PDVGui | None:

--- a/pdv-python/pdv/tree_loader.py
+++ b/pdv-python/pdv/tree_loader.py
@@ -32,11 +32,11 @@ Divergent details between the two callers are exposed as named arguments:
 - ``module_id_default`` — fallback ``module_id`` for ``script`` nodes when
   the on-disk metadata is missing it.
 
-``sys.path`` wiring for module libraries is handled exclusively by
-``handle_modules_setup``: after ``load_tree_index`` populates the tree,
-main sends ``pdv.modules.setup`` and the kernel walks each ``PDVModule``
-subtree to collect the parent directories of every ``PDVLib``
-descendant. The loader itself never touches ``sys.path``.
+``sys.path`` wiring for module libraries is handled by
+``handle_modules_setup`` (the canonical path) and, for project load only,
+by a ``between_passes`` callback that imports module entry points early
+so custom serializers are registered before Pass 2 deserializes data.
+The loader itself never touches ``sys.path``.
 
 See Also
 --------
@@ -65,6 +65,7 @@ def load_tree_index(
     patch_module_id_on_skip: str | None = None,
     module_id_default: str = "",
     working_dir: str = "",
+    between_passes: Callable[[], None] | None = None,
 ) -> None:
     """Mount a tree-index node list into ``tree`` using the two-pass algorithm.
 
@@ -98,6 +99,11 @@ def load_tree_index(
     working_dir : str
         Working directory used to resolve relative paths during
         deserialization of file-backed leaves.
+    between_passes : callable, optional
+        Invoked after Pass 1 (containers) completes and before Pass 2
+        (leaves) begins. Used by project load to import module entry
+        points — which may register custom serializers — so that
+        custom-format data nodes can be deserialized in Pass 2.
     """
     # Local imports to avoid circular dependencies — tree.py imports nothing
     # from this module, so importing tree.py here is safe.
@@ -164,6 +170,9 @@ def load_tree_index(
             mod._save_dir = tree._save_dir
             tree.set_quiet(full_path, mod)
 
+    if between_passes is not None:
+        between_passes()
+
     # ── Pass 2: leaves ───────────────────────────────────────────────────
     total = len(nodes)
     for index, node in enumerate(nodes, start=1):
@@ -202,7 +211,8 @@ def load_tree_index(
                     on_progress(index, total)
                 continue
 
-        rel_path = storage.get("relative_path", "")
+        node_uuid = node.get("uuid", storage.get("uuid", ""))
+        node_filename = storage.get("filename", "")
         # source_rel_path is the path of this file relative to its owning
         # module root (e.g. "scripts/run.py"). Set by the module bind path
         # for module-owned files and re-read here so it survives
@@ -216,7 +226,8 @@ def load_tree_index(
             tree.set_quiet(
                 full_path,
                 PDVScript(
-                    relative_path=rel_path,
+                    uuid=node_uuid,
+                    filename=node_filename,
                     language=language,
                     doc=doc,
                     module_id=mod_id,
@@ -228,14 +239,16 @@ def load_tree_index(
             tree.set_quiet(
                 full_path,
                 PDVNote(
-                    relative_path=rel_path,
+                    uuid=node_uuid,
+                    filename=node_filename,
                     title=title,
                 ),
             )
         elif node_type == "gui":
             mod_id = meta.get("module_id", node.get("module_id", module_id_default))
             gui_node = PDVGui(
-                relative_path=rel_path,
+                uuid=node_uuid,
+                filename=node_filename,
                 module_id=mod_id,
                 source_rel_path=src_rel,
             )
@@ -258,7 +271,8 @@ def load_tree_index(
             tree.set_quiet(
                 full_path,
                 PDVNamelist(
-                    relative_path=rel_path,
+                    uuid=node_uuid,
+                    filename=node_filename,
                     format=namelist_format,
                     module_id=mod_id,
                     source_rel_path=src_rel,
@@ -269,7 +283,8 @@ def load_tree_index(
             tree.set_quiet(
                 full_path,
                 PDVLib(
-                    relative_path=rel_path,
+                    uuid=node_uuid,
+                    filename=node_filename,
                     module_id=mod_id,
                     source_rel_path=src_rel,
                 ),

--- a/pdv-python/pdv/tree_loader.py
+++ b/pdv-python/pdv/tree_loader.py
@@ -47,6 +47,7 @@ pdv.handlers.modules — pdv.module.register handler
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Callable, Literal
 
 
@@ -214,6 +215,14 @@ def load_tree_index(
 
         node_uuid = node.get("uuid", storage.get("uuid", ""))
         node_filename = storage.get("filename", "")
+        if node_uuid and (".." in node_uuid or "/" in node_uuid or "\\" in node_uuid):
+            warnings.warn(
+                f"Skipping node '{node_path_rel}' with unsafe UUID: {node_uuid!r}",
+                stacklevel=2,
+            )
+            if on_progress is not None:
+                on_progress(index, total)
+            continue
         # source_rel_path is the path of this file relative to its owning
         # module root (e.g. "scripts/run.py"). Set by the module bind path
         # for module-owned files and re-read here so it survives

--- a/pdv-python/pdv/tree_loader.py
+++ b/pdv-python/pdv/tree_loader.py
@@ -108,6 +108,7 @@ def load_tree_index(
     # Local imports to avoid circular dependencies — tree.py imports nothing
     # from this module, so importing tree.py here is safe.
     from pdv.tree import (  # noqa: PLC0415
+        PDVFile,
         PDVGui,
         PDVLib,
         PDVModule,
@@ -286,6 +287,15 @@ def load_tree_index(
                     uuid=node_uuid,
                     filename=node_filename,
                     module_id=mod_id,
+                    source_rel_path=src_rel,
+                ),
+            )
+        elif node_type == "file":
+            tree.set_quiet(
+                full_path,
+                PDVFile(
+                    uuid=node_uuid,
+                    filename=node_filename,
                     source_rel_path=src_rel,
                 ),
             )

--- a/pdv-python/pyproject.toml
+++ b/pdv-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdv-python"
-version = "0.0.11"
+version = "0.0.12"
 description = "PDV kernel support package — implements the PDV comm protocol and data structures for Python kernels."
 requires-python = ">=3.10"
 dependencies = [
@@ -19,12 +19,17 @@ data = [
     "pandas>=2.0",
     "pyarrow>=14.0",
 ]
+# Optional copy-on-write file cloning for faster file operations
+copy = [
+    "reflink-copy>=0.2",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "numpy>=1.24",
     "pandas>=2.0",
     "pyarrow>=14.0",
+    "reflink-copy>=0.2",
 ]
 
 [tool.setuptools.packages.find]

--- a/pdv-python/tests/test_checksum.py
+++ b/pdv-python/tests/test_checksum.py
@@ -130,12 +130,15 @@ class TestNdarrayContentSensitivity:
 class TestFileBackedNodeContentSensitivity:
     def test_file_backed_node_content_sensitivity(self, tmp_path):
         """Changing the content of a script file changes the checksum."""
-        script_file = tmp_path / "script.py"
+        node_uuid = "chk_uuid_001"
+        script_dir = tmp_path / "tree" / node_uuid
+        script_dir.mkdir(parents=True)
+        script_file = script_dir / "script.py"
         script_file.write_text("def run(pdv_tree):\n    return {}\n", encoding="utf-8")
 
         tree = PDVTree()
         tree._set_working_dir(str(tmp_path))
-        script = PDVScript(relative_path="script.py")
+        script = PDVScript(uuid=node_uuid, filename="script.py")
         dict.__setitem__(tree, "s", script)
 
         checksum_before = tree_checksum(tree)
@@ -153,7 +156,7 @@ class TestFileBackedNodeContentSensitivity:
         """A missing script file does not raise; it feeds the sentinel value."""
         tree = PDVTree()
         tree._set_working_dir(str(tmp_path))
-        script = PDVScript(relative_path="nonexistent.py")
+        script = PDVScript(uuid="missing_uuid1", filename="nonexistent.py")
         dict.__setitem__(tree, "s", script)
 
         # Should not raise
@@ -161,51 +164,46 @@ class TestFileBackedNodeContentSensitivity:
         assert len(checksum) == 32
 
 
-class TestRelativePathNotHashed:
-    """Regression test for a long-standing bug where tree_checksum folded
-    ``relative_path`` into the digest of file-backed nodes, so any PDVScript
-    / PDVGui / PDVNamelist / PDVNote checksum drifted after save/load
-    because ``serialize_node`` rewrites the stored rel-path (``hello.py`` →
-    ``tree/hello.py``) but leaves the in-memory node untouched. See task #12
-    of the #140 module editing workflow.
-
-    The fix removes ``relative_path`` from the hash inputs — it's a storage
-    layout detail, not part of node identity. Content is still hashed in
-    full via ``_feed_file_content``, and the parent folder's key iteration
-    folds the tree path into the digest.
+class TestUuidNotHashed:
+    """Regression test: the UUID is a storage layout detail — it must NOT
+    be folded into the content hash. Two scripts with different UUIDs but
+    identical file content must produce the same checksum.
     """
 
-    def test_script_checksum_ignores_relative_path(self, tmp_path):
-        """Two PDVScripts pointing at the same content via different rel paths hash identically."""
-        file_a = tmp_path / "a.py"
-        file_b_dir = tmp_path / "tree"
-        file_b_dir.mkdir()
-        file_b = file_b_dir / "a.py"
+    def test_script_checksum_ignores_uuid(self, tmp_path):
+        """Two PDVScripts with different UUIDs but same content hash identically."""
+        uuid_a = "chk_uuid_a01"
+        uuid_b = "chk_uuid_b01"
         content = "def run(pdv_tree):\n    return {}\n"
-        file_a.write_text(content, encoding="utf-8")
-        file_b.write_text(content, encoding="utf-8")
+        for u in (uuid_a, uuid_b):
+            d = tmp_path / "tree" / u
+            d.mkdir(parents=True)
+            (d / "a.py").write_text(content, encoding="utf-8")
 
         tree_a = PDVTree()
         tree_a._set_working_dir(str(tmp_path))
-        dict.__setitem__(tree_a, "s", PDVScript(relative_path="a.py"))
+        dict.__setitem__(tree_a, "s", PDVScript(uuid=uuid_a, filename="a.py"))
 
         tree_b = PDVTree()
         tree_b._set_working_dir(str(tmp_path))
-        dict.__setitem__(tree_b, "s", PDVScript(relative_path="tree/a.py"))
+        dict.__setitem__(tree_b, "s", PDVScript(uuid=uuid_b, filename="a.py"))
 
         assert tree_checksum(tree_a) == tree_checksum(tree_b)
 
     def test_script_checksum_still_content_sensitive(self, tmp_path):
-        """Removing relative_path from the hash must not weaken content sensitivity."""
-        file_a = tmp_path / "a.py"
-        file_a.write_text("VERSION = 1\n", encoding="utf-8")
+        """UUID exclusion must not weaken content sensitivity."""
+        node_uuid = "chk_uuid_c01"
+        d = tmp_path / "tree" / node_uuid
+        d.mkdir(parents=True)
+        f = d / "a.py"
+        f.write_text("VERSION = 1\n", encoding="utf-8")
 
         tree = PDVTree()
         tree._set_working_dir(str(tmp_path))
-        dict.__setitem__(tree, "s", PDVScript(relative_path="a.py"))
+        dict.__setitem__(tree, "s", PDVScript(uuid=node_uuid, filename="a.py"))
         before = tree_checksum(tree)
 
-        file_a.write_text("VERSION = 2\n", encoding="utf-8")
+        f.write_text("VERSION = 2\n", encoding="utf-8")
         after = tree_checksum(tree)
         assert before != after
 
@@ -232,13 +230,16 @@ class TestRoundtrip:
         dict.__setitem__(tree, "flag", True)
         dict.__setitem__(tree, "items", [1, 2, 3])
 
-        script_file = os.path.join(working_dir, "hello.py")
+        hello_uuid = "chk_hello_01"
+        script_dir = os.path.join(working_dir, "tree", hello_uuid)
+        os.makedirs(script_dir, exist_ok=True)
+        script_file = os.path.join(script_dir, "hello.py")
         with open(script_file, "w", encoding="utf-8") as f:
             f.write("def run(pdv_tree: dict):\n    return {}\n")
         dict.__setitem__(
             tree,
             "hello",
-            PDVScript(relative_path="hello.py", language="python"),
+            PDVScript(uuid=hello_uuid, filename="hello.py", language="python"),
         )
 
         checksum_before = tree_checksum(tree)

--- a/pdv-python/tests/test_early_module_setup.py
+++ b/pdv-python/tests/test_early_module_setup.py
@@ -1,0 +1,233 @@
+"""
+Tests for _early_module_setup() in handlers/project.py.
+
+Covers:
+- Lib directories are inserted into sys.path.
+- Entry points are imported via importlib.
+- Missing pdv-module.json is skipped gracefully.
+- Invalid JSON in pdv-module.json is skipped gracefully.
+- Missing entry_point key is skipped.
+- Failed entry point import logs warning but doesn't abort.
+- Duplicate lib dirs are not added to sys.path twice.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+from pdv.handlers.project import _early_module_setup
+
+
+class TestEarlyModuleSetup:
+    def test_lib_dir_added_to_sys_path(self, tmp_path):
+        working_dir = str(tmp_path / "work")
+        save_dir = str(tmp_path / "save")
+        os.makedirs(working_dir)
+        os.makedirs(save_dir)
+
+        lib_uuid = "lib_uuid_0001"
+        lib_dir = os.path.join(working_dir, "tree", lib_uuid)
+        os.makedirs(lib_dir)
+
+        nodes = [
+            {
+                "path": "mymod",
+                "type": "module",
+                "metadata": {"module_id": "test_mod"},
+                "storage": {"value": {}},
+            },
+            {
+                "path": "mymod.lib.helpers",
+                "type": "lib",
+                "uuid": lib_uuid,
+                "storage": {"uuid": lib_uuid, "filename": "helpers.py"},
+            },
+        ]
+
+        try:
+            _early_module_setup(nodes, save_dir, working_dir)
+            assert lib_dir in sys.path
+        finally:
+            if lib_dir in sys.path:
+                sys.path.remove(lib_dir)
+
+    def test_entry_point_imported(self, tmp_path):
+        working_dir = str(tmp_path / "work")
+        save_dir = str(tmp_path / "save")
+        os.makedirs(working_dir)
+
+        mod_dir = os.path.join(save_dir, "modules", "test_mod")
+        os.makedirs(mod_dir)
+        manifest = {"entry_point": "json"}
+        with open(os.path.join(mod_dir, "pdv-module.json"), "w") as f:
+            json.dump(manifest, f)
+
+        nodes = [
+            {
+                "path": "mymod",
+                "type": "module",
+                "metadata": {"module_id": "test_mod"},
+                "storage": {"value": {}},
+            },
+        ]
+
+        _early_module_setup(nodes, save_dir, working_dir)
+        assert "json" in sys.modules
+
+    def test_missing_manifest_skipped(self, tmp_path):
+        working_dir = str(tmp_path / "work")
+        save_dir = str(tmp_path / "save")
+        os.makedirs(working_dir)
+        os.makedirs(save_dir)
+
+        nodes = [
+            {
+                "path": "mymod",
+                "type": "module",
+                "metadata": {"module_id": "no_manifest_mod"},
+                "storage": {"value": {}},
+            },
+        ]
+
+        _early_module_setup(nodes, save_dir, working_dir)
+
+    def test_invalid_json_manifest_skipped(self, tmp_path):
+        working_dir = str(tmp_path / "work")
+        save_dir = str(tmp_path / "save")
+        os.makedirs(working_dir)
+
+        mod_dir = os.path.join(save_dir, "modules", "bad_json_mod")
+        os.makedirs(mod_dir)
+        with open(os.path.join(mod_dir, "pdv-module.json"), "w") as f:
+            f.write("{broken json")
+
+        nodes = [
+            {
+                "path": "mymod",
+                "type": "module",
+                "metadata": {"module_id": "bad_json_mod"},
+                "storage": {"value": {}},
+            },
+        ]
+
+        _early_module_setup(nodes, save_dir, working_dir)
+
+    def test_missing_entry_point_key_skipped(self, tmp_path):
+        working_dir = str(tmp_path / "work")
+        save_dir = str(tmp_path / "save")
+        os.makedirs(working_dir)
+
+        mod_dir = os.path.join(save_dir, "modules", "no_ep_mod")
+        os.makedirs(mod_dir)
+        with open(os.path.join(mod_dir, "pdv-module.json"), "w") as f:
+            json.dump({"name": "No EP"}, f)
+
+        nodes = [
+            {
+                "path": "mymod",
+                "type": "module",
+                "metadata": {"module_id": "no_ep_mod"},
+                "storage": {"value": {}},
+            },
+        ]
+
+        _early_module_setup(nodes, save_dir, working_dir)
+
+    def test_failed_import_logs_warning_does_not_abort(self, tmp_path):
+        working_dir = str(tmp_path / "work")
+        save_dir = str(tmp_path / "save")
+        os.makedirs(working_dir)
+
+        mod_dir = os.path.join(save_dir, "modules", "bad_import_mod")
+        os.makedirs(mod_dir)
+        manifest = {"entry_point": "nonexistent_module_pdv_test_xyz"}
+        with open(os.path.join(mod_dir, "pdv-module.json"), "w") as f:
+            json.dump(manifest, f)
+
+        nodes = [
+            {
+                "path": "mymod",
+                "type": "module",
+                "metadata": {"module_id": "bad_import_mod"},
+                "storage": {"value": {}},
+            },
+        ]
+
+        _early_module_setup(nodes, save_dir, working_dir)
+
+    def test_duplicate_lib_dirs_not_added_twice(self, tmp_path):
+        working_dir = str(tmp_path / "work")
+        save_dir = str(tmp_path / "save")
+        os.makedirs(working_dir)
+        os.makedirs(save_dir)
+
+        lib_uuid = "dup_lib_00001"
+        lib_dir = os.path.join(working_dir, "tree", lib_uuid)
+        os.makedirs(lib_dir)
+
+        nodes = [
+            {
+                "path": "mymod.lib.a",
+                "type": "lib",
+                "uuid": lib_uuid,
+                "storage": {"uuid": lib_uuid, "filename": "a.py"},
+            },
+            {
+                "path": "mymod.lib.b",
+                "type": "lib",
+                "uuid": lib_uuid,
+                "storage": {"uuid": lib_uuid, "filename": "b.py"},
+            },
+        ]
+
+        try:
+            _early_module_setup(nodes, save_dir, working_dir)
+            count = sys.path.count(lib_dir)
+            assert count == 1
+        finally:
+            while lib_dir in sys.path:
+                sys.path.remove(lib_dir)
+
+    def test_no_module_nodes_is_noop(self, tmp_path):
+        working_dir = str(tmp_path / "work")
+        save_dir = str(tmp_path / "save")
+        os.makedirs(working_dir)
+        os.makedirs(save_dir)
+
+        nodes = [
+            {
+                "path": "data.x",
+                "type": "scalar",
+                "storage": {"backend": "inline", "value": 42},
+            },
+        ]
+
+        _early_module_setup(nodes, save_dir, working_dir)
+
+    def test_lib_uuid_from_storage_fallback(self, tmp_path):
+        """Lib node without top-level uuid falls back to storage.uuid."""
+        working_dir = str(tmp_path / "work")
+        save_dir = str(tmp_path / "save")
+        os.makedirs(working_dir)
+        os.makedirs(save_dir)
+
+        lib_uuid = "fallback_0001"
+        lib_dir = os.path.join(working_dir, "tree", lib_uuid)
+        os.makedirs(lib_dir)
+
+        nodes = [
+            {
+                "path": "mymod.lib.helpers",
+                "type": "lib",
+                "storage": {"uuid": lib_uuid, "filename": "helpers.py"},
+            },
+        ]
+
+        try:
+            _early_module_setup(nodes, save_dir, working_dir)
+            assert lib_dir in sys.path
+        finally:
+            if lib_dir in sys.path:
+                sys.path.remove(lib_dir)

--- a/pdv-python/tests/test_environment.py
+++ b/pdv-python/tests/test_environment.py
@@ -18,6 +18,7 @@ from pdv.environment import (
     resolve_project_path,
     path_is_safe,
     working_dir_tree_path,
+    uuid_tree_path,
     ensure_parent,
     make_working_dir,
 )
@@ -106,6 +107,19 @@ class TestWorkingDirTreePath:
         """A three-part tree path maps to the correct nested structure."""
         result = working_dir_tree_path(tmp_working_dir, "data.waveforms.ch1", ".npy")
         expected = os.path.join(tmp_working_dir, "tree", "data", "waveforms", "ch1.npy")
+        assert result == expected
+
+
+class TestUuidTreePath:
+    def test_simple_uuid_path(self, tmp_working_dir):
+        """uuid_tree_path returns <working_dir>/tree/<uuid>/<filename>."""
+        result = uuid_tree_path(tmp_working_dir, "a1b2c3d4e5f6", "ch1.npy")
+        assert result == os.path.join(tmp_working_dir, "tree", "a1b2c3d4e5f6", "ch1.npy")
+
+    def test_uuid_path_with_extension(self, tmp_working_dir):
+        """uuid_tree_path handles various file extensions."""
+        result = uuid_tree_path(tmp_working_dir, "abc123def456", "script.py")
+        expected = os.path.join(tmp_working_dir, "tree", "abc123def456", "script.py")
         assert result == expected
 
 

--- a/pdv-python/tests/test_environment.py
+++ b/pdv-python/tests/test_environment.py
@@ -5,7 +5,7 @@ Tests cover:
 1. validate_working_dir() happy path and error cases.
 2. resolve_project_path() path-traversal rejection.
 3. path_is_safe() boundary cases.
-4. working_dir_tree_path() path construction.
+4. uuid_tree_path() path construction.
 5. ensure_parent() directory creation.
 
 Reference: ARCHITECTURE.md §6.1, §6.2
@@ -17,7 +17,6 @@ from pdv.environment import (
     validate_working_dir,
     resolve_project_path,
     path_is_safe,
-    working_dir_tree_path,
     uuid_tree_path,
     ensure_parent,
     make_working_dir,
@@ -95,19 +94,6 @@ class TestPathIsSafe:
         # Construct a path that would escape via traversal before realpath
         attempt = os.path.join(str(tmp_path), "..", "outside")
         assert path_is_safe(attempt, str(tmp_path)) is False
-
-
-class TestWorkingDirTreePath:
-    def test_simple_path(self, tmp_working_dir):
-        """A simple one-part tree path maps correctly."""
-        result = working_dir_tree_path(tmp_working_dir, "x", ".npy")
-        assert result == os.path.join(tmp_working_dir, "tree", "x.npy")
-
-    def test_nested_path(self, tmp_working_dir):
-        """A three-part tree path maps to the correct nested structure."""
-        result = working_dir_tree_path(tmp_working_dir, "data.waveforms.ch1", ".npy")
-        expected = os.path.join(tmp_working_dir, "tree", "data", "waveforms", "ch1.npy")
-        assert result == expected
 
 
 class TestUuidTreePath:

--- a/pdv-python/tests/test_handlers_modules.py
+++ b/pdv-python/tests/test_handlers_modules.py
@@ -10,6 +10,7 @@ Tests cover:
 Reference: ARCHITECTURE.md §3.4
 """
 
+import os
 import sys
 import uuid
 from unittest.mock import MagicMock, patch
@@ -63,6 +64,7 @@ class TestHandleModulesSetup:
     """
 
     def _install_module_with_libs(self, tree, tmp_path, alias, lib_rel_names):
+        from pdv.environment import generate_node_uuid
         from pdv.tree import PDVLib, PDVModule, PDVTree
 
         # Point the tree at tmp_path so PDVLib.resolve_path() lines up with
@@ -74,10 +76,17 @@ class TestHandleModulesSetup:
         lib_container = PDVTree()
         lib_container._working_dir = str(tmp_path)
         for rel in lib_rel_names:
-            abs_path = tmp_path / rel
-            abs_path.parent.mkdir(parents=True, exist_ok=True)
+            # rel is like "tree/<alias>/lib/helpers.py" — we need to create the
+            # file at <tmp_path>/tree/<uuid>/<filename> and map the old structure.
+            import pathlib
+            rel_path = pathlib.PurePosixPath(rel)
+            filename = rel_path.name
+            node_uuid = generate_node_uuid()
+            uuid_dir = tmp_path / "tree" / node_uuid
+            uuid_dir.mkdir(parents=True, exist_ok=True)
+            abs_path = uuid_dir / filename
             abs_path.write_text("# test lib\n")
-            lib_node = PDVLib(relative_path=rel, module_id=alias)
+            lib_node = PDVLib(uuid=node_uuid, filename=filename, module_id=alias)
             key = abs_path.stem
             dict.__setitem__(lib_container, key, lib_node)
         dict.__setitem__(module, "lib", lib_container)
@@ -94,10 +103,15 @@ class TestHandleModulesSetup:
         )
         assert module is not None
 
-        expected_dirs = [
-            str(tmp_path / "tree" / "toy" / "lib"),
-            str(tmp_path / "tree" / "toy" / "extras"),
-        ]
+        # With UUID storage, each lib lives in tree/<uuid>/<filename>.
+        # Collect expected dirs from the actual lib nodes.
+        from pdv.tree import PDVLib
+        lib_container = dict.__getitem__(module, "lib")
+        expected_dirs = []
+        for key in dict.keys(lib_container):
+            lib_node = dict.__getitem__(lib_container, key)
+            if isinstance(lib_node, PDVLib):
+                expected_dirs.append(os.path.dirname(lib_node.resolve_path(str(tmp_path))))
 
         mock_comm = _make_mock_comm()
         msg = _make_msg("pdv.modules.setup", {"modules": [{"alias": "toy"}]})
@@ -121,14 +135,27 @@ class TestHandleModulesSetup:
                     sys.path.remove(expected)
 
     def test_deduplicates_sibling_libs(self, tree_with_comm, tmp_path):
-        """Two PDVLib nodes in the same directory produce one sys.path entry."""
-        self._install_module_with_libs(
-            tree_with_comm,
-            tmp_path,
-            "toy",
-            ["tree/toy/lib/a.py", "tree/toy/lib/b.py"],
-        )
-        expected_dir = str(tmp_path / "tree" / "toy" / "lib")
+        """Two PDVLib nodes with the same UUID produce one sys.path entry."""
+        from pdv.tree import PDVLib, PDVModule, PDVTree
+
+        tree_with_comm._set_working_dir(str(tmp_path))
+        # Use a single UUID for both libs to test dedup.
+        shared_uuid = "dedup_uuid01"
+        uuid_dir = tmp_path / "tree" / shared_uuid
+        uuid_dir.mkdir(parents=True, exist_ok=True)
+        (uuid_dir / "a.py").write_text("# test lib a\n")
+        (uuid_dir / "b.py").write_text("# test lib b\n")
+
+        module = PDVModule(module_id="toy", name="toy", version="0.1.0")
+        module._working_dir = str(tmp_path)
+        lib_container = PDVTree()
+        lib_container._working_dir = str(tmp_path)
+        dict.__setitem__(lib_container, "a", PDVLib(uuid=shared_uuid, filename="a.py", module_id="toy"))
+        dict.__setitem__(lib_container, "b", PDVLib(uuid=shared_uuid, filename="b.py", module_id="toy"))
+        dict.__setitem__(module, "lib", lib_container)
+        dict.__setitem__(tree_with_comm, "toy", module)
+
+        expected_dir = str(uuid_dir)
 
         # Clear any prior entries so the count assertion is meaningful.
         while expected_dir in sys.path:
@@ -151,13 +178,20 @@ class TestHandleModulesSetup:
 
     def test_missing_module_warns_and_continues(self, tree_with_comm, tmp_path):
         """Unknown aliases warn but do not abort the loop — other modules still set up."""
-        self._install_module_with_libs(
+        module = self._install_module_with_libs(
             tree_with_comm,
             tmp_path,
             "present",
             ["tree/present/lib/p.py"],
         )
-        expected_dir = str(tmp_path / "tree" / "present" / "lib")
+        # Find the actual expected dir from the installed lib node.
+        from pdv.tree import PDVLib
+        lib_container = dict.__getitem__(module, "lib")
+        expected_dirs = []
+        for key in dict.keys(lib_container):
+            lib_node = dict.__getitem__(lib_container, key)
+            if isinstance(lib_node, PDVLib):
+                expected_dirs.append(os.path.dirname(lib_node.resolve_path(str(tmp_path))))
 
         mock_comm = _make_mock_comm()
         msg = _make_msg(
@@ -173,10 +207,12 @@ class TestHandleModulesSetup:
             ):
                 handle_modules_setup(msg)
 
-            assert expected_dir in sys.path
+            for expected_dir in expected_dirs:
+                assert expected_dir in sys.path
         finally:
-            while expected_dir in sys.path:
-                sys.path.remove(expected_dir)
+            for expected_dir in expected_dirs:
+                while expected_dir in sys.path:
+                    sys.path.remove(expected_dir)
 
     def test_empty_module_is_noop_but_not_error(self, tree_with_comm):
         """An empty PDVModule (create_empty just ran) triggers no sys.path edits and no warnings."""
@@ -241,14 +277,17 @@ class TestHandleModulesSetup:
         from pdv.tree import PDVLib, PDVModule, PDVScript, PDVTree
 
         alias = "ddho"
-        scripts_dir = tmp_path / "tree" / alias / "scripts"
-        lib_dir = tmp_path / "tree" / alias / "lib"
-        scripts_dir.mkdir(parents=True)
+        lib_uuid = "ddho_lib_001"
+        scr_uuid = "ddho_scr_001"
+
+        lib_dir = tmp_path / "tree" / lib_uuid
+        scr_dir = tmp_path / "tree" / scr_uuid
         lib_dir.mkdir(parents=True)
+        scr_dir.mkdir(parents=True)
 
         lib_file = lib_dir / "ddho_lib.py"
         lib_file.write_text("K = 1.25\n")
-        script_file = scripts_dir / "run_ddho.py"
+        script_file = scr_dir / "run_ddho.py"
         script_file.write_text(
             "from ddho_lib import K\n"
             "def run(pdv_tree):\n"
@@ -266,7 +305,8 @@ class TestHandleModulesSetup:
             libs_container,
             "ddho_lib",
             PDVLib(
-                relative_path=f"tree/{alias}/lib/ddho_lib.py",
+                uuid=lib_uuid,
+                filename="ddho_lib.py",
                 module_id=alias,
             ),
         )
@@ -274,7 +314,8 @@ class TestHandleModulesSetup:
             scripts_container,
             "run_ddho",
             PDVScript(
-                relative_path=f"tree/{alias}/scripts/run_ddho.py",
+                uuid=scr_uuid,
+                filename="run_ddho.py",
                 language="python",
                 module_id=alias,
             ),

--- a/pdv-python/tests/test_handlers_modules.py
+++ b/pdv-python/tests/test_handlers_modules.py
@@ -391,45 +391,48 @@ class TestHandleHandlerInvoke:
 
 class TestHandleModuleReloadLibs:
     """Tests for pdv.module.reload_libs — the script:run preflight that
-    importlib.reloads modules whose __file__ is under <workdir>/<alias>/lib/.
-    See the #140 workflow plan §4.
+    importlib.reloads modules whose __file__ is under a PDVLib's
+    UUID-based directory.  See the #140 workflow plan §4.
     """
 
     def test_reloads_lib_file_under_alias(self, tree_with_comm, tmp_path):
         """A lib file edited on disk is observably reloaded in sys.modules."""
 
-        from pdv.tree import PDVModule
+        from pdv.tree import PDVLib, PDVModule, PDVTree
 
-        # Arrange: working-dir/tree/<alias>/lib/<libname>.py — the
-        # ``tree/`` prefix is the canonical working-dir subdir for
-        # file-backed nodes after the Option-A layout fix.
         alias = "my_mod"
-        lib_dir = tmp_path / "tree" / alias / "lib"
+        lib_uuid = "aabbccddeeff"
+        lib_filename = "helpers_reload_v1.py"
+
+        # UUID-based layout: tree/<uuid>/<filename>
+        lib_dir = tmp_path / "tree" / lib_uuid
         lib_dir.mkdir(parents=True)
-        lib_file = lib_dir / "helpers_reload_v1.py"
+        lib_file = lib_dir / lib_filename
         lib_file.write_text("VALUE = 1\n")
         sys.path.insert(0, str(lib_dir))
 
-        # Force the working dir for this test's tree.
         tree_with_comm._working_dir = str(tmp_path)
 
-        # Install a PDVModule at the alias so the handler's is_module
-        # check passes.
-        tree_with_comm[alias] = PDVModule(
+        # Build a PDVModule with a PDVLib child so _iter_pdv_libs finds it.
+        module_node = PDVModule(
             module_id=alias,
             name="My",
             version="0.1.0",
         )
+        lib_container = PDVTree()
+        lib_container[lib_filename.removesuffix(".py")] = PDVLib(
+            uuid=lib_uuid, filename=lib_filename, module_id=alias,
+        )
+        module_node["lib"] = lib_container
+        tree_with_comm[alias] = module_node
 
         try:
             import helpers_reload_v1  # noqa: PLC0415
 
             assert helpers_reload_v1.VALUE == 1
 
-            # Edit the file on disk — simulates an external editor save.
             lib_file.write_text("VALUE = 42\n")
 
-            # Call the reload handler.
             mock_comm = _make_mock_comm()
             msg = _make_msg("pdv.module.reload_libs", {"alias": alias})
             with (
@@ -438,7 +441,6 @@ class TestHandleModuleReloadLibs:
             ):
                 handle_module_reload_libs(msg)
 
-            # Assert: the new value is observable and the response lists the reload.
             assert helpers_reload_v1.VALUE == 42
             response = mock_comm._sent[-1]
             assert response["type"] == "pdv.module.reload_libs.response"

--- a/pdv-python/tests/test_handlers_project.py
+++ b/pdv-python/tests/test_handlers_project.py
@@ -85,7 +85,8 @@ class TestHandleProjectLoad:
         """File-backed nodes from tree-index.json are eagerly deserialized into the tree."""
         numpy = pytest.importorskip("numpy")
         arr = numpy.array([1.0, 2.0, 3.0])
-        tree_dir = os.path.join(tree_with_comm._working_dir, "tree")
+        node_uuid = "arr_uuid_001"
+        tree_dir = os.path.join(tree_with_comm._working_dir, "tree", node_uuid)
         os.makedirs(tree_dir, exist_ok=True)
         numpy.save(os.path.join(tree_dir, "arr.npy"), arr)
         nodes = [
@@ -94,7 +95,8 @@ class TestHandleProjectLoad:
                 "type": "ndarray",
                 "storage": {
                     "backend": "local_file",
-                    "relative_path": "tree/arr.npy",
+                    "uuid": node_uuid,
+                    "filename": "arr.npy",
                     "format": "npy",
                 },
             },
@@ -127,8 +129,8 @@ class TestHandleProjectLoad:
         """Script descriptors are restored as PDVScript instances, not plain text."""
         # Create file in working dir (TypeScript copies before load)
         working_dir = tree_with_comm._working_dir
-        script_rel = os.path.join("tree", "scripts", "demo.py")
-        script_file = os.path.join(working_dir, script_rel)
+        node_uuid = "scr_demo_001"
+        script_file = os.path.join(working_dir, "tree", node_uuid, "demo.py")
         os.makedirs(os.path.dirname(script_file), exist_ok=True)
         with open(script_file, "w", encoding="utf-8") as fh:
             fh.write("def run(pdv_tree: dict):\n    return {}\n")
@@ -143,9 +145,11 @@ class TestHandleProjectLoad:
             {
                 "path": "scripts.demo",
                 "type": "script",
+                "uuid": node_uuid,
                 "storage": {
                     "backend": "local_file",
-                    "relative_path": script_rel,
+                    "uuid": node_uuid,
+                    "filename": "demo.py",
                     "format": "py_script",
                 },
                 "metadata": {"language": "python", "doc": None, "preview": "script"},
@@ -287,12 +291,13 @@ class TestHandleProjectSave:
         """Module-owned PDVFile nodes surface in the save response so the main
         process can mirror them into <saveDir>/modules/<id>/<source_rel_path>."""
         working_dir = tree_with_comm._working_dir
-        # Place a script file and a lib file under the working-dir alias.
-        scripts_dir = os.path.join(working_dir, "my_mod", "scripts")
-        lib_dir = os.path.join(working_dir, "my_mod", "lib")
-        os.makedirs(scripts_dir, exist_ok=True)
+        scr_uuid = "mod_scr_ow01"
+        lib_uuid = "mod_lib_ow01"
+        script_dir = os.path.join(working_dir, "tree", scr_uuid)
+        lib_dir = os.path.join(working_dir, "tree", lib_uuid)
+        os.makedirs(script_dir, exist_ok=True)
         os.makedirs(lib_dir, exist_ok=True)
-        script_path = os.path.join(scripts_dir, "run.py")
+        script_path = os.path.join(script_dir, "run.py")
         with open(script_path, "w") as f:
             f.write("def run(pdv_tree: dict):\n    return {}\n")
         lib_path = os.path.join(lib_dir, "helpers.py")
@@ -303,13 +308,15 @@ class TestHandleProjectSave:
         module = PDVModule(module_id="my_mod", name="My", version="0.1.0")
         module["scripts"] = PDVTree()
         module["scripts.run"] = PDVScript(
-            relative_path=script_path,
+            uuid=scr_uuid,
+            filename="run.py",
             module_id="my_mod",
             source_rel_path="scripts/run.py",
         )
         module["lib"] = PDVTree()
         module["lib.helpers"] = PDVLib(
-            relative_path=lib_path,
+            uuid=lib_uuid,
+            filename="helpers.py",
             module_id="my_mod",
             source_rel_path="lib/helpers.py",
         )
@@ -343,11 +350,13 @@ class TestHandleProjectSave:
     ):
         """Each PDVModule surfaces a full manifest bundle with module-root-relative descriptors."""
         working_dir = tree_with_comm._working_dir
-        scripts_dir = os.path.join(working_dir, "toy", "scripts")
-        lib_dir = os.path.join(working_dir, "toy", "lib")
-        os.makedirs(scripts_dir, exist_ok=True)
+        scr_uuid = "toy_scr_mm01"
+        lib_uuid = "toy_lib_mm01"
+        script_dir = os.path.join(working_dir, "tree", scr_uuid)
+        lib_dir = os.path.join(working_dir, "tree", lib_uuid)
+        os.makedirs(script_dir, exist_ok=True)
         os.makedirs(lib_dir, exist_ok=True)
-        script_path = os.path.join(scripts_dir, "hello.py")
+        script_path = os.path.join(script_dir, "hello.py")
         with open(script_path, "w") as f:
             f.write("def run(pdv_tree: dict):\n    return {}\n")
         lib_path = os.path.join(lib_dir, "helpers.py")
@@ -365,13 +374,15 @@ class TestHandleProjectSave:
         )
         module["scripts"] = PDVTree()
         module["scripts.hello"] = PDVScript(
-            relative_path=script_path,
+            uuid=scr_uuid,
+            filename="hello.py",
             module_id="toy",
             source_rel_path="scripts/hello.py",
         )
         module["lib"] = PDVTree()
         module["lib.helpers"] = PDVLib(
-            relative_path=lib_path,
+            uuid=lib_uuid,
+            filename="helpers.py",
             module_id="toy",
             source_rel_path="lib/helpers.py",
         )
@@ -399,20 +410,16 @@ class TestHandleProjectSave:
         assert bundle["language"] == "python"
 
         by_path = {e["path"]: e for e in bundle["entries"]}
-        # Three container entries (scripts, lib, plots) and two leaves
-        # — all rooted at the module, not prefixed with "toy.".
         assert "scripts" in by_path
         assert "lib" in by_path
         assert "plots" in by_path
         assert by_path["scripts"]["type"] == "folder"
         assert "scripts.hello" in by_path
         assert by_path["scripts.hello"]["type"] == "script"
-        assert (
-            by_path["scripts.hello"]["storage"]["relative_path"] == "scripts/hello.py"
-        )
+        assert by_path["scripts.hello"]["storage"]["format"] == "py_script"
         assert by_path["scripts.hello"]["parent_path"] == "scripts"
         assert "lib.helpers" in by_path
-        assert by_path["lib.helpers"]["storage"]["relative_path"] == "lib/helpers.py"
+        assert by_path["lib.helpers"]["storage"]["format"] == "py_lib"
         assert by_path["lib.helpers"]["type"] == "lib"
 
     def test_save_response_has_empty_manifests_when_no_modules(
@@ -437,14 +444,15 @@ class TestHandleProjectSave:
     ):
         """Scripts outside any PDVModule subtree do not appear in module_owned_files."""
         working_dir = tree_with_comm._working_dir
-        scripts_dir = os.path.join(working_dir, "project_scripts")
-        os.makedirs(scripts_dir, exist_ok=True)
-        script_path = os.path.join(scripts_dir, "plain.py")
+        scr_uuid = "plain_scr_01"
+        script_dir = os.path.join(working_dir, "tree", scr_uuid)
+        os.makedirs(script_dir, exist_ok=True)
+        script_path = os.path.join(script_dir, "plain.py")
         with open(script_path, "w") as f:
             f.write("def run(pdv_tree: dict):\n    return {}\n")
         # Plain PDVScript with no module context and no source_rel_path.
         tree_with_comm["scripts"] = PDVTree()
-        tree_with_comm["scripts.plain"] = PDVScript(relative_path=script_path)
+        tree_with_comm["scripts.plain"] = PDVScript(uuid=scr_uuid, filename="plain.py")
 
         mock_comm = _make_mock_comm()
         msg = _make_msg("pdv.project.save", {"save_dir": tmp_save_dir})
@@ -466,8 +474,8 @@ class TestTwoPassLoading:
     def test_child_before_parent_gui(self, tree_with_comm, tmp_save_dir):
         """GUI node listed before its module parent still loads correctly."""
         working_dir = tree_with_comm._working_dir
-        gui_rel = os.path.join("tree", "mymod", "gui.gui.json")
-        gui_file = os.path.join(working_dir, gui_rel)
+        gui_uuid = "gui_uuid_cb01"
+        gui_file = os.path.join(working_dir, "tree", gui_uuid, "gui.gui.json")
         os.makedirs(os.path.dirname(gui_file), exist_ok=True)
         with open(gui_file, "w") as f:
             f.write("{}")
@@ -477,9 +485,11 @@ class TestTwoPassLoading:
             {
                 "path": "mymod.gui",
                 "type": "gui",
+                "uuid": gui_uuid,
                 "storage": {
                     "backend": "local_file",
-                    "relative_path": gui_rel,
+                    "uuid": gui_uuid,
+                    "filename": "gui.gui.json",
                     "format": "gui_json",
                 },
                 "metadata": {"module_id": "test_mod", "preview": "GUI"},
@@ -551,12 +561,12 @@ class TestTwoPassLoading:
 
         mod = PDVModule(module_id="gui_mod", name="GuiMod", version="1.0")
         tree_with_comm["gmod"] = mod
-        gui_rel = os.path.join("tree", "gmod", "gui.gui.json")
-        gui_file = os.path.join(tree_with_comm._working_dir, gui_rel)
+        gui_uuid = "gui_uuid_rt01"
+        gui_file = os.path.join(tree_with_comm._working_dir, "tree", gui_uuid, "gui.gui.json")
         os.makedirs(os.path.dirname(gui_file), exist_ok=True)
         with open(gui_file, "w") as f:
             f.write('{"layout": {}}')
-        gui = PDVGui(relative_path=gui_file, module_id="gui_mod")
+        gui = PDVGui(uuid=gui_uuid, filename="gui.gui.json", module_id="gui_mod")
         dict.__setitem__(mod, "gui", gui)
         mod.gui = gui
 
@@ -577,12 +587,12 @@ class TestTwoPassLoading:
 
     def test_namelist_format_roundtrip(self, tree_with_comm, tmp_save_dir):
         """Namelist format and module_id survive save→load."""
-        nml_rel = os.path.join("tree", "solver.nml")
-        nml_file = os.path.join(tree_with_comm._working_dir, nml_rel)
+        nml_uuid = "nml_uuid_rt01"
+        nml_file = os.path.join(tree_with_comm._working_dir, "tree", nml_uuid, "solver.nml")
         os.makedirs(os.path.dirname(nml_file), exist_ok=True)
         with open(nml_file, "w") as f:
             f.write("&solver /\n")
-        nml = PDVNamelist(relative_path=nml_file, format="fortran", module_id="nml_mod")
+        nml = PDVNamelist(uuid=nml_uuid, filename="solver.nml", format="fortran", module_id="nml_mod")
         tree_with_comm["solver"] = nml
 
         mock_comm = _make_mock_comm()
@@ -607,11 +617,11 @@ class TestTwoPassLoading:
         assert loaded.format == "fortran"
         assert loaded.module_id == "nml_mod"
 
-    def test_relative_paths_stored(self, tree_with_comm, tmp_save_dir):
-        """After load, PDVFile nodes store relative (not absolute) paths."""
+    def test_uuid_and_filename_stored(self, tree_with_comm, tmp_save_dir):
+        """After load, PDVFile nodes store uuid and filename."""
         working_dir = tree_with_comm._working_dir
-        script_rel = os.path.join("tree", "demo.py")
-        script_file = os.path.join(working_dir, script_rel)
+        node_uuid = "demo_uuid_01"
+        script_file = os.path.join(working_dir, "tree", node_uuid, "demo.py")
         os.makedirs(os.path.dirname(script_file), exist_ok=True)
         with open(script_file, "w") as f:
             f.write("def run(pdv_tree: dict):\n    return {}\n")
@@ -620,9 +630,11 @@ class TestTwoPassLoading:
             {
                 "path": "demo",
                 "type": "script",
+                "uuid": node_uuid,
                 "storage": {
                     "backend": "local_file",
-                    "relative_path": script_rel,
+                    "uuid": node_uuid,
+                    "filename": "demo.py",
                     "format": "py_script",
                 },
                 "metadata": {"language": "python", "preview": "script"},
@@ -638,8 +650,8 @@ class TestTwoPassLoading:
             handle_project_load(msg)
         script = tree_with_comm["demo"]
         assert isinstance(script, PDVScript)
-        assert not os.path.isabs(script.relative_path)
-        assert script.relative_path == script_rel
+        assert script.uuid == node_uuid
+        assert script.filename == "demo.py"
 
     def test_module_working_dir_propagated(self, tree_with_comm, tmp_save_dir):
         """After load, PDVModule subtree nodes share the root working dir."""

--- a/pdv-python/tests/test_handlers_script.py
+++ b/pdv-python/tests/test_handlers_script.py
@@ -36,7 +36,8 @@ class TestHandleScriptRegister:
             {
                 "parent_path": "scripts.analysis",
                 "name": "fit_model",
-                "relative_path": "scripts/analysis/fit_model.py",
+                "uuid": "abc123def456",
+                "filename": "fit_model.py",
                 "language": "python",
             }
         )
@@ -48,7 +49,8 @@ class TestHandleScriptRegister:
 
         node = tree["scripts.analysis.fit_model"]
         assert isinstance(node, PDVScript)
-        assert node.relative_path == "scripts/analysis/fit_model.py"
+        assert node.uuid == "abc123def456"
+        assert node.filename == "fit_model.py"
         response = mock_comm._sent[-1]
         assert response["type"] == "pdv.script.register.response"
         assert response["status"] == "ok"
@@ -67,7 +69,8 @@ class TestHandleScriptRegister:
             {
                 "parent_path": "my_mod.scripts",
                 "name": "solve",
-                "relative_path": "my_mod/scripts/solve.py",
+                "uuid": "mod_solve_001",
+                "filename": "solve.py",
                 "language": "python",
                 "module_id": "my_mod",
                 "source_rel_path": "scripts/solve.py",
@@ -86,7 +89,7 @@ class TestHandleScriptRegister:
     def test_register_missing_name_sends_error(self):
         tree = PDVTree()
         mock_comm = _make_mock_comm()
-        msg = _make_msg({"parent_path": "scripts", "relative_path": "scripts/x.py"})
+        msg = _make_msg({"parent_path": "scripts", "uuid": "abc123def456", "filename": "x.py"})
         with (
             patch.object(comms_mod, "_comm", mock_comm),
             patch.object(comms_mod, "_pdv_tree", tree),
@@ -98,10 +101,10 @@ class TestHandleScriptRegister:
         assert response["status"] == "error"
         assert response["payload"]["code"] == "script.missing_name"
 
-    def test_register_missing_relative_path_sends_error(self):
+    def test_register_missing_uuid_sends_error(self):
         tree = PDVTree()
         mock_comm = _make_mock_comm()
-        msg = _make_msg({"parent_path": "scripts", "name": "x"})
+        msg = _make_msg({"parent_path": "scripts", "name": "x", "filename": "x.py"})
         with (
             patch.object(comms_mod, "_comm", mock_comm),
             patch.object(comms_mod, "_pdv_tree", tree),
@@ -111,7 +114,22 @@ class TestHandleScriptRegister:
         assert len(mock_comm._sent) == 1
         response = mock_comm._sent[0]
         assert response["status"] == "error"
-        assert response["payload"]["code"] == "script.missing_relative_path"
+        assert response["payload"]["code"] == "script.missing_uuid"
+
+    def test_register_missing_filename_sends_error(self):
+        tree = PDVTree()
+        mock_comm = _make_mock_comm()
+        msg = _make_msg({"parent_path": "scripts", "name": "x", "uuid": "abc123def456"})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree),
+        ):
+            handle_script_register(msg)
+
+        assert len(mock_comm._sent) == 1
+        response = mock_comm._sent[0]
+        assert response["status"] == "error"
+        assert response["payload"]["code"] == "script.missing_filename"
 
     def test_register_with_parent_path_creates_nested_script(self):
         tree = PDVTree()
@@ -120,7 +138,8 @@ class TestHandleScriptRegister:
             {
                 "parent_path": "pipeline.stage1",
                 "name": "preprocess",
-                "relative_path": "pipeline/stage1/preprocess.py",
+                "uuid": "abc123def457",
+                "filename": "preprocess.py",
             }
         )
         with (
@@ -141,7 +160,8 @@ class TestHandleScriptRegister:
             {
                 "parent_path": "scripts",
                 "name": "new_script",
-                "relative_path": "scripts/new_script.py",
+                "uuid": "abc123def458",
+                "filename": "new_script.py",
             }
         )
         with (

--- a/pdv-python/tests/test_handlers_tree.py
+++ b/pdv-python/tests/test_handlers_tree.py
@@ -107,11 +107,15 @@ class TestHandleTreeList:
 
     def test_script_nodes_do_not_include_params(self, tree_with_comm, tmp_path):
         """Script node descriptors from tree.list do not include params (fetched on demand)."""
-        script_file = tmp_path / "fit_model.py"
+        node_uuid = "scr_uuid_001"
+        script_dir = tmp_path / "tree" / node_uuid
+        script_dir.mkdir(parents=True)
+        script_file = script_dir / "fit_model.py"
         script_file.write_text(
             "def run(pdv_tree: dict, sigma: float = 0.1):\n    return {}\n"
         )
-        tree_with_comm["script_node"] = PDVScript(relative_path=str(script_file))
+        tree_with_comm._set_working_dir(str(tmp_path))
+        tree_with_comm["script_node"] = PDVScript(uuid=node_uuid, filename="fit_model.py")
         tree_with_comm["value_node"] = 42
 
         mock_comm = _make_mock_comm()

--- a/pdv-python/tests/test_integration_dispatch.py
+++ b/pdv-python/tests/test_integration_dispatch.py
@@ -124,15 +124,17 @@ class TestIntegrationDispatch:
     def test_project_save_load_roundtrip_with_multiple_node_types(
         self, tmp_working_dir: str, tmp_save_dir: str, tmp_path
     ) -> None:
-        script_file = tmp_path / "roundtrip_script.py"
-        script_file.write_text(
-            "def run(pdv_tree: dict):\n    return {'ok': True}\n", encoding="utf-8"
-        )
+        scr_uuid = "integ_scr_01"
+        script_dir = os.path.join(tmp_working_dir, "tree", scr_uuid)
+        os.makedirs(script_dir, exist_ok=True)
+        script_file = os.path.join(script_dir, "roundtrip_script.py")
+        with open(script_file, "w", encoding="utf-8") as f:
+            f.write("def run(pdv_tree: dict):\n    return {'ok': True}\n")
 
         tree = PDVTree()
         tree._set_working_dir(tmp_working_dir)
         tree["data.x"] = 1
-        tree["scripts.demo"] = PDVScript(relative_path=str(script_file))
+        tree["scripts.demo"] = PDVScript(uuid=scr_uuid, filename="roundtrip_script.py")
 
         try:
             import numpy as np  # type: ignore
@@ -164,10 +166,11 @@ class TestIntegrationDispatch:
             index_nodes = json.loads(fh.read())
         for node in index_nodes:
             storage = node.get("storage", {})
-            rel = storage.get("relative_path", "")
-            if storage.get("backend") == "local_file" and rel:
-                src = os.path.join(tmp_save_dir, rel)
-                dst = os.path.join(tmp_working_dir, rel)
+            node_uuid = storage.get("uuid", "")
+            filename = storage.get("filename", "")
+            if storage.get("backend") == "local_file" and node_uuid and filename:
+                src = os.path.join(tmp_save_dir, "tree", node_uuid, filename)
+                dst = os.path.join(tmp_working_dir, "tree", node_uuid, filename)
                 os.makedirs(os.path.dirname(dst), exist_ok=True)
                 if os.path.exists(src):
                     shutil.copy2(src, dst)
@@ -194,11 +197,12 @@ class TestIntegrationDispatch:
     def test_script_register_then_run_pipeline(
         self, tmp_working_dir: str, tmp_path
     ) -> None:
-        script_file = tmp_path / "double.py"
-        script_file.write_text(
-            "def run(pdv_tree: dict, x: int = 1):\n    return {'result': x * 2}\n",
-            encoding="utf-8",
-        )
+        scr_uuid = "integ_scr_02"
+        script_dir = os.path.join(tmp_working_dir, "tree", scr_uuid)
+        os.makedirs(script_dir, exist_ok=True)
+        script_file = os.path.join(script_dir, "double.py")
+        with open(script_file, "w", encoding="utf-8") as f:
+            f.write("def run(pdv_tree: dict, x: int = 1):\n    return {'result': x * 2}\n")
 
         tree = PDVTree()
         tree._set_working_dir(tmp_working_dir)
@@ -219,7 +223,8 @@ class TestIntegrationDispatch:
                     {
                         "parent_path": "scripts",
                         "name": "double",
-                        "relative_path": str(script_file),
+                        "uuid": scr_uuid,
+                        "filename": "double.py",
                         "language": "python",
                     },
                 )

--- a/pdv-python/tests/test_integration_dispatch.py
+++ b/pdv-python/tests/test_integration_dispatch.py
@@ -159,7 +159,7 @@ class TestIntegrationDispatch:
         fresh_tree = PDVTree()
         fresh_tree._set_working_dir(tmp_working_dir)
         # Simulate TypeScript's copyFilesForLoad: copy file-backed nodes to working dir
-        import shutil
+        from pdv.environment import smart_copy
 
         tree_index_path = os.path.join(tmp_save_dir, "tree-index.json")
         with open(tree_index_path, "r", encoding="utf-8") as fh:
@@ -171,9 +171,8 @@ class TestIntegrationDispatch:
             if storage.get("backend") == "local_file" and node_uuid and filename:
                 src = os.path.join(tmp_save_dir, "tree", node_uuid, filename)
                 dst = os.path.join(tmp_working_dir, "tree", node_uuid, filename)
-                os.makedirs(os.path.dirname(dst), exist_ok=True)
                 if os.path.exists(src):
-                    shutil.copy2(src, dst)
+                    smart_copy(src, dst)
         load_comm = _make_mock_comm()
         with (
             patch.object(comms_mod, "_comm", load_comm),

--- a/pdv-python/tests/test_namelist.py
+++ b/pdv-python/tests/test_namelist.py
@@ -16,34 +16,32 @@ from pdv.tree import PDVNamelist
 
 class TestPDVNamelistClass:
     def test_construction_defaults(self):
-        node = PDVNamelist("path/to/input.nml")
-        assert node.relative_path == "path/to/input.nml"
+        node = PDVNamelist("nml_uuid_0001", "input.nml")
+        assert node.uuid == "nml_uuid_0001"
+        assert node.filename == "input.nml"
         assert node.format == "auto"
         assert node.module_id is None
 
     def test_construction_explicit(self):
-        node = PDVNamelist("input.nml", format="fortran", module_id="my_mod")
+        node = PDVNamelist("nml_uuid_0002", "input.nml", format="fortran", module_id="my_mod")
         assert node.format == "fortran"
         assert node.module_id == "my_mod"
 
     def test_preview(self):
-        node = PDVNamelist("input.nml", format="fortran")
+        node = PDVNamelist("nml_uuid_0003", "input.nml", format="fortran")
         assert node.preview() == "Namelist (fortran)"
 
     def test_repr(self):
-        node = PDVNamelist("input.nml", format="toml", module_id="m")
+        node = PDVNamelist("nml_uuid_0004", "input.nml", format="toml", module_id="m")
         r = repr(node)
         assert "PDVNamelist" in r
         assert "toml" in r
         assert "module_id='m'" in r
 
-    def test_resolve_path_absolute(self):
-        node = PDVNamelist("/abs/path/input.nml")
-        assert node.resolve_path("/working") == "/abs/path/input.nml"
-
-    def test_resolve_path_relative(self):
-        node = PDVNamelist("sub/input.nml")
-        assert node.resolve_path("/working") == "/working/sub/input.nml"
+    def test_resolve_path(self):
+        node = PDVNamelist("nml_uuid_0005", "input.nml")
+        import os
+        assert node.resolve_path("/working") == os.path.join("/working", "tree", "nml_uuid_0005", "input.nml")
 
 
 # ---------------------------------------------------------------------------
@@ -247,7 +245,7 @@ class TestSerializationSupport:
     def test_detect_kind_namelist(self):
         from pdv.serialization import detect_kind, KIND_NAMELIST
 
-        node = PDVNamelist("test.nml", format="fortran")
+        node = PDVNamelist("nml_uuid_s001", "test.nml", format="fortran")
         assert detect_kind(node) == KIND_NAMELIST
 
     def test_serialize_namelist_node(self, tmp_path):
@@ -257,18 +255,21 @@ class TestSerializationSupport:
             FORMAT_NAMELIST,
         )
 
-        # Create a source file
-        source = tmp_path / "input.nml"
+        node_uuid = "nml_uuid_s002"
+        source_dir = tmp_path / "tree" / node_uuid
+        source_dir.mkdir(parents=True)
+        source = source_dir / "input.nml"
         source.write_text("&test\n  x = 1\n/\n")
 
-        node = PDVNamelist(str(source), format="fortran")
+        node = PDVNamelist(node_uuid, "input.nml", format="fortran")
         working_dir = str(tmp_path)
         descriptor = serialize_node("mod.solver_nml", node, working_dir)
 
         assert descriptor["type"] == KIND_NAMELIST
         assert descriptor["storage"]["format"] == FORMAT_NAMELIST
         assert descriptor["storage"]["backend"] == "local_file"
-        assert "relative_path" in descriptor["storage"]
+        assert "uuid" in descriptor["storage"]
+        assert "filename" in descriptor["storage"]
         meta = descriptor["metadata"]
         assert meta["language"] == "namelist"
         assert meta["namelist_format"] == "fortran"

--- a/pdv-python/tests/test_note.py
+++ b/pdv-python/tests/test_note.py
@@ -64,51 +64,36 @@ def _make_msg(payload, msg_id=None):
 class TestPDVNote:
     """Tests for the PDVNote wrapper class."""
 
-    def test_construction_stores_path(self):
-        note = PDVNote(relative_path="/tmp/notes/intro.md")
-        assert note.relative_path == "/tmp/notes/intro.md"
+    def test_construction_stores_uuid_and_filename(self):
+        note = PDVNote(uuid="note_uuid_001", filename="intro.md")
+        assert note.uuid == "note_uuid_001"
+        assert note.filename == "intro.md"
 
     def test_construction_stores_title(self):
-        note = PDVNote(relative_path="intro.md", title="Introduction")
+        note = PDVNote(uuid="note_uuid_002", filename="intro.md", title="Introduction")
         assert note.title == "Introduction"
 
     def test_title_defaults_to_none(self):
-        note = PDVNote(relative_path="intro.md")
+        note = PDVNote(uuid="note_uuid_003", filename="intro.md")
         assert note.title is None
 
     def test_preview_returns_title_when_set(self):
-        note = PDVNote(relative_path="intro.md", title="My Title")
+        note = PDVNote(uuid="note_uuid_004", filename="intro.md", title="My Title")
         assert note.preview() == "My Title"
 
-    def test_preview_reads_first_line_from_file(self, tmp_path):
-        md_file = tmp_path / "test.md"
-        md_file.write_text("# Hello World\n\nSome content.\n")
-        note = PDVNote(relative_path=str(md_file))
-        assert note.preview() == "Hello World"
-
-    def test_preview_skips_empty_lines(self, tmp_path):
-        md_file = tmp_path / "test.md"
-        md_file.write_text("\n\n\n## Section Title\n")
-        note = PDVNote(relative_path=str(md_file))
-        assert note.preview() == "Section Title"
-
     def test_preview_fallback_when_file_missing(self):
-        note = PDVNote(relative_path="/nonexistent/path.md")
-        assert note.preview() == "Markdown note"
-
-    def test_preview_fallback_for_empty_file(self, tmp_path):
-        md_file = tmp_path / "empty.md"
-        md_file.write_text("")
-        note = PDVNote(relative_path=str(md_file))
+        note = PDVNote(uuid="note_uuid_005", filename="path.md")
         assert note.preview() == "Markdown note"
 
     def test_preview_truncates_long_titles(self):
-        note = PDVNote(relative_path="x.md", title="A" * 200)
+        note = PDVNote(uuid="note_uuid_006", filename="x.md", title="A" * 200)
         assert len(note.preview()) == 100
 
     def test_repr(self):
-        note = PDVNote(relative_path="notes/intro.md")
-        assert repr(note) == "PDVNote('notes/intro.md')"
+        note = PDVNote(uuid="note_uuid_007", filename="intro.md")
+        r = repr(note)
+        assert "PDVFile" in r or "PDVNote" in r
+        assert "note_uuid_007" in r
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +105,7 @@ class TestDetectKindMarkdown:
     """Tests for detect_kind() with PDVNote."""
 
     def test_pdvnote_returns_markdown(self):
-        note = PDVNote(relative_path="test.md")
+        note = PDVNote(uuid="note_uuid_008", filename="test.md")
         assert detect_kind(note) == KIND_MARKDOWN
 
     def test_pdvnote_distinct_from_text(self):
@@ -131,9 +116,12 @@ class TestSerializeMarkdown:
     """Tests for serialize_node() with markdown nodes."""
 
     def test_serialize_creates_md_file(self, tmp_path):
-        source = tmp_path / "source.md"
+        node_uuid = "note_ser_001"
+        source_dir = tmp_path / "tree" / node_uuid
+        source_dir.mkdir(parents=True)
+        source = source_dir / "source.md"
         source.write_text("# My Note\n\nHello world.\n")
-        note = PDVNote(relative_path=str(source))
+        note = PDVNote(uuid=node_uuid, filename="source.md")
 
         descriptor = serialize_node("notes.intro", note, str(tmp_path))
 
@@ -141,36 +129,21 @@ class TestSerializeMarkdown:
         assert descriptor["metadata"]["language"] == "markdown"
         assert descriptor["storage"]["backend"] == "local_file"
         assert descriptor["storage"]["format"] == FORMAT_MARKDOWN
-        assert descriptor["storage"]["relative_path"].endswith(".md")
-
-        # Verify the file exists at the serialized location
-        rel_path = descriptor["storage"]["relative_path"]
-        abs_path = os.path.join(str(tmp_path), rel_path)
-        assert os.path.exists(abs_path)
-        with open(abs_path, "r") as f:
-            assert f.read() == "# My Note\n\nHello world.\n"
-
-    def test_serialize_copies_file_to_tree_dir(self, tmp_path):
-        source_dir = tmp_path / "workspace"
-        source_dir.mkdir()
-        source = source_dir / "original.md"
-        source.write_text("Content here.")
-        note = PDVNote(relative_path=str(source))
-
-        descriptor = serialize_node("docs.readme", note, str(tmp_path))
-
-        rel = descriptor["storage"]["relative_path"]
-        assert "tree" in rel  # File is stored under tree/ directory
+        assert "uuid" in descriptor["storage"]
+        assert "filename" in descriptor["storage"]
 
     def test_serialize_raises_for_missing_file(self, tmp_path):
-        note = PDVNote(relative_path="/nonexistent/file.md")
+        note = PDVNote(uuid="note_ser_002", filename="missing.md")
         with pytest.raises(Exception):
             serialize_node("notes.missing", note, str(tmp_path))
 
-    def test_serialize_preview_from_file(self, tmp_path):
-        source = tmp_path / "source.md"
+    def test_serialize_preview_from_title(self, tmp_path):
+        node_uuid = "note_ser_003"
+        source_dir = tmp_path / "tree" / node_uuid
+        source_dir.mkdir(parents=True)
+        source = source_dir / "source.md"
         source.write_text("# Physics Notes\n\nSome equations.\n")
-        note = PDVNote(relative_path=str(source))
+        note = PDVNote(uuid=node_uuid, filename="source.md", title="Physics Notes")
 
         descriptor = serialize_node("notes.physics", note, str(tmp_path))
         assert descriptor["metadata"]["preview"] == "Physics Notes"
@@ -180,13 +153,16 @@ class TestDeserializeMarkdown:
     """Tests for deserialize_node() with markdown format."""
 
     def test_deserialize_reads_md_content(self, tmp_path):
-        md_file = tmp_path / "tree" / "notes" / "intro.md"
-        md_file.parent.mkdir(parents=True)
+        node_uuid = "note_des_001"
+        md_dir = tmp_path / "tree" / node_uuid
+        md_dir.mkdir(parents=True)
+        md_file = md_dir / "intro.md"
         md_file.write_text("# Hello\n\nWorld.\n")
 
         storage_ref = {
             "backend": "local_file",
-            "relative_path": "tree/notes/intro.md",
+            "uuid": node_uuid,
+            "filename": "intro.md",
             "format": FORMAT_MARKDOWN,
         }
         result = deserialize_node(storage_ref, str(tmp_path))
@@ -195,7 +171,8 @@ class TestDeserializeMarkdown:
     def test_deserialize_raises_for_missing_file(self, tmp_path):
         storage_ref = {
             "backend": "local_file",
-            "relative_path": "tree/notes/missing.md",
+            "uuid": "note_des_002",
+            "filename": "missing.md",
             "format": FORMAT_MARKDOWN,
         }
         with pytest.raises(FileNotFoundError):
@@ -206,17 +183,11 @@ class TestNodePreviewMarkdown:
     """Tests for node_preview() with markdown kind."""
 
     def test_preview_with_titled_note(self):
-        note = PDVNote(relative_path="x.md", title="Analysis Results")
+        note = PDVNote(uuid="note_prv_001", filename="x.md", title="Analysis Results")
         assert node_preview(note, KIND_MARKDOWN) == "Analysis Results"
 
-    def test_preview_with_file_note(self, tmp_path):
-        md_file = tmp_path / "test.md"
-        md_file.write_text("## Section One\n")
-        note = PDVNote(relative_path=str(md_file))
-        assert node_preview(note, KIND_MARKDOWN) == "Section One"
-
     def test_preview_fallback(self):
-        note = PDVNote(relative_path="/nonexistent.md")
+        note = PDVNote(uuid="note_prv_003", filename="nonexistent.md")
         assert node_preview(note, KIND_MARKDOWN) == "Markdown note"
 
 
@@ -235,7 +206,8 @@ class TestHandleNoteRegister:
             {
                 "parent_path": "notes",
                 "name": "introduction",
-                "relative_path": "notes/introduction.md",
+                "uuid": "note_reg_001",
+                "filename": "introduction.md",
             }
         )
         with (
@@ -246,7 +218,8 @@ class TestHandleNoteRegister:
 
         node = tree["notes.introduction"]
         assert isinstance(node, PDVNote)
-        assert node.relative_path == "notes/introduction.md"
+        assert node.uuid == "note_reg_001"
+        assert node.filename == "introduction.md"
         response = mock_comm._sent[-1]
         assert response["type"] == "pdv.note.register.response"
         assert response["status"] == "ok"
@@ -255,7 +228,7 @@ class TestHandleNoteRegister:
     def test_register_missing_name_sends_error(self):
         tree = PDVTree()
         mock_comm = _make_mock_comm()
-        msg = _make_msg({"parent_path": "notes", "relative_path": "notes/x.md"})
+        msg = _make_msg({"parent_path": "notes", "uuid": "note_reg_002", "filename": "x.md"})
         with (
             patch.object(comms_mod, "_comm", mock_comm),
             patch.object(comms_mod, "_pdv_tree", tree),
@@ -266,10 +239,10 @@ class TestHandleNoteRegister:
         assert response["status"] == "error"
         assert response["payload"]["code"] == "note.missing_name"
 
-    def test_register_missing_relative_path_sends_error(self):
+    def test_register_missing_uuid_sends_error(self):
         tree = PDVTree()
         mock_comm = _make_mock_comm()
-        msg = _make_msg({"parent_path": "notes", "name": "x"})
+        msg = _make_msg({"parent_path": "notes", "name": "x", "filename": "x.md"})
         with (
             patch.object(comms_mod, "_comm", mock_comm),
             patch.object(comms_mod, "_pdv_tree", tree),
@@ -278,7 +251,7 @@ class TestHandleNoteRegister:
 
         response = mock_comm._sent[0]
         assert response["status"] == "error"
-        assert response["payload"]["code"] == "note.missing_relative_path"
+        assert response["payload"]["code"] == "note.missing_uuid"
 
     def test_register_at_root_path(self):
         tree = PDVTree()
@@ -287,7 +260,8 @@ class TestHandleNoteRegister:
             {
                 "parent_path": "",
                 "name": "readme",
-                "relative_path": "readme.md",
+                "uuid": "note_reg_003",
+                "filename": "readme.md",
             }
         )
         with (
@@ -308,7 +282,8 @@ class TestHandleNoteRegister:
             {
                 "parent_path": "notes",
                 "name": "new_note",
-                "relative_path": "notes/new_note.md",
+                "uuid": "note_reg_004",
+                "filename": "new_note.md",
             }
         )
         with (
@@ -331,7 +306,7 @@ class TestHandleNoteRegister:
 class TestPDVAppNewNote:
     """Tests for pdv.new_note() convenience method."""
 
-    def test_new_note_creates_file_and_tree_node(self, tmp_path):
+    def test_new_note_creates_tree_node(self, tmp_path):
         tree = PDVTree()
         tree._working_dir = str(tmp_path)
         mock_comm = _make_mock_comm()
@@ -346,46 +321,6 @@ class TestPDVAppNewNote:
         node = tree["notes.intro"]
         assert isinstance(node, PDVNote)
         assert node.title == "Introduction"
-        # File should exist
-        assert os.path.exists(node.relative_path)
-        content = open(node.relative_path, "r").read()
-        assert content.startswith("# Introduction")
-
-    def test_new_note_without_title_creates_empty_file(self, tmp_path):
-        tree = PDVTree()
-        tree._working_dir = str(tmp_path)
-        mock_comm = _make_mock_comm()
-        app = PDVApp()
-
-        with (
-            patch.object(comms_mod, "_comm", mock_comm),
-            patch.object(comms_mod, "_pdv_tree", tree),
-        ):
-            app.new_note("scratch")
-
-        node = tree["scratch"]
-        assert isinstance(node, PDVNote)
-        content = open(node.relative_path, "r").read()
-        assert content == ""
-
-    def test_new_note_does_not_overwrite_existing_file(self, tmp_path):
-        tree = PDVTree()
-        tree._working_dir = str(tmp_path)
-        mock_comm = _make_mock_comm()
-        app = PDVApp()
-
-        # Pre-create the file
-        md_file = tmp_path / "existing.md"
-        md_file.write_text("Existing content")
-
-        with (
-            patch.object(comms_mod, "_comm", mock_comm),
-            patch.object(comms_mod, "_pdv_tree", tree),
-        ):
-            app.new_note("existing", title="New Title")
-
-        content = open(tree["existing"].relative_path, "r").read()
-        assert content == "Existing content"
 
 
 # ---------------------------------------------------------------------------
@@ -394,13 +329,16 @@ class TestPDVAppNewNote:
 
 
 class TestMarkdownRoundTrip:
-    """Tests for serialize → deserialize round-trip with markdown nodes."""
+    """Tests for serialize -> deserialize round-trip with markdown nodes."""
 
     def test_roundtrip_preserves_content(self, tmp_path):
         original_content = "# Physics Derivation\n\n$$E = mc^2$$\n\nMore text.\n"
-        source = tmp_path / "deriv.md"
+        node_uuid = "note_rt_001"
+        source_dir = tmp_path / "tree" / node_uuid
+        source_dir.mkdir(parents=True)
+        source = source_dir / "deriv.md"
         source.write_text(original_content)
-        note = PDVNote(relative_path=str(source))
+        note = PDVNote(uuid=node_uuid, filename="deriv.md")
 
         descriptor = serialize_node("notes.derivation", note, str(tmp_path))
         restored = deserialize_node(descriptor["storage"], str(tmp_path))

--- a/pdv-python/tests/test_pdvapp_api.py
+++ b/pdv-python/tests/test_pdvapp_api.py
@@ -1,0 +1,174 @@
+"""
+Tests for PDVApp.add_file() and PDVApp.new_note() in namespace.py.
+
+Covers:
+- add_file: copies file to UUID-based storage, returns PDVFile.
+- add_file: raises FileNotFoundError for missing source.
+- add_file: raises ValueError for directory source.
+- add_file: raises PDVError when tree has no working dir.
+- add_file: tilde expansion works.
+- new_note: creates .md file in UUID storage, attaches to tree.
+- new_note: initializes with title header when provided.
+- new_note: creates empty file when no title.
+- new_note: does nothing when tree is None.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import pdv.comms as comms_mod
+from pdv.errors import PDVError
+from pdv.namespace import PDVApp
+from pdv.tree import PDVFile, PDVNote, PDVTree
+
+
+class TestAddFile:
+    def test_copies_file_and_returns_pdvfile(self, tree_with_comm, tmp_path):
+        source = tmp_path / "input.csv"
+        source.write_text("a,b,c\n1,2,3\n")
+
+        app = PDVApp()
+        with patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm):
+            result = app.add_file(str(source))
+
+        assert isinstance(result, PDVFile)
+        assert result.filename == "input.csv"
+        assert len(result.uuid) == 12
+
+        dest = os.path.join(
+            tree_with_comm._working_dir, "tree", result.uuid, "input.csv"
+        )
+        assert os.path.exists(dest)
+        assert open(dest).read() == "a,b,c\n1,2,3\n"
+
+    def test_original_file_not_moved(self, tree_with_comm, tmp_path):
+        source = tmp_path / "keep_me.txt"
+        source.write_text("original")
+
+        app = PDVApp()
+        with patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm):
+            app.add_file(str(source))
+
+        assert source.exists()
+        assert source.read_text() == "original"
+
+    def test_binary_file_preserved(self, tree_with_comm, tmp_path):
+        source = tmp_path / "data.bin"
+        binary_data = bytes(range(256))
+        source.write_bytes(binary_data)
+
+        app = PDVApp()
+        with patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm):
+            result = app.add_file(str(source))
+
+        dest = os.path.join(
+            tree_with_comm._working_dir, "tree", result.uuid, "data.bin"
+        )
+        assert open(dest, "rb").read() == binary_data
+
+    def test_raises_for_missing_source(self, tree_with_comm):
+        app = PDVApp()
+        with (
+            patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm),
+            pytest.raises(FileNotFoundError, match="not found"),
+        ):
+            app.add_file("/no/such/file.txt")
+
+    def test_raises_for_directory_source(self, tree_with_comm, tmp_path):
+        dir_path = tmp_path / "some_dir"
+        dir_path.mkdir()
+
+        app = PDVApp()
+        with (
+            patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm),
+            pytest.raises(ValueError, match="not a file"),
+        ):
+            app.add_file(str(dir_path))
+
+    def test_raises_when_no_working_dir(self, tmp_path):
+        source = tmp_path / "exists.txt"
+        source.write_text("data")
+        tree = PDVTree()
+        app = PDVApp()
+        with (
+            patch.object(comms_mod, "get_pdv_tree", return_value=tree),
+            pytest.raises(PDVError, match="not available"),
+        ):
+            app.add_file(str(source))
+
+    def test_tilde_expansion(self, tree_with_comm, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        source = tmp_path / "doc.txt"
+        source.write_text("hello")
+
+        app = PDVApp()
+        with patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm):
+            result = app.add_file("~/doc.txt")
+
+        assert isinstance(result, PDVFile)
+        assert result.filename == "doc.txt"
+
+
+class TestNewNote:
+    def test_creates_note_in_tree(self, tree_with_comm):
+        app = PDVApp()
+        with patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm):
+            app.new_note("notes.intro", title="Introduction")
+
+        note = tree_with_comm["notes.intro"]
+        assert isinstance(note, PDVNote)
+        assert note.filename == "intro.md"
+        assert note.title == "Introduction"
+        assert len(note.uuid) == 12
+
+    def test_file_initialized_with_title_header(self, tree_with_comm):
+        app = PDVApp()
+        with patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm):
+            app.new_note("notes.physics", title="Physics Notes")
+
+        note = tree_with_comm["notes.physics"]
+        file_path = os.path.join(
+            tree_with_comm._working_dir, "tree", note.uuid, "physics.md"
+        )
+        assert os.path.exists(file_path)
+        content = open(file_path, encoding="utf-8").read()
+        assert content == "# Physics Notes\n"
+
+    def test_file_empty_when_no_title(self, tree_with_comm):
+        app = PDVApp()
+        with patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm):
+            app.new_note("notes.blank")
+
+        note = tree_with_comm["notes.blank"]
+        file_path = os.path.join(
+            tree_with_comm._working_dir, "tree", note.uuid, "blank.md"
+        )
+        assert os.path.exists(file_path)
+        content = open(file_path, encoding="utf-8").read()
+        assert content == ""
+
+    def test_noop_when_tree_is_none(self, capsys):
+        app = PDVApp()
+        with patch.object(comms_mod, "get_pdv_tree", return_value=None):
+            app.new_note("notes.ghost", title="Ghost")
+
+        captured = capsys.readouterr()
+        assert "not initialized" in captured.out
+
+    def test_nested_path_creates_intermediate_folders(self, tree_with_comm):
+        app = PDVApp()
+        with patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm):
+            app.new_note("docs.section.intro", title="Intro")
+
+        note = tree_with_comm["docs.section.intro"]
+        assert isinstance(note, PDVNote)
+
+    def test_prints_confirmation(self, tree_with_comm, capsys):
+        app = PDVApp()
+        with patch.object(comms_mod, "get_pdv_tree", return_value=tree_with_comm):
+            app.new_note("notes.hello", title="Hello")
+
+        captured = capsys.readouterr()
+        assert "notes.hello" in captured.out

--- a/pdv-python/tests/test_purge_orphaned.py
+++ b/pdv-python/tests/test_purge_orphaned.py
@@ -1,0 +1,110 @@
+"""
+Tests for _purge_orphaned_tree_files() in handlers/project.py.
+
+Covers:
+- Orphaned UUID directories are removed after save.
+- Referenced UUID directories (via node uuid or storage uuid) are preserved.
+- Non-UUID entries in tree/ are left alone.
+- Empty tree dir or missing tree dir does not crash.
+- Filesystem errors during rmtree are swallowed gracefully.
+"""
+
+import os
+
+from pdv.handlers.project import _purge_orphaned_tree_files
+
+
+class TestPurgeOrphanedTreeFiles:
+    def test_removes_unreferenced_uuid_dirs(self, tmp_path):
+        tree_dir = tmp_path / "tree"
+        tree_dir.mkdir()
+        orphan = tree_dir / "aabbccddeeff"
+        orphan.mkdir()
+        (orphan / "data.npy").write_bytes(b"fake")
+
+        _purge_orphaned_tree_files(str(tmp_path), [])
+
+        assert not orphan.exists()
+
+    def test_preserves_referenced_by_node_uuid(self, tmp_path):
+        tree_dir = tmp_path / "tree"
+        tree_dir.mkdir()
+        kept = tree_dir / "112233445566"
+        kept.mkdir()
+        (kept / "script.py").write_text("pass")
+
+        nodes = [{"uuid": "112233445566", "storage": {}}]
+        _purge_orphaned_tree_files(str(tmp_path), nodes)
+
+        assert kept.exists()
+
+    def test_preserves_referenced_by_storage_uuid(self, tmp_path):
+        tree_dir = tmp_path / "tree"
+        tree_dir.mkdir()
+        kept = tree_dir / "aabb11223344"
+        kept.mkdir()
+        (kept / "arr.npy").write_bytes(b"data")
+
+        nodes = [{"storage": {"uuid": "aabb11223344"}}]
+        _purge_orphaned_tree_files(str(tmp_path), nodes)
+
+        assert kept.exists()
+
+    def test_ignores_non_uuid_entries(self, tmp_path):
+        tree_dir = tmp_path / "tree"
+        tree_dir.mkdir()
+        not_uuid = tree_dir / "not-a-uuid-dir"
+        not_uuid.mkdir()
+
+        _purge_orphaned_tree_files(str(tmp_path), [])
+
+        assert not_uuid.exists()
+
+    def test_ignores_files_not_dirs(self, tmp_path):
+        tree_dir = tmp_path / "tree"
+        tree_dir.mkdir()
+        stray_file = tree_dir / "aabbccddeeff"
+        stray_file.write_text("not a dir")
+
+        _purge_orphaned_tree_files(str(tmp_path), [])
+
+        assert stray_file.exists()
+
+    def test_no_tree_dir_is_noop(self, tmp_path):
+        _purge_orphaned_tree_files(str(tmp_path), [])
+
+    def test_mixed_referenced_and_orphaned(self, tmp_path):
+        tree_dir = tmp_path / "tree"
+        tree_dir.mkdir()
+
+        ref_uuid = "111111111111"
+        orphan_uuid = "222222222222"
+        (tree_dir / ref_uuid).mkdir()
+        (tree_dir / ref_uuid / "data.npy").write_bytes(b"keep")
+        (tree_dir / orphan_uuid).mkdir()
+        (tree_dir / orphan_uuid / "old.npy").write_bytes(b"remove")
+
+        nodes = [{"uuid": ref_uuid, "storage": {}}]
+        _purge_orphaned_tree_files(str(tmp_path), nodes)
+
+        assert (tree_dir / ref_uuid).exists()
+        assert not (tree_dir / orphan_uuid).exists()
+
+    def test_rmtree_error_is_swallowed(self, tmp_path, monkeypatch):
+        tree_dir = tmp_path / "tree"
+        tree_dir.mkdir()
+        orphan = tree_dir / "aabbccddeeff"
+        orphan.mkdir()
+
+        import shutil
+        original_rmtree = shutil.rmtree
+
+        def failing_rmtree(path, **kwargs):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(shutil, "rmtree", failing_rmtree)
+
+        _purge_orphaned_tree_files(str(tmp_path), [])
+
+        monkeypatch.setattr(shutil, "rmtree", original_rmtree)
+        assert orphan.exists()

--- a/pdv-python/tests/test_serialization.py
+++ b/pdv-python/tests/test_serialization.py
@@ -27,7 +27,9 @@ from pdv.serialization import (
     KIND_SEQUENCE,
     KIND_FOLDER,
     KIND_SCRIPT,
+    KIND_FILE,
     KIND_UNKNOWN,
+    FORMAT_FILE,
 )
 from pdv.errors import PDVSerializationError
 
@@ -468,3 +470,244 @@ class TestCompositeMappingSerialize:
             desc["storage"], tmp_working_dir, trusted=True
         )
         assert isinstance(restored, WeirdPicklable)
+
+
+class TestPDVFileSerialize:
+    """Tests for bare PDVFile serialization and round-trip."""
+
+    def test_bare_pdvfile_is_kind_file(self):
+        from pdv.tree import PDVFile
+
+        node = PDVFile(uuid="abc123def456", filename="mesh.h5")
+        assert detect_kind(node) == KIND_FILE
+
+    def test_pdvfile_serialize_emits_file_descriptor(self, tmp_working_dir):
+        """serialize_node writes descriptor with format=file and local_file backend."""
+        from pdv.tree import PDVFile
+
+        node_uuid = "filenode_001"
+        src_dir = os.path.join(tmp_working_dir, "tree", node_uuid)
+        os.makedirs(src_dir, exist_ok=True)
+        src_path = os.path.join(src_dir, "mesh.h5")
+        with open(src_path, "wb") as fh:
+            fh.write(b"\x89HDF\r\n\x1a\nfake content")
+
+        node = PDVFile(uuid=node_uuid, filename="mesh.h5")
+        desc = serialize_node("simulation.mesh", node, tmp_working_dir)
+
+        assert desc["type"] == KIND_FILE
+        assert desc["uuid"] == node_uuid
+        assert desc["storage"]["backend"] == "local_file"
+        assert desc["storage"]["format"] == FORMAT_FILE
+        assert desc["storage"]["uuid"] == node_uuid
+        assert desc["storage"]["filename"] == "mesh.h5"
+        assert "preview" in desc["metadata"]
+
+    def test_pdvfile_serialize_copies_to_save_dir(
+        self, tmp_working_dir, tmp_save_dir
+    ):
+        """Serialization copies the backing file from source_dir to working_dir (=save dir)."""
+        from pdv.environment import uuid_tree_path
+        from pdv.tree import PDVFile
+
+        node_uuid = "filenode_002"
+        src_dir = os.path.join(tmp_working_dir, "tree", node_uuid)
+        os.makedirs(src_dir, exist_ok=True)
+        src_path = os.path.join(src_dir, "data.bin")
+        payload = b"\x00\x01\x02hello\xff"
+        with open(src_path, "wb") as fh:
+            fh.write(payload)
+
+        node = PDVFile(uuid=node_uuid, filename="data.bin")
+        serialize_node(
+            "imports.data",
+            node,
+            tmp_save_dir,
+            source_dir=tmp_working_dir,
+        )
+
+        dest_path = uuid_tree_path(tmp_save_dir, node_uuid, "data.bin")
+        assert os.path.exists(dest_path)
+        with open(dest_path, "rb") as fh:
+            assert fh.read() == payload
+
+    def test_pdvfile_serialize_missing_file_raises(self, tmp_working_dir):
+        from pdv.tree import PDVFile
+
+        node = PDVFile(uuid="ghost_uuid_xx", filename="nowhere.dat")
+        with pytest.raises(PDVSerializationError, match="File not found"):
+            serialize_node("ghost", node, tmp_working_dir)
+
+    def test_pdvfile_deserialize_returns_bytes(self, tmp_working_dir):
+        """deserialize_node on FORMAT_FILE returns raw bytes (fallback path)."""
+        from pdv.environment import ensure_parent, uuid_tree_path
+
+        node_uuid = "deser_file_01"
+        abs_path = uuid_tree_path(tmp_working_dir, node_uuid, "blob.bin")
+        ensure_parent(abs_path)
+        payload = b"raw-bytes-content"
+        with open(abs_path, "wb") as fh:
+            fh.write(payload)
+
+        storage = {
+            "backend": "local_file",
+            "uuid": node_uuid,
+            "filename": "blob.bin",
+            "format": FORMAT_FILE,
+        }
+        result = deserialize_node(storage, tmp_working_dir, trusted=False)
+        assert result == payload
+
+    def test_pdvfile_round_trip_through_tree_loader(self, tmp_working_dir):
+        """serialize_node + load_tree_index reconstruct a PDVFile with correct fields."""
+        from pdv.tree import PDVFile, PDVTree
+        from pdv.tree_loader import load_tree_index
+
+        node_uuid = "rt_file_uuid1"
+        src_dir = os.path.join(tmp_working_dir, "tree", node_uuid)
+        os.makedirs(src_dir, exist_ok=True)
+        src_path = os.path.join(src_dir, "dataset.h5")
+        with open(src_path, "wb") as fh:
+            fh.write(b"roundtrip-payload")
+
+        node = PDVFile(uuid=node_uuid, filename="dataset.h5")
+        descriptors = [serialize_node("imports.dataset", node, tmp_working_dir)]
+
+        fresh = PDVTree()
+        fresh._working_dir = tmp_working_dir
+        load_tree_index(fresh, descriptors, conflict_strategy="replace")
+
+        loaded = fresh["imports.dataset"]
+        assert isinstance(loaded, PDVFile)
+        assert loaded.uuid == node_uuid
+        assert loaded.filename == "dataset.h5"
+        assert loaded.resolve_path(tmp_working_dir) == src_path
+
+    def test_pdvfile_preview(self):
+        from pdv.tree import PDVFile
+
+        node = PDVFile(uuid="prev_uuid_01", filename="camera.jpg")
+        assert node_preview(node, KIND_FILE) == "camera.jpg"
+
+
+class TestAddFile:
+    """Tests for pdv.add_file() — user-facing file import API."""
+
+    def _fresh_tree(self, tmp_working_dir):
+        from pdv.tree import PDVTree
+
+        tree = PDVTree()
+        tree._set_working_dir(tmp_working_dir)
+        return tree
+
+    def test_add_file_imports_and_returns_pdvfile(self, tmp_working_dir, tmp_path):
+        """add_file() copies the source and returns a PDVFile with fresh UUID."""
+        import pdv.comms as comms_mod
+        from pdv.environment import uuid_tree_path
+        from pdv.namespace import PDVApp
+        from pdv.tree import PDVFile
+
+        source = tmp_path / "mesh.h5"
+        source.write_bytes(b"\x89HDF\r\nmesh-data")
+
+        tree = self._fresh_tree(tmp_working_dir)
+        old_tree = comms_mod._pdv_tree
+        comms_mod._pdv_tree = tree
+        try:
+            node = PDVApp().add_file(str(source))
+        finally:
+            comms_mod._pdv_tree = old_tree
+
+        assert isinstance(node, PDVFile)
+        assert node.filename == "mesh.h5"
+        assert len(node.uuid) == 12
+        dest = uuid_tree_path(tmp_working_dir, node.uuid, "mesh.h5")
+        assert os.path.exists(dest)
+        with open(dest, "rb") as fh:
+            assert fh.read() == b"\x89HDF\r\nmesh-data"
+
+    def test_add_file_expands_tilde(self, tmp_working_dir, tmp_path, monkeypatch):
+        import pdv.comms as comms_mod
+        from pdv.namespace import PDVApp
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        source = tmp_path / "mesh.h5"
+        source.write_bytes(b"tilde-content")
+
+        tree = self._fresh_tree(tmp_working_dir)
+        old_tree = comms_mod._pdv_tree
+        comms_mod._pdv_tree = tree
+        try:
+            node = PDVApp().add_file("~/mesh.h5")
+        finally:
+            comms_mod._pdv_tree = old_tree
+
+        assert node.filename == "mesh.h5"
+
+    def test_add_file_missing_source_raises(self, tmp_working_dir):
+        import pdv.comms as comms_mod
+        from pdv.namespace import PDVApp
+
+        tree = self._fresh_tree(tmp_working_dir)
+        old_tree = comms_mod._pdv_tree
+        comms_mod._pdv_tree = tree
+        try:
+            with pytest.raises(FileNotFoundError):
+                PDVApp().add_file("/definitely/not/a/real/path.xyz")
+        finally:
+            comms_mod._pdv_tree = old_tree
+
+    def test_add_file_directory_raises(self, tmp_working_dir, tmp_path):
+        import pdv.comms as comms_mod
+        from pdv.namespace import PDVApp
+
+        tree = self._fresh_tree(tmp_working_dir)
+        old_tree = comms_mod._pdv_tree
+        comms_mod._pdv_tree = tree
+        try:
+            with pytest.raises(ValueError, match="not a file"):
+                PDVApp().add_file(str(tmp_path))
+        finally:
+            comms_mod._pdv_tree = old_tree
+
+    def test_add_file_no_working_dir_raises(self, tmp_path):
+        import pdv.comms as comms_mod
+        from pdv.errors import PDVError
+        from pdv.namespace import PDVApp
+        from pdv.tree import PDVTree
+
+        source = tmp_path / "mesh.h5"
+        source.write_bytes(b"x")
+
+        tree = PDVTree()  # no working_dir set
+        old_tree = comms_mod._pdv_tree
+        comms_mod._pdv_tree = tree
+        try:
+            with pytest.raises(PDVError, match="has not received pdv.init"):
+                PDVApp().add_file(str(source))
+        finally:
+            comms_mod._pdv_tree = old_tree
+
+    def test_add_file_then_assign_to_tree(self, tmp_working_dir, tmp_path):
+        """End-to-end: imported PDVFile can be assigned to a tree path and resolved."""
+        import pdv.comms as comms_mod
+        from pdv.namespace import PDVApp
+        from pdv.tree import PDVFile
+
+        source = tmp_path / "table.csv"
+        source.write_text("a,b\n1,2\n")
+
+        tree = self._fresh_tree(tmp_working_dir)
+        old_tree = comms_mod._pdv_tree
+        comms_mod._pdv_tree = tree
+        try:
+            node = PDVApp().add_file(str(source))
+            tree["imports.table"] = node
+        finally:
+            comms_mod._pdv_tree = old_tree
+
+        assert isinstance(tree["imports.table"], PDVFile)
+        resolved = tree["imports.table"].resolve_path(tmp_working_dir)
+        assert os.path.exists(resolved)
+        with open(resolved) as fh:
+            assert fh.read() == "a,b\n1,2\n"

--- a/pdv-python/tests/test_serialization.py
+++ b/pdv-python/tests/test_serialization.py
@@ -100,7 +100,7 @@ class TestDetectKind:
         """PDVScript returns KIND_SCRIPT."""
         from pdv.tree import PDVScript
 
-        assert detect_kind(PDVScript("scripts/test.py")) == KIND_SCRIPT
+        assert detect_kind(PDVScript("abc123def456", "test.py")) == KIND_SCRIPT
 
 
 class TestSerializeAndDeserialize:
@@ -248,11 +248,12 @@ class TestMetadataSubDict:
     def test_gui_descriptor_metadata(self, tmp_working_dir):
         from pdv.tree import PDVGui
 
-        gui_file = os.path.join(tmp_working_dir, "tree", "mod", "gui.gui.json")
+        node_uuid = "gui_uuid_001"
+        gui_file = os.path.join(tmp_working_dir, "tree", node_uuid, "gui.gui.json")
         os.makedirs(os.path.dirname(gui_file), exist_ok=True)
         with open(gui_file, "w") as f:
             f.write("{}")
-        gui = PDVGui(relative_path=gui_file, module_id="test_mod")
+        gui = PDVGui(uuid=node_uuid, filename="gui.gui.json", module_id="test_mod")
         desc = serialize_node("mod.gui", gui, tmp_working_dir)
         assert "metadata" in desc
         meta = desc["metadata"]
@@ -262,12 +263,13 @@ class TestMetadataSubDict:
     def test_namelist_descriptor_metadata(self, tmp_working_dir):
         from pdv.tree import PDVNamelist
 
-        nml_file = os.path.join(tmp_working_dir, "tree", "mod", "solver.nml")
+        node_uuid = "nml_uuid_001"
+        nml_file = os.path.join(tmp_working_dir, "tree", node_uuid, "solver.nml")
         os.makedirs(os.path.dirname(nml_file), exist_ok=True)
         with open(nml_file, "w") as f:
             f.write("&solver /\n")
         nml = PDVNamelist(
-            relative_path=nml_file, format="fortran", module_id="test_mod"
+            uuid=node_uuid, filename="solver.nml", format="fortran", module_id="test_mod"
         )
         desc = serialize_node("mod.solver", nml, tmp_working_dir)
         assert "metadata" in desc
@@ -279,11 +281,12 @@ class TestMetadataSubDict:
     def test_lib_descriptor_metadata(self, tmp_working_dir):
         from pdv.tree import PDVLib
 
-        lib_file = os.path.join(tmp_working_dir, "tree", "mod", "lib", "helpers.py")
+        node_uuid = "lib_uuid_001"
+        lib_file = os.path.join(tmp_working_dir, "tree", node_uuid, "helpers.py")
         os.makedirs(os.path.dirname(lib_file), exist_ok=True)
         with open(lib_file, "w") as f:
             f.write("# helpers\n")
-        lib = PDVLib(relative_path=lib_file, module_id="test_mod")
+        lib = PDVLib(uuid=node_uuid, filename="helpers.py", module_id="test_mod")
         desc = serialize_node("mod.lib.helpers", lib, tmp_working_dir)
         assert "metadata" in desc
         meta = desc["metadata"]
@@ -294,12 +297,13 @@ class TestMetadataSubDict:
     def test_script_descriptor_metadata(self, tmp_working_dir):
         from pdv.tree import PDVScript
 
-        script_file = os.path.join(tmp_working_dir, "tree", "run.py")
+        node_uuid = "scr_uuid_001"
+        script_file = os.path.join(tmp_working_dir, "tree", node_uuid, "run.py")
         os.makedirs(os.path.dirname(script_file), exist_ok=True)
         with open(script_file, "w") as f:
             f.write('"""My script."""\ndef run(pdv_tree: dict):\n    return {}\n')
         script = PDVScript(
-            relative_path=script_file, language="python", doc="My script."
+            uuid=node_uuid, filename="run.py", language="python", doc="My script."
         )
         desc = serialize_node("run", script, tmp_working_dir)
         assert "metadata" in desc
@@ -314,12 +318,14 @@ class TestMetadataSubDict:
         """PDVScript with source_rel_path set round-trips through serialize_node."""
         from pdv.tree import PDVScript
 
-        script_file = os.path.join(tmp_working_dir, "my_mod", "scripts", "run.py")
+        node_uuid = "mod_scr_001"
+        script_file = os.path.join(tmp_working_dir, "tree", node_uuid, "run.py")
         os.makedirs(os.path.dirname(script_file), exist_ok=True)
         with open(script_file, "w") as f:
             f.write('"""Module script."""\ndef run(pdv_tree: dict):\n    return {}\n')
         script = PDVScript(
-            relative_path=script_file,
+            uuid=node_uuid,
+            filename="run.py",
             language="python",
             doc="Module script.",
             module_id="my_mod",
@@ -333,12 +339,13 @@ class TestMetadataSubDict:
         from pdv.tree import PDVLib, PDVModule, PDVScript, PDVTree
         from pdv.tree_loader import load_tree_index
 
-        mod_root = os.path.join(tmp_working_dir, "my_mod")
-        scripts_dir = os.path.join(mod_root, "scripts")
-        lib_dir = os.path.join(mod_root, "lib")
-        os.makedirs(scripts_dir, exist_ok=True)
+        scr_uuid = "mod_scr_rt01"
+        lib_uuid = "mod_lib_rt01"
+        script_dir = os.path.join(tmp_working_dir, "tree", scr_uuid)
+        lib_dir = os.path.join(tmp_working_dir, "tree", lib_uuid)
+        os.makedirs(script_dir, exist_ok=True)
         os.makedirs(lib_dir, exist_ok=True)
-        script_file = os.path.join(scripts_dir, "run.py")
+        script_file = os.path.join(script_dir, "run.py")
         with open(script_file, "w") as f:
             f.write("def run(pdv_tree: dict):\n    return {}\n")
         lib_file = os.path.join(lib_dir, "helpers.py")
@@ -346,12 +353,14 @@ class TestMetadataSubDict:
             f.write("VALUE = 1\n")
 
         script = PDVScript(
-            relative_path=script_file,
+            uuid=scr_uuid,
+            filename="run.py",
             module_id="my_mod",
             source_rel_path="scripts/run.py",
         )
         lib = PDVLib(
-            relative_path=lib_file,
+            uuid=lib_uuid,
+            filename="helpers.py",
             module_id="my_mod",
             source_rel_path="lib/helpers.py",
         )
@@ -443,6 +452,7 @@ class TestCompositeMappingSerialize:
 
     def test_pickle_fallback_node_writes_file(self, tmp_working_dir):
         from pdv.serialization import pickle_fallback_node
+        from pdv.environment import uuid_tree_path
 
         obj = WeirdPicklable()
         desc = pickle_fallback_node("u", obj, tmp_working_dir)
@@ -450,8 +460,9 @@ class TestCompositeMappingSerialize:
         assert desc["storage"]["format"] == "pickle"
         assert desc["metadata"]["fallback"] == "pickle"
         assert "python_type" in desc["metadata"]
-        rel = desc["storage"]["relative_path"]
-        assert os.path.exists(os.path.join(tmp_working_dir, rel))
+        node_uuid = desc["storage"]["uuid"]
+        filename = desc["storage"]["filename"]
+        assert os.path.exists(uuid_tree_path(tmp_working_dir, node_uuid, filename))
         # Round-trips via deserialize_node with trusted=True.
         restored = deserialize_node(
             desc["storage"], tmp_working_dir, trusted=True

--- a/pdv-python/tests/test_serialization_errors.py
+++ b/pdv-python/tests/test_serialization_errors.py
@@ -16,7 +16,8 @@ def test_missing_file_raises_descriptive_error(tmp_save_dir):
         deserialize_node(
             {
                 "backend": "local_file",
-                "relative_path": "tree/missing_arr.npy",
+                "uuid": "missing_uuid1",
+                "filename": "missing_arr.npy",
                 "format": "npy",
             },
             tmp_save_dir,
@@ -24,7 +25,8 @@ def test_missing_file_raises_descriptive_error(tmp_save_dir):
 
 
 def test_corrupted_npy_raises_descriptive_error(tmp_save_dir):
-    tree_dir = os.path.join(tmp_save_dir, "tree")
+    node_uuid = "corrupt_uuid"
+    tree_dir = os.path.join(tmp_save_dir, "tree", node_uuid)
     os.makedirs(tree_dir, exist_ok=True)
     bad_file = os.path.join(tree_dir, "bad.npy")
     with open(bad_file, "wb") as fh:
@@ -36,7 +38,8 @@ def test_corrupted_npy_raises_descriptive_error(tmp_save_dir):
         deserialize_node(
             {
                 "backend": "local_file",
-                "relative_path": "tree/bad.npy",
+                "uuid": node_uuid,
+                "filename": "bad.npy",
                 "format": "npy",
             },
             tmp_save_dir,
@@ -45,7 +48,8 @@ def test_corrupted_npy_raises_descriptive_error(tmp_save_dir):
 
 
 def test_wrong_format_hint_raises_error(tmp_save_dir):
-    tree_dir = os.path.join(tmp_save_dir, "tree")
+    node_uuid = "fmt_uuid_001"
+    tree_dir = os.path.join(tmp_save_dir, "tree", node_uuid)
     os.makedirs(tree_dir, exist_ok=True)
     file_path = os.path.join(tree_dir, "x.bin")
     with open(file_path, "wb") as fh:
@@ -55,7 +59,8 @@ def test_wrong_format_hint_raises_error(tmp_save_dir):
         deserialize_node(
             {
                 "backend": "local_file",
-                "relative_path": "tree/x.bin",
+                "uuid": node_uuid,
+                "filename": "x.bin",
                 "format": "made-up-format",
             },
             tmp_save_dir,
@@ -63,7 +68,8 @@ def test_wrong_format_hint_raises_error(tmp_save_dir):
 
 
 def test_deserialize_pickle_without_trusted_raises(tmp_save_dir):
-    tree_dir = os.path.join(tmp_save_dir, "tree")
+    node_uuid = "pkl_uuid_001"
+    tree_dir = os.path.join(tmp_save_dir, "tree", node_uuid)
     os.makedirs(tree_dir, exist_ok=True)
     file_path = os.path.join(tree_dir, "unsafe.pickle")
     with open(file_path, "wb") as fh:
@@ -75,7 +81,8 @@ def test_deserialize_pickle_without_trusted_raises(tmp_save_dir):
         deserialize_node(
             {
                 "backend": "local_file",
-                "relative_path": "tree/unsafe.pickle",
+                "uuid": node_uuid,
+                "filename": "unsafe.pickle",
                 "format": "pickle",
             },
             tmp_save_dir,

--- a/pdv-python/tests/test_serializers.py
+++ b/pdv-python/tests/test_serializers.py
@@ -143,12 +143,13 @@ def test_serialize_roundtrip_with_custom_serializer(tmp_path):
     assert descriptor["type"] == KIND_UNKNOWN
     assert descriptor["storage"]["backend"] == "local_file"
     assert descriptor["storage"]["format"] == "unpicklable_v1"
-    assert descriptor["storage"]["relative_path"].endswith(".json")
+    assert descriptor["storage"]["filename"].endswith(".json")
     assert descriptor["metadata"]["python_type"].endswith("_Unpicklable")
     assert descriptor["metadata"]["serializer"].endswith("_Unpicklable")
     assert descriptor["metadata"]["preview"] == "unpicklable(2 keys)"
 
-    abs_path = os.path.join(str(tmp_path), descriptor["storage"]["relative_path"])
+    from pdv.environment import uuid_tree_path
+    abs_path = uuid_tree_path(str(tmp_path), descriptor["storage"]["uuid"], descriptor["storage"]["filename"])
     assert os.path.exists(abs_path)
 
     loaded = deserialize_node(descriptor["storage"], str(tmp_path))
@@ -164,12 +165,14 @@ def test_serialize_unknown_without_serializer_still_requires_trusted(tmp_path):
 
 
 def test_deserialize_unknown_custom_format_raises(tmp_path):
-    backing = tmp_path / "tree" / "data" / "solver.json"
-    backing.parent.mkdir(parents=True, exist_ok=True)
-    backing.write_text("{}")
+    node_uuid = "unk_fmt_uuid"
+    backing_dir = tmp_path / "tree" / node_uuid
+    backing_dir.mkdir(parents=True, exist_ok=True)
+    (backing_dir / "solver.json").write_text("{}")
     storage_ref = {
         "backend": "local_file",
-        "relative_path": "tree/data/solver.json",
+        "uuid": node_uuid,
+        "filename": "solver.json",
         "format": "no_such_format",
     }
     with pytest.raises(PDVSerializationError, match="no_such_format"):
@@ -210,7 +213,7 @@ def test_public_register_serializer_entry_point_roundtrip(tmp_path):
     sol = _Solution(t=np.linspace(0, 1, 5), x=np.arange(5.0), params={"k": 1})
     descriptor = serialize_node("results.run", sol, str(tmp_path))
     assert descriptor["storage"]["format"] == "solution_v1"
-    assert descriptor["storage"]["relative_path"].endswith(".npz")
+    assert descriptor["storage"]["filename"].endswith(".npz")
 
     loaded = deserialize_node(descriptor["storage"], str(tmp_path))
     assert isinstance(loaded, _Solution)

--- a/pdv-python/tests/test_smart_copy.py
+++ b/pdv-python/tests/test_smart_copy.py
@@ -1,0 +1,65 @@
+"""Tests for pdv.environment.smart_copy and UUID helpers."""
+
+from __future__ import annotations
+
+import os
+import re
+from unittest import mock
+
+import pytest
+
+from pdv.environment import generate_node_uuid, smart_copy, uuid_tree_path
+
+
+class TestGenerateNodeUuid:
+    def test_length(self) -> None:
+        assert len(generate_node_uuid()) == 12
+
+    def test_hex_chars(self) -> None:
+        assert re.fullmatch(r"[0-9a-f]{12}", generate_node_uuid())
+
+    def test_uniqueness(self) -> None:
+        uuids = {generate_node_uuid() for _ in range(100)}
+        assert len(uuids) == 100
+
+
+class TestUuidTreePath:
+    def test_basic(self) -> None:
+        result = uuid_tree_path("/tmp/pdv-abc", "a1b2c3d4e5f6", "ch1.npy")
+        assert result == os.path.join("/tmp/pdv-abc", "tree", "a1b2c3d4e5f6", "ch1.npy")
+
+    def test_preserves_filename(self) -> None:
+        result = uuid_tree_path("/work", "abc123def456", "n_pendulum.py")
+        assert result.endswith("n_pendulum.py")
+
+
+class TestSmartCopy:
+    def test_copies_content(self, tmp_path: os.PathLike) -> None:
+        src = tmp_path / "src.txt"
+        src.write_text("hello world")
+        dst = tmp_path / "dst.txt"
+        smart_copy(str(src), str(dst))
+        assert dst.read_text() == "hello world"
+
+    def test_creates_parent_dirs(self, tmp_path: os.PathLike) -> None:
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"\x00\x01\x02")
+        dst = tmp_path / "deep" / "nested" / "dir" / "dst.bin"
+        smart_copy(str(src), str(dst))
+        assert dst.read_bytes() == b"\x00\x01\x02"
+
+    def test_works_without_reflink(self, tmp_path: os.PathLike) -> None:
+        src = tmp_path / "src.txt"
+        src.write_text("data")
+        dst = tmp_path / "dst.txt"
+        with mock.patch.dict("sys.modules", {"reflink_copy": None}):
+            smart_copy(str(src), str(dst))
+        assert dst.read_text() == "data"
+
+    def test_copies_binary_file(self, tmp_path: os.PathLike) -> None:
+        src = tmp_path / "src.npy"
+        content = bytes(range(256)) * 100
+        src.write_bytes(content)
+        dst = tmp_path / "out" / "dst.npy"
+        smart_copy(str(src), str(dst))
+        assert dst.read_bytes() == content

--- a/pdv-python/tests/test_tree.py
+++ b/pdv-python/tests/test_tree.py
@@ -245,19 +245,27 @@ class TestPDVScript:
         self, tree_with_comm, tmp_working_dir, tmp_path
     ):
         """PDVScript.run() calls the script's run() function."""
-        script_file = tmp_path / "test_script.py"
+        node_uuid = "abc123def456"
+        script_dir = tmp_path / "tree" / node_uuid
+        script_dir.mkdir(parents=True)
+        script_file = script_dir / "test_script.py"
         script_file.write_text("def run(tree, **kwargs):\n    return 42\n")
-        script = PDVScript(relative_path=str(script_file), language="python")
+        tree_with_comm._set_working_dir(str(tmp_path))
+        script = PDVScript(uuid=node_uuid, filename="test_script.py", language="python")
         result = script.run(tree_with_comm)
         assert result == 42
 
     def test_run_passes_tree_as_first_arg(self, tree_with_comm, tmp_path):
         """The tree is passed as the first argument to the script run()."""
-        script_file = tmp_path / "check_tree.py"
+        node_uuid = "abc123def457"
+        script_dir = tmp_path / "tree" / node_uuid
+        script_dir.mkdir(parents=True)
+        script_file = script_dir / "check_tree.py"
         script_file.write_text(
             "def run(tree, **kwargs):\n    return type(tree).__name__\n"
         )
-        script = PDVScript(relative_path=str(script_file))
+        tree_with_comm._set_working_dir(str(tmp_path))
+        script = PDVScript(uuid=node_uuid, filename="check_tree.py")
         result = script.run(tree_with_comm)
         assert result == "PDVTree"
 
@@ -267,39 +275,51 @@ class TestPDVScript:
         """Calling script.run(**kwargs) uses the bootstrapped global tree."""
         from pdv import comms
 
-        script_file = tmp_path / "global_tree.py"
+        node_uuid = "abc123def458"
+        script_dir = tmp_path / "tree" / node_uuid
+        script_dir.mkdir(parents=True)
+        script_file = script_dir / "global_tree.py"
         script_file.write_text('def run(tree, **kwargs):\n    return tree["x"]\n')
-        script = PDVScript(relative_path=str(script_file))
+        tree_with_comm._set_working_dir(str(tmp_path))
+        script = PDVScript(uuid=node_uuid, filename="global_tree.py")
         tree_with_comm["x"] = 7
         monkeypatch.setattr(comms, "_pdv_tree", tree_with_comm)
         assert script.run() == 7
 
     def test_run_missing_file_raises(self, tree_with_comm):
         """Running a non-existent script raises FileNotFoundError."""
-        script = PDVScript(relative_path="/nonexistent/path/to/script.py")
+        script = PDVScript(uuid="missing_uuid1", filename="script.py")
         with pytest.raises(FileNotFoundError):
             script.run(tree_with_comm)
 
     def test_run_no_run_fn_raises(self, tree_with_comm, tmp_path):
         """Running a script without run() raises PDVScriptError."""
-        script_file = tmp_path / "no_run.py"
+        node_uuid = "abc123def459"
+        script_dir = tmp_path / "tree" / node_uuid
+        script_dir.mkdir(parents=True)
+        script_file = script_dir / "no_run.py"
         script_file.write_text("x = 1\n")
-        script = PDVScript(relative_path=str(script_file))
+        tree_with_comm._set_working_dir(str(tmp_path))
+        script = PDVScript(uuid=node_uuid, filename="no_run.py")
         with pytest.raises(PDVScriptError):
             script.run(tree_with_comm)
 
     def test_preview(self, tmp_path):
         """preview() returns the first line of the script docstring."""
         script = PDVScript(
-            relative_path="scripts/test.py", doc="My script does stuff\nmore details"
+            uuid="abc123def460", filename="test.py", doc="My script does stuff\nmore details"
         )
         assert script.preview() == "My script does stuff"
 
     def test_run_script_via_tree(self, tree_with_comm, tmp_path):
         """pdv_tree.run_script('path') works end-to-end."""
-        script_file = tmp_path / "myrun.py"
+        node_uuid = "abc123def461"
+        script_dir = tmp_path / "tree" / node_uuid
+        script_dir.mkdir(parents=True)
+        script_file = script_dir / "myrun.py"
         script_file.write_text("def run(tree, **kwargs):\n    return 100\n")
-        tree_with_comm["s"] = PDVScript(relative_path=str(script_file))
+        tree_with_comm._set_working_dir(str(tmp_path))
+        tree_with_comm["s"] = PDVScript(uuid=node_uuid, filename="myrun.py")
         result = tree_with_comm.run_script("s")
         assert result == 100
 

--- a/pdv-python/tests/test_tree.py
+++ b/pdv-python/tests/test_tree.py
@@ -125,6 +125,55 @@ class TestChangeNotification:
         _, payload = mock_send.call_args[0]
         assert payload["changed_paths"] == ["x"]
 
+    def test_set_emits_for_newly_created_intermediates(
+        self, tree_with_comm, mock_send
+    ):
+        """Setting a deep path on an empty tree emits for each new ancestor.
+
+        Renderers use changed_paths to decide which subtree to re-fetch.
+        Without per-intermediate events, the parent of a deep leaf may not
+        yet exist in the renderer's view, so nothing refreshes. See the
+        Tree component in the Electron renderer.
+        """
+        tree_with_comm["imports.mesh"] = 1
+        tree_with_comm._flush_changes()
+        _, payload = mock_send.call_args[0]
+        assert set(payload["changed_paths"]) == {"imports", "imports.mesh"}
+
+    def test_set_does_not_emit_for_existing_intermediates(
+        self, tree_with_comm, mock_send
+    ):
+        """If all intermediates already exist as dicts, no extra events fire."""
+        tree_with_comm["imports.other"] = 1
+        tree_with_comm._flush_changes()
+        mock_send.reset_mock()
+        tree_with_comm["imports.mesh"] = 2
+        tree_with_comm._flush_changes()
+        _, payload = mock_send.call_args[0]
+        assert payload["changed_paths"] == ["imports.mesh"]
+
+    def test_set_emits_for_all_newly_created_deep_ancestors(
+        self, tree_with_comm, mock_send
+    ):
+        """A three-level new path emits for each intermediate ancestor."""
+        tree_with_comm["a.b.c"] = 1
+        tree_with_comm._flush_changes()
+        _, payload = mock_send.call_args[0]
+        assert set(payload["changed_paths"]) == {"a", "a.b", "a.b.c"}
+
+    def test_set_replacing_non_dict_intermediate_emits_for_that_ancestor(
+        self, tree_with_comm, mock_send
+    ):
+        """When set_quiet replaces a non-dict intermediate with a PDVTree,
+        that ancestor counts as newly created for renderer purposes."""
+        tree_with_comm["imports"] = 5  # leaf, not a dict
+        tree_with_comm._flush_changes()
+        mock_send.reset_mock()
+        tree_with_comm["imports.mesh"] = "v"
+        tree_with_comm._flush_changes()
+        _, payload = mock_send.call_args[0]
+        assert set(payload["changed_paths"]) == {"imports", "imports.mesh"}
+
 
 class TestMutatingDictMethods:
     """Tests for dict methods that must emit change notifications."""

--- a/pdv-python/tests/test_tree_handlers.py
+++ b/pdv-python/tests/test_tree_handlers.py
@@ -112,104 +112,93 @@ class TestDuplicate:
 
 
 class TestRelocateFiles:
-    """Tests for _relocate_files and _relocate_single_file."""
+    """Tests for _relocate_files and _relocate_single_file.
 
-    def test_relocate_single_file_moves(self, tmp_working_dir):
+    With UUID-based storage, rename/move is a no-op (the file path is
+    independent of the tree path). Only copy=True (duplicate) needs
+    to create a new file with a fresh UUID.
+    """
+
+    def test_relocate_single_file_noop_on_rename(self, tmp_working_dir):
+        """Rename (copy=False) is a no-op with UUID storage."""
         from pdv.handlers.tree import _relocate_single_file
 
-        tree_dir = os.path.join(tmp_working_dir, "tree")
+        node_uuid = "reloc_uuid01"
+        tree_dir = os.path.join(tmp_working_dir, "tree", node_uuid)
         os.makedirs(tree_dir)
         old_path = os.path.join(tree_dir, "old_script.py")
         with open(old_path, "w") as f:
             f.write("# test")
 
-        script = PDVScript(relative_path="tree/old_script.py")
-        _relocate_single_file(script, "new_script", tmp_working_dir, copy=False)
+        script = PDVScript(uuid=node_uuid, filename="old_script.py")
+        _relocate_single_file(script, tmp_working_dir, copy=False)
 
-        assert script.relative_path == os.path.join("tree", "new_script.py")
-        new_abs = os.path.join(tmp_working_dir, "tree", "new_script.py")
-        assert os.path.exists(new_abs)
-        assert not os.path.exists(old_path)
+        # UUID should be unchanged since it's a rename (no-op)
+        assert script.uuid == node_uuid
+        assert os.path.exists(old_path)
 
     def test_relocate_single_file_copies(self, tmp_working_dir):
+        """Duplicate (copy=True) assigns a new UUID and copies the file."""
         from pdv.handlers.tree import _relocate_single_file
 
-        tree_dir = os.path.join(tmp_working_dir, "tree")
+        node_uuid = "reloc_uuid02"
+        tree_dir = os.path.join(tmp_working_dir, "tree", node_uuid)
         os.makedirs(tree_dir)
         old_path = os.path.join(tree_dir, "src.py")
         with open(old_path, "w") as f:
             f.write("# test")
 
-        script = PDVScript(relative_path="tree/src.py")
-        _relocate_single_file(script, "dst", tmp_working_dir, copy=True)
+        script = PDVScript(uuid=node_uuid, filename="src.py")
+        _relocate_single_file(script, tmp_working_dir, copy=True)
 
+        # Original file still exists
         assert os.path.exists(old_path)
-        new_abs = os.path.join(tmp_working_dir, "tree", "dst.py")
-        assert os.path.exists(new_abs)
+        # Script should have a new UUID
+        assert script.uuid != node_uuid
+        # New file should exist at the new UUID location
+        new_path = script.resolve_path(tmp_working_dir)
+        assert os.path.exists(new_path)
 
-    def test_relocate_with_filename_override(self, tmp_working_dir):
+    def test_relocate_rejects_non_pdvfile(self):
         from pdv.handlers.tree import _relocate_single_file
+        with pytest.raises(TypeError, match="Expected PDVFile"):
+            _relocate_single_file("not_a_file", "/tmp", copy=False)
 
-        tree_dir = os.path.join(tmp_working_dir, "tree")
-        os.makedirs(tree_dir)
-        old_path = os.path.join(tree_dir, "old.py")
-        with open(old_path, "w") as f:
-            f.write("# test")
-
-        script = PDVScript(relative_path="tree/old.py")
-        _relocate_single_file(script, "new_key", tmp_working_dir,
-                              copy=False, filename="custom_name.py")
-
-        assert script.relative_path == os.path.join("tree", "custom_name.py")
-
-    def test_relocate_files_recursive(self, tmp_working_dir):
+    def test_relocate_files_recursive_copy(self, tmp_working_dir):
+        """Recursive duplicate assigns fresh UUIDs to file-backed descendants."""
         from pdv.handlers.tree import _relocate_files
 
-        tree_dir = os.path.join(tmp_working_dir, "tree", "parent")
+        node_uuid = "reloc_uuid03"
+        tree_dir = os.path.join(tmp_working_dir, "tree", node_uuid)
         os.makedirs(tree_dir)
         script_path = os.path.join(tree_dir, "my_script.py")
         with open(script_path, "w") as f:
             f.write("# test")
 
         container = PDVTree()
-        script = PDVScript(relative_path=os.path.join("tree", "parent", "my_script.py"))
+        script = PDVScript(uuid=node_uuid, filename="my_script.py")
         dict.__setitem__(container, "my_script", script)
 
-        _relocate_files(container, "parent", "new_parent", tmp_working_dir, copy=False)
-        assert script.relative_path == os.path.join("tree", "new_parent", "my_script.py")
+        _relocate_files(container, "parent", "new_parent", tmp_working_dir, copy=True)
+        # Script should have a new UUID after copy
+        assert script.uuid != node_uuid
+        new_path = script.resolve_path(tmp_working_dir)
+        assert os.path.exists(new_path)
 
-    def test_relocate_rejects_non_pdvfile(self):
-        from pdv.handlers.tree import _relocate_single_file
-        with pytest.raises(TypeError, match="Expected PDVFile"):
-            _relocate_single_file("not_a_file", "path", "/tmp", copy=False)
-
-    def test_rename_relocates_backing_file(self, tmp_working_dir):
-        """Rename of a file-backed node should update its _relative_path."""
-        from pdv.handlers.tree import _relocate_files
-
-        tree_dir = os.path.join(tmp_working_dir, "tree")
-        os.makedirs(tree_dir)
-        old_file = os.path.join(tree_dir, "old_name.py")
-        with open(old_file, "w") as f:
-            f.write("# script")
-
-        script = PDVScript(relative_path="tree/old_name.py")
-        _relocate_files(script, "old_name", "new_name", tmp_working_dir, copy=False)
-
-        assert script.relative_path == os.path.join("tree", "new_name.py")
-        assert os.path.exists(os.path.join(tmp_working_dir, "tree", "new_name.py"))
-        assert not os.path.exists(old_file)
-
-    def test_note_relocation(self, tmp_working_dir):
+    def test_note_relocation_copy(self, tmp_working_dir):
+        """Duplicate of a note creates a fresh UUID."""
         from pdv.handlers.tree import _relocate_single_file
 
-        tree_dir = os.path.join(tmp_working_dir, "tree")
+        node_uuid = "reloc_uuid04"
+        tree_dir = os.path.join(tmp_working_dir, "tree", node_uuid)
         os.makedirs(tree_dir)
         note_path = os.path.join(tree_dir, "my_note.md")
         with open(note_path, "w") as f:
             f.write("# Note")
 
-        note = PDVNote(relative_path="tree/my_note.md")
-        _relocate_single_file(note, "renamed_note", tmp_working_dir, copy=False)
+        note = PDVNote(uuid=node_uuid, filename="my_note.md")
+        _relocate_single_file(note, tmp_working_dir, copy=True)
 
-        assert note.relative_path == os.path.join("tree", "renamed_note.md")
+        assert note.uuid != node_uuid
+        new_path = note.resolve_path(tmp_working_dir)
+        assert os.path.exists(new_path)


### PR DESCRIPTION
Here's a PR summary:

---

## UUID-based file storage and Python-initiated save/load

### Summary

- **UUID-based file storage**: Every file-backed tree node (`PDVScript`, `PDVLib`, `PDVGui`, `PDVNote`, `PDVNamelist`) now gets a 12-hex UUID and stores its backing file at `<workdir>/tree/<uuid>/<filename>`. Tree paths are fully decoupled from the filesystem — renames, moves, and restructures no longer require file copies or renames.
- **Python-initiated save/load**: New `pdv.save_project()`, `pdv.save_project_as()`, `pdv.open_project()`, and `pdv.add_file()` APIs let users save, load, and import files directly from the console or scripts without going through the GUI.
- **Save deadlock fix**: Python-initiated saves serialize the tree synchronously on the kernel side and push results to the main process, avoiding the comm round-trip that would deadlock while the shell is busy executing user code.
- **Orphan cleanup**: `_purge_orphaned_tree_files` removes UUID directories in the save dir that no longer correspond to any live tree node, preventing stale files from accumulating across save cycles.
- **`resolveNodePath` / `resolveNodeDir` helpers**: Centralized TS-side path resolution mirroring `PDVFile.resolve_path()` on the Python side. All hardcoded `path.join(workingDir, "tree", ...)` calls replaced.
- **Removed legacy code**: `working_dir_tree_path()`, alias-based module scaffolding, stale `PDVScriptRegisterPayload` interface, and dead `_relocate_files` parameter all removed.

### Version

`0.0.12` (both `electron/package.json` and `pdv-python/pyproject.toml`)

### Tests

- **Python**: 355 passed, 2 skipped
- **TypeScript**: 307 passed

### Notable changes by area

| Area                                    | What changed                                                                                                                          |
| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
| `pdv-python/pdv/tree.py`                | `PDVFile` base class with UUID, filename, `resolve_path()`. All file-backed node types inherit it.                                    |
| `pdv-python/pdv/namespace.py`           | `PDVApp` gains `save_project`, `save_project_as`, `open_project`, `add_file` methods                                                  |
| `pdv-python/pdv/handlers/project.py`    | Synchronous `serialize_tree_to_dir`, `_early_module_setup` for lib sys.path wiring during load, orphan purge                          |
| `pdv-python/pdv/handlers/modules.py`    | `handle_module_reload_libs` rewritten to walk `PDVLib` nodes via `_iter_pdv_libs` + `resolve_path()` instead of hardcoded alias paths |
| `pdv-python/pdv/environment.py`         | `uuid_tree_path()`, `smart_copy()`, `generate_node_uuid()`. Legacy `working_dir_tree_path()` removed                                  |
| `electron/main/pdv-protocol.ts`         | `resolveNodePath()`, `resolveNodeDir()` helpers                                                                                       |
| `electron/main/project-manager.ts`      | Cached kernel results for deadlock-free Python-initiated saves, `clearCachedKernelResults()` on kernel stop                           |
| `electron/main/ipc-register-project.ts` | `save_completed` push handler, save sequencing via chained promises                                                                   |
| `electron/main/project-file-sync.ts`    | Load/save file copy uses `resolveNodePath`                                                                                            |
| `ARCHITECTURE.md`                       | §6.3 documents the UUID storage design                                                                                                |