### PR TITLE
hotfix: implement file relocation for autosave cache to ensure data integrity during explicit saves

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -3,7 +3,7 @@
 # Generates release-notes.md for a published release.
 #
 # Required environment variables:
-#   TAG       - the release tag (e.g. v0.1.1)
+#   TAG       - the release tag (e.g. v0.1.2)
 #   REPO      - "owner/repo"
 #   GH_TOKEN  - GitHub token with read access
 #

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,5 @@
 # PDV Architecture Document
-**Version**: 0.1.1
+**Version**: 0.1.2
 **Date**: 2026-04-07
 **Status**: Authoritative design specification. All new code must conform to this document. Deviations require updating this document first.
 
@@ -117,7 +117,7 @@ Every PDV message — whether sent by the app or by the kernel — has the follo
 
 ```json
 {
-  "pdv_version": "0.1.1",
+  "pdv_version": "0.1.2",
   "msg_id": "<uuid-v4>",
   "in_reply_to": "<uuid-v4-or-null>",
   "type": "<message-type-string>",
@@ -128,7 +128,7 @@ Every PDV message — whether sent by the app or by the kernel — has the follo
 
 | Field | Type | Description |
 |---|---|---|
-| `pdv_version` | string | App/package version (e.g. `"0.1.1"`). Both the Electron app and `pdv-python` use their installed version as this value. The app rejects messages with an incompatible major version. |
+| `pdv_version` | string | App/package version (e.g. `"0.1.2"`). Both the Electron app and `pdv-python` use their installed version as this value. The app rejects messages with an incompatible major version. |
 | `msg_id` | string | UUID v4. Unique identifier for this message. |
 | `in_reply_to` | string \| null | The `msg_id` of the request this is responding to. `null` for unsolicited push messages. |
 | `type` | string | Dot-namespaced message type (see Section 3.4). |
@@ -829,7 +829,7 @@ Each `modules/<id>/` subdirectory is maintained authoritatively by `project:save
 | `schema_version` | string | Semantic version of the project.json format. The app rejects manifests with an incompatible major version. Currently `"1.2"`. |
 | `project_id` | string | UUIDv4 assigned on first save under schema 1.2. Stable across renames and moves. Used by per-project environment bookkeeping (§10.5). 1.1 manifests without this field get one assigned on upgrade. |
 | `saved_at` | string | ISO 8601 timestamp of last save. |
-| `pdv_version` | string | PDV app version used when saving (e.g. `"0.1.1"`). |
+| `pdv_version` | string | PDV app version used when saving (e.g. `"0.1.2"`). |
 | `project_name` | string? | Optional human-readable project name chosen by the user. Displayed in the title bar and recent projects list. Falls back to the directory name when absent (backward compat). |
 | `language` | string | Kernel language: `"python"` or `"julia"`. |
 | `interpreter_path` | string? | Optional path to the interpreter used at save time. Used for pre-selection when `environment.mode == "shared"`; ignored when `environment.mode == "project"`. |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A desktop environment for computational and experimental physics analysis. PDV combines a tabbed code editor, an execution console, and a persistent, typed data hierarchy, the **Tree**, that lives inside a language kernel. The Tree is what separates PDV from a Jupyter notebook: it is a navigable, save/load-able data structure that persists across sessions, giving you structured data management and reproducible analysis workflows.
 
-**Status**: Beta (`v0.1.1`) — under active development.
+**Status**: Beta (`v0.1.2`) — under active development.
 
 ![PDV screenshot](docs/assets/screenshot.png)
 

--- a/electron/main/ipc-register-app-state.test.ts
+++ b/electron/main/ipc-register-app-state.test.ts
@@ -74,7 +74,7 @@ vi.mock("electron", () => ({
   dialog: dialogMocks,
   shell: shellMocks,
   app: {
-    getVersion: () => "0.1.1-test",
+    getVersion: () => "0.1.2-test",
     quit: vi.fn(),
   },
 }));

--- a/electron/main/ipc-register-coverage.test.ts
+++ b/electron/main/ipc-register-coverage.test.ts
@@ -221,7 +221,7 @@ function setupAll(): void {
     getPendingModuleSettings: () => ({}),
     getModuleHealthWarningsByAlias: () => new Map(),
     detectPythonVersion: async () => "3.11.6",
-    getPdvVersion: () => "0.1.1",
+    getPdvVersion: () => "0.1.2",
     runWithProjectManifestWriteLock: async (_dir, fn) => fn(),
   });
   registerProjectIpcHandlers({

--- a/electron/main/ipc-register-modules.test.ts
+++ b/electron/main/ipc-register-modules.test.ts
@@ -106,7 +106,7 @@ function setup(initial: Partial<Harness> = {}): Harness {
     getPendingModuleSettings: () => ({}),
     getModuleHealthWarningsByAlias: () => new Map(),
     detectPythonVersion: async () => "3.11.6",
-    getPdvVersion: () => "0.1.1",
+    getPdvVersion: () => "0.1.2",
     runWithProjectManifestWriteLock: async (_dir, fn) => fn(),
   });
   return harness;

--- a/electron/main/ipc-register-project.test.ts
+++ b/electron/main/ipc-register-project.test.ts
@@ -202,7 +202,7 @@ describe("project:load", () => {
     setup();
     vi.spyOn(ProjectManager, "readManifest").mockResolvedValue({
       tree_checksum: "sha-1",
-      pdv_version: "0.1.1",
+      pdv_version: "0.1.2",
       project_name: "demo",
     } as never);
     fsMocks.readFile.mockImplementation(async (filePath: string) => {
@@ -218,7 +218,7 @@ describe("project:load", () => {
       nodeCount: number;
     };
     expect(result.checksum).toBe("sha-1");
-    expect(result.savedPdvVersion).toBe("0.1.1");
+    expect(result.savedPdvVersion).toBe("0.1.2");
     expect(result.nodeCount).toBe(2);
   });
 
@@ -275,7 +275,7 @@ describe("project:peekLanguages / peekManifest", () => {
     vi.spyOn(ProjectManager, "readManifest").mockResolvedValueOnce({
       language: "julia",
       interpreter_path: "/usr/bin/julia",
-      pdv_version: "0.1.1",
+      pdv_version: "0.1.2",
       project_name: "demo",
     } as never);
     const ok = (await getHandler(IPC.project.peekManifest)({}, "/save")) as {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "physics-data-viewer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "author": {
     "name": "Matthew Pharr",

--- a/electron/renderer/src/app/useProjectWorkflow.test.ts
+++ b/electron/renderer/src/app/useProjectWorkflow.test.ts
@@ -239,7 +239,7 @@ describe("useProjectWorkflow.executeOpenProject", () => {
               checksum: "deadbeef0000",
               checksumValid: true,
               nodeCount: 3,
-              savedPdvVersion: "0.1.1",
+              savedPdvVersion: "0.1.2",
               projectName: "loaded-demo",
               missingFiles: undefined,
             })) as never,
@@ -258,7 +258,7 @@ describe("useProjectWorkflow.executeOpenProject", () => {
     expect(state.activeCellTab).toBe(7);
     expect(state.lastChecksum).toBe("deadbe");
     expect(state.checksumMismatch).toBe(false);
-    expect(state.savedPdvVersion).toBe("0.1.1");
+    expect(state.savedPdvVersion).toBe("0.1.2");
     expect(loadedProjectTabsRef.current).toEqual({
       tabs: [{ id: 7, code: "loaded" }],
       activeTabId: 7,

--- a/examples/modules/N-pendulum-julia/pdv-module.json
+++ b/examples/modules/N-pendulum-julia/pdv-module.json
@@ -9,7 +9,7 @@
   "lib_dir": "lib",
   "default_gui": "gui.json",
   "compatibility": {
-    "pdv_min": "0.1.1",
+    "pdv_min": "0.1.2",
     "pdv_max": "99.0.0",
     "julia": ">=1.10"
   },

--- a/examples/modules/N-pendulum/pdv-module.json
+++ b/examples/modules/N-pendulum/pdv-module.json
@@ -9,7 +9,7 @@
   "lib_dir": "lib",
   "default_gui": "gui.json",
   "compatibility": {
-    "pdv_min": "0.1.1",
+    "pdv_min": "0.1.2",
     "pdv_max": "99.0.0",
     "python": ">=3.10,<3.14",
     "python_min": "3.10.0",

--- a/pdv-python/pdv/serialization.py
+++ b/pdv-python/pdv/serialization.py
@@ -281,18 +281,104 @@ def detect_kind(value: Any) -> str:
     return KIND_UNKNOWN
 
 
+def _verify_or_relocate_cached_file(
+    descriptor: dict,
+    working_dir: str,
+) -> bool:
+    """Make a cache-hit descriptor's backing file reachable under ``working_dir``.
+
+    The autosave cache stores ``(digest, descriptor)`` pairs whose
+    ``storage.uuid`` was minted by whichever serialize call wrote the file.
+    For an autosave miss the file lands in ``<saveDir>/.autosave/tree/<uuid>/``;
+    for an explicit-save miss it lands in ``<saveDir>/tree/<uuid>/``. When the
+    *next* save sees a cache hit, the descriptor's UUID is reused verbatim —
+    but the file may not be where the new ``tree-index.json`` is going to claim
+    it is.
+
+    This helper closes that gap. For a file-backed descriptor it:
+
+    1. Returns True if the file is already at ``<working_dir>/tree/<uuid>/<filename>``.
+    2. Otherwise tries the sibling autosave dir (``<working_dir>/.autosave/...``)
+       and moves the file into the canonical location via ``os.replace`` —
+       same-volume rename is effectively free, so this is the cheap path that
+       lets an explicit save adopt files left behind by an autosave.
+    3. If ``working_dir`` itself ends in ``.autosave``, treats the parent's
+       ``tree/<uuid>/`` as a valid home too (a previous explicit save's file).
+       In that case no move happens — autosave recovery's overlay handles it.
+    4. Otherwise returns False so the caller falls through to re-serialize.
+
+    Inline (``backend != "local_file"``) descriptors are always valid.
+    """
+    import os  # noqa: PLC0415
+
+    storage = descriptor.get("storage", {})
+    if storage.get("backend") != "local_file":
+        return True
+    node_uuid = storage.get("uuid")
+    filename = storage.get("filename")
+    if not node_uuid or not filename:
+        return True
+
+    from pdv.environment import ensure_parent, uuid_tree_path  # noqa: PLC0415
+
+    canonical = uuid_tree_path(working_dir, node_uuid, filename)
+    if os.path.exists(canonical):
+        return True
+
+    working_norm = working_dir.rstrip(os.sep)
+    is_autosave_dir = os.path.basename(working_norm) == ".autosave"
+
+    if not is_autosave_dir:
+        # Explicit save: file may have been written by a previous autosave.
+        # Same-volume rename brings it into the canonical tree dir.
+        autosave_loc = uuid_tree_path(
+            os.path.join(working_dir, ".autosave"), node_uuid, filename
+        )
+        if os.path.exists(autosave_loc):
+            try:
+                ensure_parent(canonical)
+                os.replace(autosave_loc, canonical)
+                return True
+            except OSError:
+                # Cross-device or permission failure — fall through and
+                # let the caller re-serialize. Safer than returning a
+                # descriptor we can't back with a file.
+                return False
+        return False
+
+    # Autosave save: the canonical file may live in the parent's tree dir
+    # from a prior explicit save. The recovery overlay (overlayAutosaveTreeFiles)
+    # leaves canonical files in place at load time, and copyFilesForLoad has
+    # already brought them into the working dir.
+    parent = os.path.dirname(working_norm)
+    if parent:
+        parent_loc = uuid_tree_path(parent, node_uuid, filename)
+        if os.path.exists(parent_loc):
+            return True
+    return False
+
+
 def _try_autosave_cache(
     autosave_cache: "dict[str, tuple[bytes, dict]] | None",
     tree_path: str,
     value: Any,
     source_dir: str,
     hit_counter: "list[int] | None" = None,
+    working_dir: str = "",
 ) -> "tuple[bytes | None, dict | None]":
     """Check autosave cache for an unchanged data node.
 
     Returns ``(digest, cached_descriptor)`` on cache hit, ``(digest, None)``
     on miss, or ``(None, None)`` when caching is disabled. When provided,
     ``hit_counter[0]`` is incremented on every cache hit.
+
+    A "hit" is only returned when the cached descriptor's backing file is
+    reachable from ``working_dir`` — see :func:`_verify_or_relocate_cached_file`.
+    If the digest matches but the file has gone missing (e.g. the canonical
+    tree dir was wiped between sessions), the cache entry is dropped and the
+    caller falls back to re-serializing. This keeps ``tree-index.json`` and
+    the on-disk tree consistent even after the cache and the filesystem
+    drift apart.
     """
     if autosave_cache is None:
         return None, None
@@ -301,9 +387,13 @@ def _try_autosave_cache(
     digest = node_digest(value, source_dir)
     cached = autosave_cache.get(tree_path)
     if cached is not None and cached[0] == digest:
-        if hit_counter is not None:
-            hit_counter[0] += 1
-        return digest, cached[1]
+        if _verify_or_relocate_cached_file(cached[1], working_dir):
+            if hit_counter is not None:
+                hit_counter[0] += 1
+            return digest, cached[1]
+        # File can't be located. Drop the stale entry so the caller's
+        # re-serialize repopulates the cache with a fresh descriptor.
+        autosave_cache.pop(tree_path, None)
     return digest, None
 
 
@@ -523,7 +613,7 @@ def serialize_node(
         return descriptor
 
     if kind == KIND_NDARRAY:
-        _digest, _cached = _try_autosave_cache(autosave_cache, tree_path, value, _source_dir, autosave_hits)
+        _digest, _cached = _try_autosave_cache(autosave_cache, tree_path, value, _source_dir, autosave_hits, working_dir)
         if _cached is not None:
             return _cached
 
@@ -551,7 +641,7 @@ def serialize_node(
         # pickle. This avoids an external parquet-engine dependency and keeps
         # name/index/dtype/extension-type round-trips lossless. Users who want
         # parquet for interchange can write it themselves.
-        _digest, _cached = _try_autosave_cache(autosave_cache, tree_path, value, _source_dir, autosave_hits)
+        _digest, _cached = _try_autosave_cache(autosave_cache, tree_path, value, _source_dir, autosave_hits, working_dir)
         if _cached is not None:
             return _cached
 
@@ -606,7 +696,7 @@ def serialize_node(
                 "value": value,
             }
         else:
-            _digest, _cached = _try_autosave_cache(autosave_cache, tree_path, value, _source_dir, autosave_hits)
+            _digest, _cached = _try_autosave_cache(autosave_cache, tree_path, value, _source_dir, autosave_hits, working_dir)
             if _cached is not None:
                 return _cached
             node_uuid = generate_node_uuid()
@@ -690,7 +780,7 @@ def serialize_node(
         )
 
     if kind == KIND_BINARY:
-        _digest, _cached = _try_autosave_cache(autosave_cache, tree_path, value, _source_dir, autosave_hits)
+        _digest, _cached = _try_autosave_cache(autosave_cache, tree_path, value, _source_dir, autosave_hits, working_dir)
         if _cached is not None:
             return _cached
         node_uuid = generate_node_uuid()
@@ -707,7 +797,7 @@ def serialize_node(
         return descriptor
 
     # KIND_UNKNOWN — try a registered custom serializer before falling back to pickle.
-    _digest, _cached = _try_autosave_cache(autosave_cache, tree_path, value, _source_dir, autosave_hits)
+    _digest, _cached = _try_autosave_cache(autosave_cache, tree_path, value, _source_dir, autosave_hits, working_dir)
     if _cached is not None:
         return _cached
 

--- a/pdv-python/pdv/serialization.py
+++ b/pdv-python/pdv/serialization.py
@@ -335,14 +335,28 @@ def _verify_or_relocate_cached_file(
             os.path.join(working_dir, ".autosave"), node_uuid, filename
         )
         if os.path.exists(autosave_loc):
+            ensure_parent(canonical)
             try:
-                ensure_parent(canonical)
                 os.replace(autosave_loc, canonical)
                 return True
-            except OSError:
-                # Cross-device or permission failure — fall through and
-                # let the caller re-serialize. Safer than returning a
-                # descriptor we can't back with a file.
+            except OSError as exc:
+                # EXDEV (cross-device) is the realistic failure here —
+                # rare, since `.autosave/` is a subdir of saveDir, but
+                # bind-mounts and overlay filesystems can split them.
+                # Fall back to copy+remove so we don't orphan the
+                # autosave file on the source side.
+                import errno  # noqa: PLC0415
+                import shutil  # noqa: PLC0415
+                if getattr(exc, "errno", None) == errno.EXDEV:
+                    try:
+                        shutil.copy2(autosave_loc, canonical)
+                        os.remove(autosave_loc)
+                        return True
+                    except OSError:
+                        pass
+                # Permission failure or copy failure — re-serialize.
+                # Safer than returning a descriptor we can't back with
+                # a file.
                 return False
         return False
 
@@ -363,8 +377,8 @@ def _try_autosave_cache(
     tree_path: str,
     value: Any,
     source_dir: str,
-    hit_counter: "list[int] | None" = None,
-    working_dir: str = "",
+    hit_counter: "list[int] | None",
+    working_dir: str,
 ) -> "tuple[bytes | None, dict | None]":
     """Check autosave cache for an unchanged data node.
 

--- a/pdv-python/pyproject.toml
+++ b/pdv-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdv-python"
-version = "0.1.1"
+version = "0.1.2"
 description = "PDV kernel support package — implements the PDV comm protocol and data structures for Python kernels."
 requires-python = ">=3.10"
 dependencies = [

--- a/pdv-python/tests/test_checksum.py
+++ b/pdv-python/tests/test_checksum.py
@@ -398,6 +398,44 @@ class TestAutosaveCache:
             "autosave copy should have been moved (rename), not duplicated"
         )
 
+    def test_autosave_after_explicit_save_leaves_canonical_file_in_place(self, tmp_path):
+        """Reverse direction of the relocation fix: after an explicit save
+        has written the canonical file under ``<saveDir>/tree/<uuid>/``, a
+        follow-up autosave with the same value must hit the cache and leave
+        the file where it is. The autosave's tree-index will reference that
+        UUID, and the recovery flow's ``copyFilesForLoad`` (which reads
+        ``<saveDir>/tree-index.json``) brings the file into the working dir
+        at load time — no second copy needs to live under ``.autosave/tree/``.
+        """
+        np = pytest.importorskip("numpy")
+        import os
+        from pdv.serialization import serialize_node
+
+        save_dir = str(tmp_path / "save")
+        autosave_dir = str(tmp_path / "save" / ".autosave")
+
+        cache: dict = {}
+        hits = [0]
+        arr = np.array([1.0, 2.0, 3.0])
+
+        first = serialize_node(
+            "x", arr, save_dir, autosave_cache=cache, autosave_hits=hits
+        )
+        canonical = os.path.join(save_dir, "tree", first["uuid"], "x.npy")
+        assert os.path.exists(canonical)
+
+        second = serialize_node(
+            "x", arr, autosave_dir, autosave_cache=cache, autosave_hits=hits
+        )
+        assert hits[0] == 1
+        assert second["uuid"] == first["uuid"]
+        # Canonical file untouched, no duplicate appears under .autosave/tree/.
+        assert os.path.exists(canonical)
+        autosave_copy = os.path.join(
+            autosave_dir, "tree", first["uuid"], "x.npy"
+        )
+        assert not os.path.exists(autosave_copy)
+
     def test_cache_hit_with_missing_file_forces_reserialize(self, tmp_path):
         """If the file backing a cached descriptor has gone missing entirely
         (no canonical copy, no .autosave copy), treat the cache entry as

--- a/pdv-python/tests/test_checksum.py
+++ b/pdv-python/tests/test_checksum.py
@@ -352,6 +352,84 @@ class TestAutosaveCache:
             f"autosave duplicated the canonical file at {autosave_tree}"
         )
 
+    def test_autosave_then_explicit_save_relocates_file(self, tmp_path):
+        """Regression: autosave writes a changed-since-save file into
+        ``<saveDir>/.autosave/tree/<uuid>/``. The next explicit save sees a
+        cache hit (value unchanged since the autosave) and must end up with
+        the backing file under ``<saveDir>/tree/<uuid>/`` — otherwise the
+        next project load hits ENOENT and the data is effectively lost.
+        """
+        np = pytest.importorskip("numpy")
+        import os
+        from pdv.serialization import serialize_node
+
+        save_dir = str(tmp_path / "save")
+        autosave_dir = str(tmp_path / "save" / ".autosave")
+
+        cache: dict = {}
+        hits = [0]
+
+        # 1. Autosave path: cache empty, write goes to autosave_dir/tree/.
+        arr = np.array([7.0, 8.0, 9.0])
+        first = serialize_node(
+            "shots.t", arr, autosave_dir, autosave_cache=cache, autosave_hits=hits
+        )
+        autosave_file = os.path.join(
+            autosave_dir, "tree", first["uuid"], "t.npy"
+        )
+        assert os.path.exists(autosave_file), (
+            "autosave-phase write should land under <autosaveDir>/tree/"
+        )
+        assert hits[0] == 0
+
+        # 2. Explicit-save path: cache holds the autosave's descriptor.
+        # Value hasn't changed, so this hits the cache — and the helper
+        # must relocate the file into the canonical save_dir/tree/.
+        second = serialize_node(
+            "shots.t", arr, save_dir, autosave_cache=cache, autosave_hits=hits
+        )
+        assert hits[0] == 1
+        assert second["uuid"] == first["uuid"]
+        canonical = os.path.join(save_dir, "tree", second["uuid"], "t.npy")
+        assert os.path.exists(canonical), (
+            "explicit save must relocate cached file to <saveDir>/tree/"
+        )
+        assert not os.path.exists(autosave_file), (
+            "autosave copy should have been moved (rename), not duplicated"
+        )
+
+    def test_cache_hit_with_missing_file_forces_reserialize(self, tmp_path):
+        """If the file backing a cached descriptor has gone missing entirely
+        (no canonical copy, no .autosave copy), treat the cache entry as
+        stale and re-serialize so ``tree-index.json`` always references a
+        file that exists on disk."""
+        np = pytest.importorskip("numpy")
+        import os
+        from pdv.serialization import serialize_node
+
+        save_dir = str(tmp_path / "save")
+        cache: dict = {}
+        hits = [0]
+        arr = np.array([1.0, 2.0, 3.0])
+
+        first = serialize_node(
+            "x", arr, save_dir, autosave_cache=cache, autosave_hits=hits
+        )
+        # Nuke the backing file out from under the cache.
+        first_path = os.path.join(save_dir, "tree", first["uuid"], "x.npy")
+        os.remove(first_path)
+
+        second = serialize_node(
+            "x", arr, save_dir, autosave_cache=cache, autosave_hits=hits
+        )
+        # No usable hit — a fresh UUID is minted and the file written again.
+        assert hits[0] == 0
+        assert second["uuid"] != first["uuid"]
+        new_path = os.path.join(save_dir, "tree", second["uuid"], "x.npy")
+        assert os.path.exists(new_path)
+        # Cache should now reference the fresh descriptor, not the stale one.
+        assert cache["x"][1]["uuid"] == second["uuid"]
+
 
 class TestRoundtrip:
     def test_roundtrip(self, tmp_path):


### PR DESCRIPTION
Fix a critical bug causing corruption of saves in specific circumstances when overwriting an autosave with a save