### PR TITLE
ci(vitest): serialize @slow test files to remove node-main-tests flake

### DIFF
--- a/electron/vitest.config.ts
+++ b/electron/vitest.config.ts
@@ -15,6 +15,13 @@ import { defineConfig, configDefaults } from "vitest/config";
  * when PYTHON_PATH is set in the environment — CI's node-main-tests job sets
  * this explicitly, and local devs can do the same once they have a Python
  * env with `pdv-python[dev]` installed.
+ *
+ * fileParallelism: disabled when @slow tests are active. Each @slow file
+ * spawns real ipykernel subprocesses (and integration.test.ts holds one for
+ * the duration of the describe block). Running them in parallel forks on a
+ * 2-core CI runner produces CPU contention severe enough that comm replies
+ * miss the CommRouter's 30s timeout — see the post-mutation pdv.tree.get
+ * stalls in node-main-tests. Fast tests still run in parallel locally.
  */
 const runSlow = !!process.env.PYTHON_PATH;
 
@@ -27,6 +34,7 @@ const slowFiles = [
 export default defineConfig({
   test: {
     pool: "forks",
+    fileParallelism: !runSlow,
     exclude: [
       ...configDefaults.exclude,
       // Playwright specs live under ./e2e and are not vitest tests.


### PR DESCRIPTION
## Summary
- Disable vitest `fileParallelism` when `PYTHON_PATH` is set (i.e. when the three @slow files run). Fast `npm test` runs are unchanged.

## Why
The `node-main-tests` job has been flaking with cascading 30 s `CommRouter` timeouts on `pdv.tree.get` (most recently #257 — cancelled after burning ~14 min on five timeouts in a row). Tracing the logs:

- `pdv.tree.list` returns in 14 ms (comm fully healthy)
- `pdv_tree['x'] = 42` execute returns cleanly
- the next `pdv.tree.get` never gets a reply and trips the 30 s timeout
- every subsequent integration test hangs on the 180 s test timeout, eventually the workflow's 15-minute ceiling cancels the job

The failing window overlaps with `kernel-manager.test.ts` running in a parallel fork and spawning ~20 ipykernel subprocesses. On the 2-core runner that's enough CPU contention to push comm-reply latency past 30 s. Serializing the three @slow files removes the contention without affecting fast-test latency for local devs.

This is the cheapest experiment that tells us whether the flake is contention vs. a real bug in the comm/debounce path — see the diagnosis discussion that produced this branch.

## Test plan
- [ ] `node-main-tests` passes on this PR
- [ ] re-run a couple of times to confirm it isn't just lucky
- [ ] local `npm test` (no PYTHON_PATH) still runs in parallel
- [ ] local `PYTHON_PATH=... npm test -- main/integration.test.ts main/kernel-manager.test.ts` passes serially

No `pdv-python/` changes, so the dependency sweep is not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)