### PR TITLE
Eagerly clear autosave cache on deletion

### DIFF
--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -322,6 +322,7 @@ function setup() {
     stopAutosaveTimer: vi.fn(),
     resetAutosaveTimer: vi.fn(),
     markAutosaveCacheDirty: vi.fn(),
+    clearAutosaveCache: vi.fn(async () => undefined),
     setAutosavePending: vi.fn(),
     consumeAutosavePending: vi.fn(() => false),
     autosave: vi.fn(async () => null),
@@ -2067,12 +2068,14 @@ describe("Step 5 IPC handlers", () => {
 
     await clear({}, "/tmp/some-project");
 
-    // ProjectManager.clearAutosave is a static method that fs.rms <dir>/.autosave/
-    // and the handler also marks the per-instance cache dirty.
+    // ProjectManager.clearAutosave is a static method that fs.rms <dir>/.autosave/.
+    // The handler also drops the kernel-side cache eagerly (via comm) and
+    // sets the per-instance dirty flag as a fallback for the next autosave.
     expect(mocks.fsRm).toHaveBeenCalledWith(
       path.join("/tmp/some-project", ".autosave"),
       expect.objectContaining({ recursive: true, force: true }),
     );
+    expect(projectManager.clearAutosaveCache).toHaveBeenCalledOnce();
     expect(projectManager.markAutosaveCacheDirty).toHaveBeenCalledOnce();
   });
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -740,6 +740,10 @@ export function registerIpcHandlers(
     const target = dir || activeProjectDir || kernelWorkingDirs.get(activeKernelId ?? "");
     if (target) {
       await ProjectManager.clearAutosave(target);
+      // Eagerly drop the kernel-side cache so the next save (autosave or
+      // explicit) can't reuse descriptors whose files were just deleted.
+      // markAutosaveCacheDirty() is the fallback if the comm fails.
+      await projectManager.clearAutosaveCache();
       projectManager.markAutosaveCacheDirty();
     }
   });

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -130,6 +130,17 @@ export const PDVMessageType = {
   PROJECT_SAVE_AS_REQUEST: "pdv.project.save_as_request",
   /** Kernel → app (push). Kernel requests the app to open a project from a directory. */
   PROJECT_OPEN_REQUEST: "pdv.project.open_request",
+  /**
+   * App → kernel. Instructs the kernel to drop its in-memory autosave
+   * checksum cache (the dict consulted by every save to skip unchanged
+   * data nodes). Sent eagerly when the user clicks "Clear autosave data"
+   * so the kernel can't reuse descriptors whose backing files were just
+   * deleted from disk. The kernel side responds with an empty payload.
+   */
+  PROJECT_CLEAR_AUTOSAVE_CACHE: "pdv.project.clear_autosave_cache",
+  /** Kernel → app. Confirms cache reset. */
+  PROJECT_CLEAR_AUTOSAVE_CACHE_RESPONSE:
+    "pdv.project.clear_autosave_cache.response",
 
   // Tree
   /** App → kernel. Request tree nodes at a given path. */

--- a/electron/main/project-manager.ts
+++ b/electron/main/project-manager.ts
@@ -664,9 +664,40 @@ export class ProjectManager {
   /**
    * Mark the autosave cache as needing to be cleared on the next autosave.
    * Called when the user manually clears autosave data from Settings.
+   *
+   * Kept as a belt-and-suspenders fallback for the eager
+   * {@link clearAutosaveCache} comm: if the comm fails (kernel disconnected,
+   * busy, etc.) the next autosave still sends ``clear_cache: true`` and
+   * resets the kernel-side cache before serializing.
    */
   markAutosaveCacheDirty(): void {
     this.autosaveClearCacheOnNext = true;
+  }
+
+  /**
+   * Eagerly drop the kernel-side autosave cache by sending a
+   * ``pdv.project.clear_autosave_cache`` comm.
+   *
+   * Called when the user clicks "Clear autosave data" so the kernel can't
+   * reuse cached descriptors whose backing files were just deleted from
+   * ``<saveDir>/.autosave/tree/``. Best-effort: a failed comm logs a
+   * warning and the per-instance dirty flag (set by
+   * {@link markAutosaveCacheDirty}) catches the next autosave as a fallback.
+   *
+   * @returns Nothing. Never throws.
+   */
+  async clearAutosaveCache(): Promise<void> {
+    try {
+      await this.commRouter.request(
+        PDVMessageType.PROJECT_CLEAR_AUTOSAVE_CACHE,
+        {},
+      );
+    } catch (err) {
+      console.warn(
+        "[ProjectManager.clearAutosaveCache] comm failed; relying on next-autosave fallback",
+        err,
+      );
+    }
   }
 
   /**

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "physics-data-viewer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "physics-data-viewer",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
         "ansi-to-html": "^0.7.2",

--- a/pdv-python/pdv/handlers/project.py
+++ b/pdv-python/pdv/handlers/project.py
@@ -967,5 +967,32 @@ def handle_project_save(msg: dict) -> None:
     )
 
 
+def handle_project_clear_autosave_cache(msg: dict) -> None:
+    """Handle the ``pdv.project.clear_autosave_cache`` message.
+
+    Resets the in-memory :data:`_autosave_cache`. Sent by the main process
+    when the user clicks "Clear autosave data" so the next save can't
+    reuse cached descriptors whose backing files were just deleted from
+    ``<saveDir>/.autosave/tree/``.
+
+    Without this, the kernel-side cache would retain entries pointing at
+    autosave-side UUIDs that no longer exist on disk. ``serialize_node``'s
+    file-existence check would catch them one at a time, but eager clear
+    is cleaner.
+
+    Expected payload: empty.
+    Response payload: empty.
+    """
+    from pdv.comms import send_message  # noqa: PLC0415
+
+    clear_autosave_cache()
+    send_message(
+        "pdv.project.clear_autosave_cache.response",
+        {},
+        in_reply_to=msg.get("msg_id"),
+    )
+
+
 register("pdv.project.load", handle_project_load)
 register("pdv.project.save", handle_project_save)
+register("pdv.project.clear_autosave_cache", handle_project_clear_autosave_cache)

--- a/pdv-python/tests/test_handlers_project.py
+++ b/pdv-python/tests/test_handlers_project.py
@@ -19,7 +19,11 @@ import uuid
 import pytest
 from unittest.mock import MagicMock, patch
 import pdv.comms as comms_mod
-from pdv.handlers.project import handle_project_load, handle_project_save
+from pdv.handlers.project import (
+    handle_project_clear_autosave_cache,
+    handle_project_load,
+    handle_project_save,
+)
 from pdv.tree import (
     PDVTree,
     PDVScript,
@@ -466,6 +470,38 @@ class TestHandleProjectSave:
             m for m in mock_comm._sent if m.get("type") == "pdv.project.save.response"
         )
         assert response["payload"].get("module_owned_files", []) == []
+
+
+class TestHandleProjectClearAutosaveCache:
+    def test_clears_module_level_cache(self, tree_with_comm, tmp_save_dir):
+        """The handler wipes ``_autosave_cache`` so the next save can't reuse
+        descriptors whose backing files were just deleted from
+        ``<saveDir>/.autosave/tree/``.
+        """
+        numpy = pytest.importorskip("numpy")
+        from pdv.handlers import project as project_mod
+
+        # Prime the cache by running a save.
+        tree_with_comm["arr"] = numpy.array([1.0, 2.0, 3.0])
+        mock_comm = _make_mock_comm()
+        save_msg = _make_msg("pdv.project.save", {"save_dir": tmp_save_dir})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_project_save(save_msg)
+        assert project_mod._autosave_cache, "save should populate the cache"
+
+        # Clear it via the comm handler.
+        clear_msg = _make_msg("pdv.project.clear_autosave_cache", {})
+        with patch.object(comms_mod, "_comm", mock_comm):
+            handle_project_clear_autosave_cache(clear_msg)
+        assert project_mod._autosave_cache == {}
+
+        response = mock_comm._sent[-1]
+        assert response["type"] == "pdv.project.clear_autosave_cache.response"
+        assert response["status"] == "ok"
+        assert response["in_reply_to"] == clear_msg["msg_id"]
 
 
 class TestTwoPassLoading:


### PR DESCRIPTION
Implement eager clearing of the autosave cache to prevent the reuse of deleted descriptors when clearing autosave data. This change enhances data integrity by ensuring that the kernel does not retain references to files that have been removed.