### PR TITLE
ci: drop include:[*] from Dependabot cooldown blocks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,6 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 7
-      include:
-        - "*"
     groups:
       actions-minor-patch:
         update-types:
@@ -46,8 +44,6 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 7
-      include:
-        - "*"
     groups:
       npm-minor-patch:
         update-types:
@@ -64,8 +60,6 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 7
-      include:
-        - "*"
     groups:
       pip-minor-patch:
         update-types:


### PR DESCRIPTION
## Summary

Follow-up to #260. GitHub's Dependabot validator rejected the cooldown blocks I introduced — the failure surfaced as a red \`.github/dependabot.yml\` check on PR #246 (no error text, just the validator marking the file invalid).

The cause appears to be the \`include: [\"*\"]\` sub-key inside each cooldown block. Per the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference), \`include\`/\`exclude\` exist to **narrow** cooldown to specific dependency-name patterns. Omitting them — as in this PR — applies the cooldown to every package in the ecosystem, which is exactly the behavior we wanted in the first place.

### Why I'm only ~85% sure

The validator's failure annotation has no message text; I'm inferring the cause from the schema docs and the fact that \`include: [\"*\"]\` is the only unusual element in the block. If the check still fails after merge, the cause is somewhere else and we'll need to dig further — but this change is safe to merge regardless because it removes an extraneous key without changing intended behavior.

## Test plan

- [ ] YAML parses cleanly (\`python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"\` — verified locally).
- [ ] After merge, the \`.github/dependabot.yml\` check on the next-active open PR (e.g. #246) should report green. If it does, the diagnosis is confirmed.
- [ ] N/A — \`pdv-python/scripts/sweep-deps.sh\` does not apply; no source or \`pyproject.toml\` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)