### PR TITLE
ci: harden workflows against supply-chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Dependabot configuration for PDV.
+#
+# Keeps three ecosystems current on a weekly cadence: the pinned GitHub
+# Actions SHAs in .github/workflows/, the Electron app's npm deps under
+# electron/, and the Python kernel's pip deps under pdv-python/. Minor and
+# patch bumps are grouped per ecosystem so routine maintenance shows up as
+# at most one PR per week per ecosystem; security advisories and major
+# version bumps still open their own individual PRs.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/electron"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pip"
+    directory: "/pdv-python"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       electron: ${{ steps.filter.outputs.electron }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
         id: filter
         with:
           filters: |
@@ -50,7 +50,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       # Always runs — parity drift can happen in any file group, and the
       # check is cheap (~10s). Fails the PR if electron/package.json,
@@ -68,10 +68,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
           # Caches ~/.npm so npm fetch is hot on cache miss for the
@@ -86,7 +86,7 @@ jobs:
       # download cache from setup-node above still warms the install.
       - name: Cache electron/node_modules
         id: node-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: electron/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('electron/package-lock.json') }}
@@ -117,10 +117,10 @@ jobs:
     name: Python tests (${{ matrix.python-version }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -144,10 +144,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
           # Caches ~/.npm so npm fetch is hot on cache miss for the
@@ -157,7 +157,7 @@ jobs:
           cache-dependency-path: electron/package-lock.json
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
           cache: 'pip'
@@ -172,7 +172,7 @@ jobs:
       # download cache from setup-node above still warms the install.
       - name: Cache electron/node_modules
         id: node-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: electron/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('electron/package-lock.json') }}
@@ -201,10 +201,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
           # Caches ~/.npm so npm fetch is hot on cache miss for the
@@ -219,7 +219,7 @@ jobs:
       # download cache from setup-node above still warms the install.
       - name: Cache electron/node_modules
         id: node-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: electron/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('electron/package-lock.json') }}
@@ -249,10 +249,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
           # Caches ~/.npm so npm fetch is hot on cache miss for the
@@ -262,7 +262,7 @@ jobs:
           cache-dependency-path: electron/package-lock.json
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
           cache: 'pip'
@@ -280,7 +280,7 @@ jobs:
       # download cache from setup-node above still warms the install.
       - name: Cache electron/node_modules
         id: node-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: electron/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('electron/package-lock.json') }}
@@ -316,7 +316,7 @@ jobs:
       # (~17s) and blow the bootstrap timeout. Keyed on the matplotlib version
       # in the installed pdv-python deps.
       - name: Cache matplotlib font cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: electron/e2e/.fixtures-cache/matplotlib
           key: mpl-fontcache-${{ runner.os }}-py3.11-${{ hashFiles('pdv-python/pyproject.toml') }}
@@ -329,7 +329,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: playwright-report
           path: |
@@ -348,7 +348,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           # git-revision-date-localized-plugin needs full history for the
           # "Last update" timestamps; without this the plugin falls back to
@@ -356,7 +356,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
           cache: 'pip'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,14 @@ on:
 
 jobs:
   claude:
+    # Restrict @claude triggers to trusted authors. Without this gate, anyone
+    # with a GitHub account could post "@claude" on a public issue/PR and run
+    # a job that holds id-token: write — see the 2026-05-11 TanStack incident.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,7 +29,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -13,10 +13,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
 
@@ -46,10 +46,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
 
@@ -79,7 +79,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Generate release notes
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,11 +19,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary

Motivated by the 2026-05-11 TanStack npm supply-chain compromise ([CVE-2026-45321](https://cvereports.com/reports/CVE-2026-45321) — Mini Shai-Hulud worm, ~170 packages across npm/PyPI). PDV is structurally insulated from the worst of that attack (no \`pull_request_target\`, no npm/PyPI publish workflow), but three cheap hardening measures further reduce the blast radius if a transitive dep or third-party Action is compromised in the future.

- **Pin third-party Actions to commit SHAs.** Every \`uses:\` line across \`ci.yml\`, \`dist.yml\`, \`docs.yml\`, \`claude.yml\` now references a 40-char commit SHA with the original tag preserved as a trailing comment. \`anthropics/claude-code-action\` is intentionally left floating on \`@v1\` so first-party fixes reach us without a Dependabot round-trip.
- **Add \`.github/dependabot.yml\`** covering \`github-actions\` (/), \`npm\` (/electron), and \`pip\` (/pdv-python) on a weekly cadence. Minor+patch updates are grouped per ecosystem so routine bumps surface as at most one PR per week per ecosystem; security advisories and major bumps still open their own PRs.
- **Tighten \`claude.yml\` \`@claude\` trigger.** The job carries \`id-token: write\` and was previously fireable by any commenter on a public issue. The \`if:\` gate now also requires \`author_association ∈ {OWNER, MEMBER, COLLABORATOR}\` on the appropriate payload object for each event type.

## Test plan

- [ ] YAML parses cleanly for all four workflows and the new \`dependabot.yml\` (verified locally with PyYAML).
- [ ] CI runs on this PR and all jobs that previously passed still pass — confirms the SHA pins resolve to working revisions of each Action.
- [ ] After merge, watch for Dependabot's first scheduled run and confirm it opens grouped PRs against \`develop\` (not \`main\`).
- [ ] Manual sanity check on \`@claude\` gating: comment \`@claude\` from a non-collaborator account on a test issue and confirm the job does not run. (Optional / can defer.)
- [ ] N/A — \`pdv-python/scripts/sweep-deps.sh\` does not apply here; no source or \`pyproject.toml\` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)