### PR TITLE
fix(kernel): harden bootstrap handshake and add startup diagnostics (#222)

### DIFF
--- a/electron/e2e/kernel-handshake-failure.spec.ts
+++ b/electron/e2e/kernel-handshake-failure.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * kernel-handshake-failure.spec.ts — Drives the cold-start failure path.
+ *
+ * Regression test for #222: when the kernel-side bootstrap raises, the user
+ * should see a multi-line diagnostic (step name, process state, kernel
+ * status, last iopub msg_type) in the env-settings dialog instead of a
+ * black-box "Kernel failed to start" message.
+ *
+ * Mechanism: prepend a temp dir to PYTHONPATH that contains a fake `pdv`
+ * package whose `bootstrap()` raises. Both the env-check probe and the
+ * spawned kernel subprocess inherit PYTHONPATH from Electron's process.env,
+ * so the fake shadows the real package without touching the user's
+ * site-packages.
+ */
+
+import { test, expect } from "@playwright/test";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { launchPDV, type LaunchedApp } from "./helpers/launch";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const electronPackage = require("../package.json") as { version: string };
+
+const FORCED_FAILURE_MARKER = "forced E2E failure for diagnostic test";
+
+let launched: LaunchedApp;
+let shimDir: string;
+
+test.beforeAll(async () => {
+  shimDir = await fs.mkdtemp(path.join(os.tmpdir(), "pdv-e2e-pdv-shim-"));
+  const pkgDir = path.join(shimDir, "pdv");
+  await fs.mkdir(pkgDir, { recursive: true });
+
+  // The fake must satisfy the bootstrap code in kernel-session.ts:
+  //   import pdv;  from pdv import PDVTree;  import pdv.comms as _pdv_comms;
+  //   pdv.bootstrap(_ip)  ← raises here
+  // …and the env-check probe (`python -c "import pdv; print(pdv.__version__)"`),
+  // which requires `__version__` to match the running app version exactly
+  // (during 0.x). PDVTree just needs to be importable; comms.py is never
+  // touched after bootstrap throws.
+  await fs.writeFile(
+    path.join(pkgDir, "__init__.py"),
+    [
+      `__version__ = ${JSON.stringify(electronPackage.version)}`,
+      "",
+      "class PDVTree(dict):",
+      "    pass",
+      "",
+      "def bootstrap(ip=None):",
+      `    raise RuntimeError(${JSON.stringify(FORCED_FAILURE_MARKER)})`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(path.join(pkgDir, "comms.py"), "", "utf8");
+
+  const existingPyPath = process.env.PYTHONPATH;
+  const pythonPath = existingPyPath
+    ? `${shimDir}${path.delimiter}${existingPyPath}`
+    : shimDir;
+
+  launched = await launchPDV({
+    env: { PYTHONPATH: pythonPath },
+  });
+});
+
+test.afterAll(async () => {
+  await launched?.cleanup();
+  if (shimDir) {
+    await fs.rm(shimDir, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap failure surfaces the multi-line diagnostic in the env-settings dialog", async () => {
+  const { window } = launched;
+  await window.getByRole("button", { name: "New Python Project" }).click();
+
+  // The handshake should fail at the bootstrap step. The renderer routes the
+  // failure to openEnvSettings(lastErrorRef.current ?? 'Kernel failed to start.'),
+  // so the diagnostic should land in the EnvironmentSelector's `.error-text`
+  // warning slot (rendered with white-space: pre-wrap so the lines stay split).
+  const warning = window.locator("p.error-text").filter({
+    hasText: /Kernel handshake failed at step/,
+  });
+  await expect(warning).toBeVisible({ timeout: 30_000 });
+
+  const text = await warning.textContent();
+  expect(text).toBeTruthy();
+
+  // Header line: step name + the original RuntimeError message.
+  expect(text!).toMatch(/Kernel handshake failed at step '(bootstrap|ready|init)':/);
+  expect(text!).toContain(FORCED_FAILURE_MARKER);
+
+  // Diagnostic body — three labeled fields.
+  expect(text!).toMatch(/process: exitCode=\S+ killed=(true|false)/);
+  expect(text!).toMatch(/kernel status: \S+/);
+  expect(text!).toMatch(/last iopub msg_type: \S+/);
+});

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -274,6 +274,8 @@ function setup() {
     ping: vi.fn(async () => undefined),
     getKernel: vi.fn(() => makeKernelInfo()),
     getQueryPort: vi.fn(() => 12345),
+    getKernelProcessState: vi.fn(() => ({ exitCode: null, killed: false })),
+    onIopubMessage: vi.fn(() => () => undefined),
     shutdownAll: vi.fn(async () => undefined),
     on: vi.fn(),
     removeListener: vi.fn(),

--- a/electron/main/kernel-manager.ts
+++ b/electron/main/kernel-manager.ts
@@ -952,6 +952,23 @@ export class KernelManager extends EventEmitter {
   }
 
   /**
+   * Return the OS process state for a kernel — used to enrich diagnostics
+   * when a handshake or execute fails.
+   *
+   * @param id - Kernel ID.
+   * @returns `{ exitCode, killed }` (both as the `child_process` reports them),
+   *   or undefined if the kernel is not found.
+   */
+  getKernelProcessState(id: string): { exitCode: number | null; killed: boolean } | undefined {
+    const managed = this.kernels.get(id);
+    if (!managed) return undefined;
+    return {
+      exitCode: managed.process.exitCode,
+      killed: managed.process.killed,
+    };
+  }
+
+  /**
    * Gracefully shut down every running kernel.
    */
   async shutdownAll(): Promise<void> {

--- a/electron/main/kernel-session.test.ts
+++ b/electron/main/kernel-session.test.ts
@@ -1,0 +1,143 @@
+/**
+ * kernel-session.test.ts — Unit tests for the bootstrap/init handshake
+ * helpers in `kernel-session.ts`. Focused on the failure-path diagnostic
+ * format so a black-box "Kernel failed to start" can be replaced with an
+ * actionable message.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { initializeKernelSession } from "./kernel-session";
+import type { KernelManager, KernelExecuteResult } from "./kernel-manager";
+import type { CommRouter } from "./comm-router";
+import type { QueryRouter } from "./query-router";
+import type { ProjectManager } from "./project-manager";
+
+interface FakeKernelManager {
+  getKernel: ReturnType<typeof vi.fn>;
+  execute: ReturnType<typeof vi.fn>;
+  onIopubMessage: ReturnType<typeof vi.fn>;
+  getQueryPort: ReturnType<typeof vi.fn>;
+  getKernelProcessState: ReturnType<typeof vi.fn>;
+}
+
+function makeKernelManager(overrides: Partial<FakeKernelManager> = {}): FakeKernelManager {
+  return {
+    getKernel: vi.fn(() => ({
+      id: "k1",
+      name: "python3",
+      language: "python",
+      status: "idle",
+    })),
+    execute: vi.fn(async (): Promise<KernelExecuteResult> => ({})),
+    onIopubMessage: vi.fn(() => () => undefined),
+    getQueryPort: vi.fn(() => 0),
+    getKernelProcessState: vi.fn(() => ({ exitCode: null, killed: false })),
+    ...overrides,
+  };
+}
+
+function makeCommRouter(): CommRouter {
+  return {
+    onPush: vi.fn(),
+    offPush: vi.fn(),
+    request: vi.fn(async () => ({})),
+  } as unknown as CommRouter;
+}
+
+function makeQueryRouter(): QueryRouter {
+  return { attach: vi.fn() } as unknown as QueryRouter;
+}
+
+function makeProjectManager(): ProjectManager {
+  return {
+    createWorkingDir: vi.fn(async () => "/tmp/pdv-fake"),
+  } as unknown as ProjectManager;
+}
+
+describe("initializeKernelSession diagnostics", () => {
+  it("bootstrap-step failure produces an enriched, multi-line error", async () => {
+    const km = makeKernelManager({
+      execute: vi.fn(async () => ({ error: "Kernel not found: ghost" })),
+    });
+    const commRouter = makeCommRouter();
+    const queryRouter = makeQueryRouter();
+    const projectManager = makeProjectManager();
+
+    await expect(
+      initializeKernelSession(
+        km as unknown as KernelManager,
+        commRouter,
+        queryRouter,
+        projectManager,
+        "ghost",
+        new Map()
+      )
+    ).rejects.toThrow(
+      /Kernel handshake failed at step 'bootstrap': Kernel not found: ghost/
+    );
+  });
+
+  it("error message includes process state, kernel status, and last iopub msg_type", async () => {
+    let lastListener: ((msg: { header: { msg_type: string } }) => void) | null = null;
+    const km = makeKernelManager({
+      onIopubMessage: vi.fn((_id, cb) => {
+        lastListener = cb as (msg: { header: { msg_type: string } }) => void;
+        return () => undefined;
+      }),
+      execute: vi.fn(async () => {
+        // Simulate that an iopub status message arrived during bootstrap
+        // before the failure was reported.
+        lastListener?.({ header: { msg_type: "status" } });
+        return { error: "boom" };
+      }),
+      getKernelProcessState: vi.fn(() => ({ exitCode: 1, killed: false })),
+      getKernel: vi.fn(() => ({
+        id: "k1",
+        name: "python3",
+        language: "python",
+        status: "dead",
+      })),
+    });
+
+    let caught: Error | null = null;
+    try {
+      await initializeKernelSession(
+        km as unknown as KernelManager,
+        makeCommRouter(),
+        makeQueryRouter(),
+        makeProjectManager(),
+        "k1",
+        new Map()
+      );
+    } catch (e) {
+      caught = e as Error;
+    }
+
+    expect(caught).not.toBeNull();
+    const msg = caught!.message;
+    expect(msg).toMatch(/^Kernel handshake failed at step 'bootstrap': boom/);
+    expect(msg).toContain("process: exitCode=1 killed=false");
+    expect(msg).toContain("kernel status: dead");
+    expect(msg).toContain("last iopub msg_type: status");
+  });
+
+  it("disposes the iopub diagnostic listener whether or not the handshake fails", async () => {
+    const dispose = vi.fn();
+    const km = makeKernelManager({
+      onIopubMessage: vi.fn(() => dispose),
+      execute: vi.fn(async () => ({ error: "boom" })),
+    });
+
+    await expect(
+      initializeKernelSession(
+        km as unknown as KernelManager,
+        makeCommRouter(),
+        makeQueryRouter(),
+        makeProjectManager(),
+        "k1",
+        new Map()
+      )
+    ).rejects.toThrow();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/electron/main/kernel-session.ts
+++ b/electron/main/kernel-session.ts
@@ -103,37 +103,57 @@ export async function initializeKernelSession(
   // Julia JIT compilation can be slow on first load; allow more time.
   const readyTimeoutMs = language === "julia" ? 60_000 : 15_000;
 
-  const readyPromise = waitForPush(commRouter, PDVMessageType.READY, readyTimeoutMs);
-  // Avoid unhandled rejection warnings if bootstrap fails before pdv.ready.
-  void readyPromise.catch(() => undefined);
-  const bootstrapResult = await kernelManager.execute(kernelId, {
-    code: bootstrapCode,
-    silent: true,
+  // Track the last iopub msg_type seen during the handshake so that, if
+  // anything throws, the diagnostic message can tell the user what the
+  // kernel was last doing instead of just "Kernel failed to start".
+  let lastIopubMsgType: string | null = null;
+  const disposeIopubObserver = kernelManager.onIopubMessage(kernelId, (m) => {
+    lastIopubMsgType = m.header.msg_type;
   });
-  if (bootstrapResult.error) {
-    throw new Error(bootstrapResult.error);
+
+  let step: "bootstrap" | "ready" | "init" = "bootstrap";
+  try {
+    const readyPromise = waitForPush(commRouter, PDVMessageType.READY, readyTimeoutMs);
+    // Avoid unhandled rejection warnings if bootstrap fails before pdv.ready.
+    void readyPromise.catch(() => undefined);
+    const bootstrapResult = await kernelManager.execute(kernelId, {
+      code: bootstrapCode,
+      silent: true,
+    });
+    if (bootstrapResult.error) {
+      throw new Error(bootstrapResult.error);
+    }
+    // KernelManager.execute resolves on `status: idle` correlated to the
+    // bootstrap execute's msg_id (see kernel-manager.ts), so by this point
+    // the shell handler has finished bootstrap and is ready for the next
+    // message. The previous extra `ping()` round-trip was a stopgap that
+    // racetrap'd cold boots; the iopub-idle signal above is the
+    // deterministic readiness invariant we actually want.
+    step = "ready";
+    await readyPromise;
+    step = "init";
+    const workingDir = await projectManager.createWorkingDir(workingDirBase);
+    await commRouter.request(PDVMessageType.INIT, {
+      working_dir: workingDir,
+      pdv_version: getAppVersion(),
+      query_port: kernelManager.getQueryPort(kernelId),
+    });
+    queryRouter.attach(kernelManager, kernelId);
+    kernelWorkingDirs.set(kernelId, workingDir);
+  } catch (err) {
+    const original = err instanceof Error ? err.message : String(err);
+    const proc = kernelManager.getKernelProcessState(kernelId);
+    const status = kernelManager.getKernel(kernelId)?.status ?? "(unknown)";
+    const procStr = proc
+      ? `exitCode=${proc.exitCode === null ? "null" : proc.exitCode} killed=${proc.killed}`
+      : "(kernel not found)";
+    throw new Error(
+      `Kernel handshake failed at step '${step}': ${original}\n` +
+        `  process: ${procStr}\n` +
+        `  kernel status: ${status}\n` +
+        `  last iopub msg_type: ${lastIopubMsgType ?? "(none)"}`
+    );
+  } finally {
+    disposeIopubObserver();
   }
-  await readyPromise;
-  // Ping the shell channel before sending pdv.init.  The bootstrap
-  // execute leaves unread kernel_info_reply / execute_reply frames in the
-  // DEALER socket's receive buffer.  Sending a kernel_info_request and
-  // reading the correlated reply drains those stale frames and confirms
-  // the kernel's shell thread is ready to accept the next message.
-  // Without this, pdv.init (a comm_msg) can be silently lost on the
-  // ROUTER socket under ipykernel ≥ 7.
-  //
-  // The default 5s ping timeout is tight on cold boots — pdv.bootstrap
-  // imports/configures matplotlib and the asyncio shell handler in
-  // ipykernel ≥ 7 is sometimes still draining bootstrap frames when the
-  // ping arrives. Use the same headroom we give pdv.ready (15s for
-  // Python, 60s for Julia).
-  await kernelManager.ping(kernelId, readyTimeoutMs);
-  const workingDir = await projectManager.createWorkingDir(workingDirBase);
-  await commRouter.request(PDVMessageType.INIT, {
-    working_dir: workingDir,
-    pdv_version: getAppVersion(),
-    query_port: kernelManager.getQueryPort(kernelId),
-  });
-  queryRouter.attach(kernelManager, kernelId);
-  kernelWorkingDirs.set(kernelId, workingDir);
 }

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -420,7 +420,7 @@ const App: React.FC = () => {
     onTreeChanged: handleTreeChanged,
   });
 
-  const { startKernel, handleEnvSave } = useKernelLifecycle({
+  const { startKernel, handleEnvSave, lastErrorRef } = useKernelLifecycle({
     config,
     currentKernelId,
     setCurrentKernelId,
@@ -1094,7 +1094,7 @@ const App: React.FC = () => {
     setActiveLanguage(language);
     if (language === 'julia') {
       const ok = await startKernel(config ?? {} as Config, 'julia');
-      if (!ok) openEnvSettings('Kernel failed to start.');
+      if (!ok) openEnvSettings(lastErrorRef.current ?? 'Kernel failed to start.');
     } else {
       if (!config?.pythonPath) {
         openEnvSettings();
@@ -1114,9 +1114,9 @@ const App: React.FC = () => {
         // Probe failed — try starting anyway
       }
       const ok = await startKernel(config, 'python');
-      if (!ok) openEnvSettings('Kernel failed to start.');
+      if (!ok) openEnvSettings(lastErrorRef.current ?? 'Kernel failed to start.');
     }
-  }, [config, runningPdvVersion, startKernel, openEnvSettings]);
+  }, [config, runningPdvVersion, startKernel, openEnvSettings, lastErrorRef]);
 
   const handleWelcomeNewProject = useCallback(async (language: 'python' | 'julia') => {
     dismissWelcome();
@@ -1684,7 +1684,7 @@ const App: React.FC = () => {
              setInterpreterWarning(null);
              void handleEnvSave(paths).then((ok) => {
                if (!ok) {
-                 openEnvSettings('Kernel failed to start with the selected environment.');
+                 openEnvSettings(lastErrorRef.current ?? 'Kernel failed to start with the selected environment.');
                }
              });
            });

--- a/electron/renderer/src/app/useKernelLifecycle.ts
+++ b/electron/renderer/src/app/useKernelLifecycle.ts
@@ -43,10 +43,16 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
   // previously queued call (only the latest queued call runs).
   const startQueueRef = useRef<Promise<boolean>>(Promise.resolve(false));
   const pendingStartRef = useRef<{ cfg: Config; language: 'python' | 'julia'; resolve: (v: boolean) => void } | null>(null);
+  // Mirrors `lastError` synchronously so callers can read the message right
+  // after `await startKernel()` returns, without waiting for React to flush
+  // setLastError. Used to surface diagnostic text (e.g. handshake-step errors)
+  // in the env-settings dialog warning slot.
+  const lastErrorRef = useRef<string | undefined>(undefined);
 
   const doStartKernel = useCallback(async (cfg: Config, language: 'python' | 'julia' = 'python'): Promise<boolean> => {
     setKernelStatus('starting');
     setLastError(undefined);
+    lastErrorRef.current = undefined;
     try {
       if (currentKernelId) {
         await window.pdv.kernels.stop(currentKernelId);
@@ -74,9 +80,11 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
       return true;
     } catch (error) {
       console.error('[App] Failed to start kernel:', error);
+      const msg = error instanceof Error ? error.message : String(error);
       setCurrentKernelId(null);
       setKernelStatus('error');
-      setLastError(error instanceof Error ? error.message : String(error));
+      lastErrorRef.current = msg;
+      setLastError(msg);
       return false;
     }
   }, [
@@ -165,5 +173,6 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
     startKernel,
     handleEnvSave,
     handleRestartKernel,
+    lastErrorRef,
   };
 }

--- a/electron/renderer/src/styles/dialogs.css
+++ b/electron/renderer/src/styles/dialogs.css
@@ -821,6 +821,7 @@
 .error-text {
   color: var(--error);
   font-size: 12px;
+  white-space: pre-wrap;
 }
 
 .help-text {

--- a/pdv-python/pdv/__init__.py
+++ b/pdv-python/pdv/__init__.py
@@ -447,6 +447,15 @@ def bootstrap(ip=None):
     # Users can still override with %matplotlib <backend> after bootstrap.
     _configure_matplotlib()
 
+    # Pay jedi's first-call grammar-table load cost here, on the same shell
+    # thread that will later serve complete_request, so the user's first
+    # completion isn't a 3–8 s stall (which serializes against execute_request).
+    if ip is not None:
+        try:
+            ip.complete("pdv_tree.")
+        except Exception:
+            pass
+
     comms_mod._bootstrapped = True
 
 

--- a/pdv-python/tests/test_integration_bootstrap.py
+++ b/pdv-python/tests/test_integration_bootstrap.py
@@ -89,3 +89,25 @@ class TestBootstrapReadyFlow:
             )
         finally:
             _reset_bootstrap_state()
+
+    def test_bootstrap_prewarms_jedi_via_ip_complete(self, mock_ipython):
+        _reset_bootstrap_state()
+        try:
+            bootstrap(mock_ipython)
+            mock_ipython.complete.assert_called_once_with("pdv_tree.")
+        finally:
+            _reset_bootstrap_state()
+
+    def test_bootstrap_succeeds_when_jedi_prewarm_raises(self, mock_ipython):
+        _reset_bootstrap_state()
+        try:
+            mock_ipython.complete.side_effect = RuntimeError("jedi exploded")
+            bootstrap(mock_ipython)
+            assert comms_mod._bootstrapped is True
+            # pdv.ready still wired up: opening a comm should send the ready push.
+            callback = mock_ipython.comm_manager.register_target.call_args[0][1]
+            mock_comm = _make_mock_comm()
+            callback(mock_comm, {"content": {"data": {}}})
+            assert any(m["type"] == "pdv.ready" for m in mock_comm._sent)
+        finally:
+            _reset_bootstrap_state()


### PR DESCRIPTION
Closes #222.

## Summary

- Pre-warm jedi inside `pdv.bootstrap()` so the first `complete_request` after a cold boot doesn't pay a 3–8 s lazy-load that serializes against execute_request on the shell queue.
- Remove the post-bootstrap `ping()` call in `initializeKernelSession`. `kernelManager.execute()` already waits for iopub `status: idle` correlated to its own `msg_id` — that *is* the deterministic readiness signal the issue's option 1 was asking for. The extra ping was the racy single-shot wait that timed out on cold boots.
- Drop the timeout bandaid (15 s Python / 60 s Julia passed into `ping`) along with the ping itself; the only remaining handshake timeout is the `pdv.ready` push (already 15 s / 60 s pre-bandaid).
- Wrap the handshake in step-tracking try/catch/finally with an iopub `msg_type` accumulator. On failure, throw a multi-line message containing the step name, the original error, the kernel process state (`exitCode` / `killed`), the kernel status, and the last iopub `msg_type` — replacing the previous black-box "Kernel failed to start" first-run UX.
- Add `KernelManager.getKernelProcessState(id)` for that diagnostics path.

## Plan deviation worth flagging

The approved plan added `KernelManager.waitForIopubIdle(parentMsgId)` and threaded `msgId` through `KernelExecuteResult`. While implementing I noticed `execute()` already registers an iopub listener that resolves on `status: idle` correlated to its own `msgId` (kernel-manager.ts:730–732, 796–800). A second listener registered *after* `await execute()` returns would never see that idle event — iopub listeners don't replay — so it would have hung the full timeout on every cold boot. The simpler fix (delete the redundant `ping()` call) is what landed.

## Out of scope (deferred)

- Comment 1 on #222 — completion-request head-of-line blocking in `enqueueShellOperation`. Pre-warming jedi removes its dominant trigger; the queue-priority work is its own surface.
- Explicit DEALER-side drain in `comm-router.ts` before `sendCommMsg` — only if field reports of dropped `pdv.init` messages persist.

## Test plan

- [x] `pytest tests/` — 456 passed, 2 skipped
- [x] `npm test` — 403 passed (38 files)
- [x] `PYTHON_PATH=… npm test main/integration.test.ts main/kernel-manager.test.ts main/kernel-manager-errors.test.ts` against ipykernel 7.2.0 — 52 passed
- [x] `PYTHON_PATH=… npm run test:e2e` — 15 passed; cold-boot kernel test in ~2 s under the new tight handshake budget
- [x] Manual cold-boot smoke on a fresh conda env with deleted matplotlib font cache: verify ready state without timeout, sub-100 ms first completion, no Execute stall
- [ ] Manual force-fail (kill kernel between bootstrap and init): verify the env-settings dialog now shows step name + process state + last iopub msg_type rather than just "Kernel failed to start"

🤖 Generated with [Claude Code](https://claude.com/claude-code)