### PR TITLE
ci: ignore Dependabot updates for anthropics/claude-code-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,12 @@ updates:
     # by Dependabot's validator for this ecosystem.
     cooldown:
       default-days: 7
+    # anthropics/claude-code-action is intentionally pinned to the
+    # floating @v1 tag (not a SHA) so first-party fixes from Anthropic
+    # reach us immediately without a Dependabot round-trip. Suppress
+    # the otherwise-routine "bump v1 → v1.x.y" PRs.
+    ignore:
+      - dependency-name: "anthropics/claude-code-action"
     groups:
       actions-minor-patch:
         update-types:


### PR DESCRIPTION
## Summary

Adds an \`ignore:\` block to the \`github-actions\` ecosystem in \`.github/dependabot.yml\` so Dependabot stops proposing version pins for \`anthropics/claude-code-action\`. That action is intentionally left on the floating \`@v1\` tag (introduced in #249) so first-party fixes from Anthropic reach the \`@claude\` workflow without a Dependabot round-trip.

Without this rule, Dependabot keeps opening PRs like #263 (\`v1\` → \`v1.0.112\`) on its weekly cadence. All other actions remain SHA-pinned and continue to be auto-bumped as normal.

After this merges, #263 can be closed.

## Test plan

- [ ] YAML parses cleanly (\`python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"\` — verified locally).
- [ ] After merge, confirm the \`.github/dependabot.yml\` validator check stays green (verifies the \`ignore\` block is accepted by Dependabot's schema).
- [ ] N/A — \`pdv-python/scripts/sweep-deps.sh\` does not apply; no source or \`pyproject.toml\` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)