### PR TITLE
ci: trigger language jobs on workflow-only changes to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,16 @@ jobs:
           filters: |
             python:
               - 'pdv-python/**'
+              - '.github/workflows/ci.yml'
             electron:
               - 'electron/**'
+              - '.github/workflows/ci.yml'
             docs:
               - 'docs/**'
               - 'mkdocs.yml'
               - 'pdv-python/**'
               - '*.md'
+              - '.github/workflows/ci.yml'
 
   version-parity:
     name: Version parity


### PR DESCRIPTION
## Summary

Closes a gap surfaced by the first Dependabot wave (PRs #250–#254). The \`Detect changes\` job's paths-filter only set \`python=true\` for \`pdv-python/**\` and \`electron=true\` for \`electron/**\`, so a workflow-only PR like \"bump actions/setup-python from 5.6.0 to 6.2.0\" would skip the entire Python test matrix — exactly the job that should validate the bumped action. Every Action-bump PR was passing CI without actually running anything that exercised the new version.

Adding \`.github/workflows/ci.yml\` to the \`python\`, \`electron\`, and \`docs\` filter groups means any change to the CI workflow now runs the full matrix.

After this merges, \`@dependabot rebase\` on #250–#254 will produce real CI signal.

## Test plan

- [x] YAML parses cleanly (\`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"\` — verified locally).
- [x] This PR's own CI run executes the full matrix (Python tests, node-main-tests, renderer-tests, Playwright E2E, build, docs-build) — confirms the new filter rule fires.
- [ ] N/A — \`pdv-python/scripts/sweep-deps.sh\` does not apply; no source or \`pyproject.toml\` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)