### PR TITLE
ci: bump Node to 24 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           # Caches ~/.npm so npm fetch is hot on cache miss for the
           # node_modules cache below. Keyed automatically on
           # cache-dependency-path's hash.
@@ -152,7 +152,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           # Caches ~/.npm so npm fetch is hot on cache miss for the
           # node_modules cache below. Keyed automatically on
           # cache-dependency-path's hash.
@@ -209,7 +209,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           # Caches ~/.npm so npm fetch is hot on cache miss for the
           # node_modules cache below. Keyed automatically on
           # cache-dependency-path's hash.
@@ -257,7 +257,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           # Caches ~/.npm so npm fetch is hot on cache miss for the
           # node_modules cache below. Keyed automatically on
           # cache-dependency-path's hash.

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         working-directory: electron
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install rpm tooling
         run: sudo apt-get update && sudo apt-get install -y rpm


### PR DESCRIPTION
## Summary

Node 20 reached end-of-life on **2026-04-30** and is no longer receiving security patches. This PR bumps all six \`node-version:\` references across \`ci.yml\` and \`dist.yml\` to **Node 24** — the current Active LTS, supported through April 2028.

Scope is intentionally minimal — just the version field. No tooling or dependency changes.

### What this affects

- **Host Node**: the version that runs vitest, electron-builder, Playwright drivers, and other build tooling on CI runners. This is what's being bumped.
- **Electron's bundled Node**: unrelated. It's governed by the \`electron\` package version (currently \`^41.5.0\`) and is what the *built app* runs against at runtime.

### Follow-up: closes the @types/node 25 dilemma

PR #266 proposes \`@types/node@20 → 25\`, which is wildly mismatched with a Node 20 runtime. With this PR landed, the right \`@types/node\` bump is **24.x**, not 25. Recommended sequence:

1. Merge this PR.
2. Close #266.
3. Either let Dependabot's next weekly run propose \`@types/node@^24\`, or bump it manually in a small follow-up.

## Test plan

- [ ] YAML parses cleanly on both files (verified locally).
- [ ] CI runs on this PR exercise the full matrix on Node 24 — confirms vitest, electron-builder, and Playwright all work on the new runtime.
- [ ] After merge, watch the next release build (\`v*\` tag) to confirm \`dist.yml\` still produces working Mac/Linux artifacts under Node 24.
- [ ] N/A — \`pdv-python/scripts/sweep-deps.sh\` does not apply; no Python changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)