### PR TITLE
feat(StatusBar): show kernel RSS and update-available badge

### DIFF
--- a/electron/main/ipc-register-kernels.ts
+++ b/electron/main/ipc-register-kernels.ts
@@ -109,6 +109,18 @@ export function registerKernelIpcHandlers(
     await setupProjectModuleNamespaces(commRouter, moduleManager, getActiveProjectDir());
   }
 
+  // Forward periodic kernel-memory snapshots to the renderer. Registered once
+  // for this window/manager pair (the payload carries `kernelId` so a single
+  // listener serves any number of kernels).
+  kernelManager.on("kernel:memoryRss", (kernelId: string, rssBytes: number) => {
+    if (win.isDestroyed()) return;
+    win.webContents.send(IPC.push.kernelMemory, {
+      kernelId,
+      rssBytes,
+      timestamp: Date.now(),
+    });
+  });
+
   // Serialize kernel start/restart so concurrent calls cannot race on
   // the shared commRouter (which causes "CommRouter detached" rejections).
   let startMutex: Promise<unknown> = Promise.resolve();

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -210,6 +210,12 @@ export const IPC = {
      */
     kernelCrashed: "pdv.kernel.crashed",
     kernelReconnected: "pdv.kernel.reconnected",
+    /**
+     * Periodic kernel-process memory snapshot. Emitted by the main process
+     * (no corresponding wire message) at ~1 Hz while the kernel is running.
+     * Sourced from an OS-level RSS read against the kernel subprocess PID.
+     */
+    kernelMemory: "pdv.kernel.memory",
     menuAction: "menu:action",
     chromeStateChanged: "chrome:stateChanged",
     executeOutput: "pdv.execute.output",
@@ -1305,6 +1311,18 @@ export type TreeChangedPayload = PDVTreeChangedPayload;
 export type ProjectLoadedPayload = PDVProjectLoadedPayload;
 
 /**
+ * Payload delivered on `IPC.push.kernelMemory`.
+ */
+export interface KernelMemoryPayload {
+  /** Kernel ID the snapshot belongs to. */
+  kernelId: string;
+  /** Resident-set-size of the kernel subprocess, in bytes. */
+  rssBytes: number;
+  /** Wall-clock timestamp (ms since epoch) when the snapshot was taken. */
+  timestamp: number;
+}
+
+/**
  * Result returned from `project.save()`.
  */
 export interface ProjectSaveResult {
@@ -1484,6 +1502,14 @@ export interface PDVApi {
      * @returns Unsubscribe function.
      */
     onReconnected(callback: (payload: { kernelId: string }) => void): () => void;
+    /**
+     * Subscribe to periodic kernel-memory snapshots. Fires at ~1 Hz while the
+     * kernel subprocess is running.
+     *
+     * @param callback - Invoked with each memory snapshot.
+     * @returns Unsubscribe function.
+     */
+    onMemory(callback: (payload: KernelMemoryPayload) => void): () => void;
   };
 
   /** Tree browsing and updates. */

--- a/electron/main/kernel-manager.ts
+++ b/electron/main/kernel-manager.ts
@@ -31,6 +31,7 @@ import { spawn, ChildProcess } from "child_process";
 import { EventEmitter } from "events";
 import type { KernelCompleteResult, KernelInspectResult } from "./ipc";
 import { buildExecutionError, type KernelExecutionLocation } from "./kernel-error-parser";
+import { getProcessRssBytes } from "./process-stats";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -201,6 +202,8 @@ interface ManagedKernel {
   shellQueue: Promise<void>;
   /** Latest execution_state from iopub status messages. */
   executionState: "idle" | "busy";
+  /** Interval handle for the periodic kernel-memory poll, or undefined if not started. */
+  memoryPollHandle?: NodeJS.Timeout;
 }
 
 // ---------------------------------------------------------------------------
@@ -536,6 +539,10 @@ export class KernelManager extends EventEmitter {
     // shutdownAll() will call stop() and do the cleanup.
     kernelProcess.on("exit", () => {
       managed.info.status = "dead";
+      if (managed.memoryPollHandle !== undefined) {
+        clearInterval(managed.memoryPollHandle);
+        managed.memoryPollHandle = undefined;
+      }
       if (!managed.shuttingDown) {
         this.emit("kernel:crashed", kernelId);
       }
@@ -545,6 +552,22 @@ export class KernelManager extends EventEmitter {
     await this.waitForKernelReady(managed);
 
     kernelInfo.status = "idle";
+
+    // Begin polling the kernel subprocess RSS at ~1 Hz. The first sample is
+    // emitted immediately so the UI doesn't show a blank "RAM: --" for a
+    // second after the kernel comes up.
+    const pid = managed.process.pid;
+    if (pid !== undefined) {
+      const sample = async (): Promise<void> => {
+        const rssBytes = await getProcessRssBytes(pid);
+        if (rssBytes !== null && this.kernels.has(kernelId)) {
+          this.emit("kernel:memoryRss", kernelId, rssBytes);
+        }
+      };
+      void sample();
+      managed.memoryPollHandle = setInterval(() => { void sample(); }, 1000);
+    }
+
     return { ...kernelInfo };
   }
 
@@ -562,6 +585,12 @@ export class KernelManager extends EventEmitter {
 
     // Signal the iopub loop to exit (it polls this flag every 100 ms).
     managed.shuttingDown = true;
+
+    // Stop the memory poll interval — we're tearing down the kernel.
+    if (managed.memoryPollHandle !== undefined) {
+      clearInterval(managed.memoryPollHandle);
+      managed.memoryPollHandle = undefined;
+    }
 
     // Attempt a graceful JMP shutdown.
     try {

--- a/electron/main/process-stats.ts
+++ b/electron/main/process-stats.ts
@@ -1,0 +1,69 @@
+/**
+ * process-stats.ts — Cross-platform process memory lookup.
+ *
+ * Provides resident-set-size (RSS) reads for an arbitrary OS process by PID.
+ * Used by kernel-manager to surface live Python kernel memory usage in the
+ * status bar without requiring kernel-side cooperation (no comm round-trip,
+ * no psutil dependency).
+ *
+ * Strategy:
+ * - darwin / linux: shell out to `ps -o rss= -p <pid>` (RSS in KB)
+ * - win32: shell out to `tasklist /FI "PID eq <pid>" /NH /FO CSV`
+ *
+ * All failures (process gone, parse error, unsupported platform) resolve to
+ * `null` so callers can degrade gracefully — the UI hides the indicator
+ * instead of surfacing a noisy error.
+ *
+ * This file does NOT cache results, schedule polling, or maintain state;
+ * scheduling is the caller's responsibility (see kernel-manager.ts).
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Read the resident-set-size (RSS) of a process by PID, in bytes.
+ *
+ * @param pid - Operating-system process id to query.
+ * @returns RSS in bytes, or `null` if the process cannot be queried (does not
+ *   exist, command fails, output cannot be parsed, or platform is unsupported).
+ * @throws Never — all errors are absorbed and returned as `null`.
+ */
+export async function getProcessRssBytes(pid: number): Promise<number | null> {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+
+  try {
+    if (process.platform === "darwin" || process.platform === "linux") {
+      const { stdout } = await execFileAsync("ps", ["-o", "rss=", "-p", String(pid)], {
+        timeout: 2000,
+      });
+      const kb = parseInt(stdout.trim(), 10);
+      if (!Number.isFinite(kb) || kb <= 0) return null;
+      return kb * 1024;
+    }
+
+    if (process.platform === "win32") {
+      const { stdout } = await execFileAsync(
+        "tasklist",
+        ["/FI", `PID eq ${pid}`, "/NH", "/FO", "CSV"],
+        { timeout: 2000 },
+      );
+      // CSV columns: "Image","PID","Session","Session#","Mem Usage"
+      // Mem Usage example: "123,456 K"
+      const line = stdout.trim().split(/\r?\n/)[0];
+      if (!line) return null;
+      const cols = line.split(/","|^"|"$/).filter((s) => s.length > 0);
+      const mem = cols[cols.length - 1];
+      if (!mem) return null;
+      const kb = parseInt(mem.replace(/[^0-9]/g, ""), 10);
+      if (!Number.isFinite(kb) || kb <= 0) return null;
+      return kb * 1024;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -55,6 +55,7 @@ const api: PDVApi = {
     onOutput: (callback) => onPush(IPC.push.executeOutput, callback),
     onKernelCrashed: (callback) => onPush(IPC.push.kernelCrashed, callback),
     onReconnected: (callback) => onPush(IPC.push.kernelReconnected, callback),
+    onMemory: (callback) => onPush(IPC.push.kernelMemory, callback),
   },
   tree: {
     list: (kernelId, nodePath = "") =>

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -115,6 +115,10 @@ const App: React.FC = () => {
   const [savedPdvVersion, setSavedPdvVersion] = useState<string | null>(null);
   const [runningPdvVersion, setRunningPdvVersion] = useState<string | null>(null);
   const [interpreterWarning, setInterpreterWarning] = useState<string | null>(null);
+  /** Latest RSS in bytes for the active kernel subprocess, or null when unknown. */
+  const [kernelMemoryRss, setKernelMemoryRss] = useState<number | null>(null);
+  /** Latest auto-update status pushed by the main process. */
+  const [updateStatus, setUpdateStatus] = useState<import('../types/pdv').UpdateStatus | null>(null);
 
   // -- App / config state ---------------------------------------------------
   const [config, setConfig] = useState<Config | null>(null);
@@ -310,6 +314,16 @@ const App: React.FC = () => {
     void window.pdv.menu.updateRecentProjects(recentProjects);
   }, [config]);
 
+  // Surface auto-update state in the status bar. Seed from the cached value in
+  // case a check completed before the App mounted, then subscribe for live
+  // transitions.
+  useEffect(() => {
+    void window.pdv.updater.getStatus().then((status) => {
+      if (status) setUpdateStatus(status);
+    });
+    return window.pdv.updater.onUpdateStatus(setUpdateStatus);
+  }, []);
+
   // Listen for File-menu actions handled at the App level.
   // project:open and project:openRecent are dispatched via refs so this effect
   // doesn't re-subscribe on every kernelStatus change (handlers defined later).
@@ -418,6 +432,7 @@ const App: React.FC = () => {
     setProgress,
     onKernelCrash: handleKernelCrash,
     onTreeChanged: handleTreeChanged,
+    setKernelMemoryRss,
   });
 
   const { startKernel, handleEnvSave } = useKernelLifecycle({
@@ -1648,6 +1663,9 @@ const App: React.FC = () => {
           savedPdvVersion={savedPdvVersion}
           runningPdvVersion={runningPdvVersion}
           lastAutosaveAt={lastAutosaveAt}
+          kernelMemoryRss={kernelMemoryRss}
+          updateStatus={updateStatus}
+          onUpdateClick={() => { setSettingsInitialTab('about'); setShowSettings(true); }}
         />
 
        <ImportModuleDialog

--- a/electron/renderer/src/app/useKernelSubscriptions.ts
+++ b/electron/renderer/src/app/useKernelSubscriptions.ts
@@ -26,6 +26,8 @@ interface UseKernelSubscriptionsOptions {
   onKernelCrash: (kernelId: string) => void;
   /** Called on incremental tree changes so the Tree can update selectively. */
   onTreeChanged: (info: TreeChangeInfo) => void;
+  /** Setter for the latest kernel-process RSS in bytes (null when unknown). */
+  setKernelMemoryRss: Dispatch<SetStateAction<number | null>>;
 }
 
 export function useKernelSubscriptions({
@@ -40,6 +42,7 @@ export function useKernelSubscriptions({
   setProgress,
   onKernelCrash,
   onTreeChanged,
+  setKernelMemoryRss,
 }: UseKernelSubscriptionsOptions): void {
   useEffect(() => {
     const unsubscribe = window.pdv.kernels.onOutput((chunk) => {
@@ -127,6 +130,11 @@ export function useKernelSubscriptions({
       setModulesRefreshToken((prev) => prev + 1);
     });
 
+    const unsubscribeMemory = window.pdv.kernels.onMemory((payload) => {
+      if (payload.kernelId !== currentKernelId) return;
+      setKernelMemoryRss(payload.rssBytes);
+    });
+
     return () => {
       unsubscribeTree();
       unsubscribeProject();
@@ -134,6 +142,9 @@ export function useKernelSubscriptions({
       unsubscribeProgress();
       unsubscribeReloading();
       unsubscribeReconnected();
+      unsubscribeMemory();
+      // Clear the readout so a fresh kernel doesn't briefly show stale memory.
+      setKernelMemoryRss(null);
     };
   }, [
     currentKernelId,
@@ -146,5 +157,6 @@ export function useKernelSubscriptions({
     setProjectReloading,
     setTreeRefreshToken,
     onTreeChanged,
+    setKernelMemoryRss,
   ]);
 }

--- a/electron/renderer/src/components/StatusBar/index.tsx
+++ b/electron/renderer/src/components/StatusBar/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import type { ProgressPayload } from '../../types/pdv';
+import type { ProgressPayload, UpdateStatus } from '../../types/pdv';
 
 interface StatusBarProps {
   isExecuting: boolean;
@@ -25,6 +25,12 @@ interface StatusBarProps {
   runningPdvVersion: string | null;
   /** Timestamp (ms) of the most recent successful autosave, or null if none yet. */
   lastAutosaveAt: number | null;
+  /** Resident-set-size of the active kernel subprocess, in bytes. Hidden when null. */
+  kernelMemoryRss: number | null;
+  /** Latest auto-update status. Status-bar badge shown when state is `available` or `downloaded`. */
+  updateStatus: UpdateStatus | null;
+  /** Click handler for the update-available badge — typically opens Settings → About. */
+  onUpdateClick: () => void;
 }
 
 /** Format a timestamp as HH:MM:SS in the user's locale. */
@@ -32,6 +38,13 @@ function formatTimeOfDay(ms: number): string {
   const d = new Date(ms);
   const pad = (n: number): string => n.toString().padStart(2, '0');
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/** Format a byte count for status-bar display: "245 MB" or "1.4 GB" (1 decimal ≥1 GB). */
+function formatBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  if (mb < 1024) return `${Math.round(mb)} MB`;
+  return `${(mb / 1024).toFixed(1)} GB`;
 }
 
 /** Application status bar at the bottom of the window. */
@@ -51,7 +64,12 @@ export const StatusBar: React.FC<StatusBarProps> = ({
   savedPdvVersion,
   runningPdvVersion,
   lastAutosaveAt,
+  kernelMemoryRss,
+  updateStatus,
+  onUpdateClick,
 }) => {
+  const showUpdateBadge =
+    updateStatus?.state === 'available' || updateStatus?.state === 'downloaded';
   const runtimeLabel = activeLanguage === 'julia'
     ? (juliaPath ?? 'julia')
     : (pythonPath ?? kernelSpec ?? 'python3');
@@ -67,6 +85,21 @@ export const StatusBar: React.FC<StatusBarProps> = ({
       )}
       <div className="status-left">
         <span className="status-item">{currentProjectDir ?? 'Unsaved Project'}</span>
+        {showUpdateBadge && updateStatus && (
+          <span
+            className="status-item status-warning status-clickable"
+            onClick={onUpdateClick}
+            title={
+              updateStatus.state === 'downloaded'
+                ? `v${updateStatus.version ?? '?'} ready — restart to install`
+                : `v${updateStatus.version ?? '?'} available`
+            }
+          >
+            ⬆ {updateStatus.state === 'downloaded'
+              ? `Update ready: v${updateStatus.version ?? '?'}`
+              : `Update available: v${updateStatus.version ?? '?'}`}
+          </span>
+        )}
         {savedPdvVersion && runningPdvVersion && savedPdvVersion !== runningPdvVersion && (
           <span
             className="status-item status-warning"
@@ -100,6 +133,14 @@ export const StatusBar: React.FC<StatusBarProps> = ({
         >
           {runtimeLabel}
         </span>
+        {kernelMemoryRss !== null && (
+          <span
+            className="status-item"
+            title="Resident memory used by the kernel subprocess"
+          >
+            RAM: {formatBytes(kernelMemoryRss)}
+          </span>
+        )}
         <span className="status-item">
           {progress ? (
             <>

--- a/electron/renderer/src/test-fixtures/pdv-mock.ts
+++ b/electron/renderer/src/test-fixtures/pdv-mock.ts
@@ -52,6 +52,7 @@ function buildBase() {
       onOutput: subStub<PDVApi["kernels"]["onOutput"]>(),
       onKernelCrashed: subStub<PDVApi["kernels"]["onKernelCrashed"]>(),
       onReconnected: subStub<PDVApi["kernels"]["onReconnected"]>(),
+      onMemory: subStub<PDVApi["kernels"]["onMemory"]>(),
     },
     tree: {
       list: stub<PDVApi["tree"]["list"]>(async () => []),

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -31,6 +31,9 @@ export type { ScriptParameter } from '../../../main/ipc';
 /** Tree node descriptor returned by `pdv.tree.list`. Canonical: `pdv-protocol.ts`. */
 export type { NodeDescriptor } from '../../../main/ipc';
 
+/** Periodic kernel-memory snapshot pushed on `IPC.push.kernelMemory`. */
+export type { KernelMemoryPayload } from '../../../main/ipc';
+
 /** Runtime kernel descriptor returned by `kernels.start/list/restart`. */
 export interface KernelInfo {
   /** Opaque kernel id used in subsequent API calls. */
@@ -692,6 +695,7 @@ export interface PDVApi {
     onOutput(callback: (chunk: ExecuteOutputChunk) => void): () => void;
     onKernelCrashed(callback: (payload: { kernelId: string }) => void): () => void;
     onReconnected(callback: (payload: { kernelId: string }) => void): () => void;
+    onMemory(callback: (payload: KernelMemoryPayload) => void): () => void;
   };
   tree: {
     list(kernelId: string, path?: string): Promise<NodeDescriptor[]>;


### PR DESCRIPTION
Adds a 1 Hz kernel-process memory readout on the right side of the status bar (sourced from a no-dep `ps` / `tasklist` shell-out against the kernel PID) and a clickable update-available badge on the left when the existing auto-updater reports state `available` or `downloaded`.