### PR TITLE
chore: remove unused Config.editors field

### DIFF
--- a/electron/renderer/src/app/useKernelLifecycle.ts
+++ b/electron/renderer/src/app/useKernelLifecycle.ts
@@ -125,7 +125,6 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
       recentProjects: config?.recentProjects ?? [],
       pythonPath: paths.pythonPath ?? config?.pythonPath,
       juliaPath: paths.juliaPath ?? config?.juliaPath,
-      editors: config?.editors,
       treeRoot: config?.treeRoot,
       settings: config?.settings,
     };

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -255,8 +255,6 @@ export interface Config {
   pythonPath?: string;
   /** Julia executable configured by user. */
   juliaPath?: string;
-  /** External editor command map. See #206 for cleanup tracking. */
-  editors?: Record<string, string>;
   /** Project root path (when persisted). */
   projectRoot?: string;
   /** Tree root path (when persisted). */


### PR DESCRIPTION
## Summary
- The `editors` field on `Config` was declared in `types/pdv.d.ts` and passed through `handleEnvSave` in `useKernelLifecycle.ts`, but no main-process or kernel code reads or writes it. Removed both references.
- Closes #206.

## Test plan
- [x] `npx tsc --noEmit` passes in `electron/`
- [x] Smoke: env save still persists `pythonPath`/`juliaPath` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)