### PR TITLE
ci: add 7-day cooldown to all Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,15 @@
 # patch bumps are grouped per ecosystem so routine maintenance shows up as
 # at most one PR per week per ecosystem; security advisories and major
 # version bumps still open their own individual PRs.
+#
+# Every ecosystem also carries a cooldown so freshly-published versions
+# sit in the registry for at least 7 days before Dependabot will propose
+# them. This is the version-update analogue of uv's --exclude-newer and
+# is intended to dodge supply-chain compromises that get caught and
+# deprecated within hours (e.g. the 2026-05-11 TanStack incident, which
+# was deprecated within ~20 minutes of publish). Security updates — the
+# repo-settings toggle, not this file — intentionally bypass the cooldown
+# because they patch a known-vulnerable version already in the tree.
 
 version: 2
 updates:
@@ -14,6 +23,13 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "develop"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+      include:
+        - "*"
     groups:
       actions-minor-patch:
         update-types:
@@ -25,6 +41,13 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "develop"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+      include:
+        - "*"
     groups:
       npm-minor-patch:
         update-types:
@@ -36,6 +59,13 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "develop"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+      include:
+        - "*"
     groups:
       pip-minor-patch:
         update-types:


### PR DESCRIPTION
## Summary

Follow-up to #249. Adds a \`cooldown:\` block to each ecosystem in \`.github/dependabot.yml\` so freshly-published versions sit in the registry for at least **7 days** (14 for major bumps) before Dependabot will propose them.

This is the version-update analogue of \`uv\`'s \`--exclude-newer\` cutoff. The 2026-05-11 [TanStack supply-chain compromise](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) was deprecated within ~20 minutes of publish; a 7-day cooldown would have made PDV (and any project using this pattern) structurally immune to that class of attack.

- **Applies to**: \`github-actions\`, \`npm\` (electron/), \`pip\` (pdv-python/).
- **Per-tier**: \`semver-major-days: 14\`, \`semver-minor-days: 7\`, \`semver-patch-days: 7\`, \`default-days: 7\`.
- **Scope**: \`include: ["*"]\` — applies to every package in each ecosystem.

### What this does *not* affect

**Security updates** (the repo-settings toggle, not this file) intentionally bypass the cooldown. They patch a known-vulnerable version already present in the tree, so the right behavior is to land them immediately rather than wait.

### Cost

Routine patches reach \`develop\` ~1 week later than they otherwise would. For a scientific desktop app shipping signed binaries on tag pushes, this is a clearly favorable trade.

## Test plan

- [ ] YAML parses cleanly (\`python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"\` — verified locally).
- [ ] After merge, confirm Dependabot's next scheduled run honors the cooldown by checking that no version-update PR opens for a release published within the last 7 days. (Easiest to verify the following week.)
- [ ] N/A — \`pdv-python/scripts/sweep-deps.sh\` does not apply; no source or \`pyproject.toml\` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)