### PR TITLE
fix: migrate tsconfig moduleResolution to node16 (#280)

### DIFF
--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "outDir": "dist",
     "rootDir": ".",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

Closes #280. Unblocks Dependabot PR #278 (TypeScript 5.9.3 → 6.0.3).

Migrates \`electron/tsconfig.json\` off the deprecated \`\"moduleResolution\": \"Node\"\` (legacy node10) — and the matching \`\"module\": \"CommonJS\"\` — to \`\"node16\"\` for both. TS 6.0 deprecates the legacy values; this change resolves the deprecation properly instead of silencing it.

## Why not Option A (\`ignoreDeprecations: \"6.0\"\`)?

The issue's recommended Option A was a one-line silence. In practice it has a chicken-and-egg problem: TS 5.9.3 rejects \`\"6.0\"\` as an invalid value for \`ignoreDeprecations\` (only \`\"5.0\"\` is accepted before TS 6.0 ships) — so the silence can't land on develop until after the TS 6.0 bump it's meant to unblock. Option B (this PR) actually resolves the deprecation and works on every TS version we care about.

\`\`\`
$ tsc -p tsconfig.json   # with \`\"ignoreDeprecations\": \"6.0\"\` on TS 5.9.3
tsconfig.json(12,27): error TS5103: Invalid value for '--ignoreDeprecations'.
\`\`\`

## Semantics

No behavior change for our setup:

- \`electron/package.json\` has no \`\"type\": \"module\"\`, so under \`module: \"node16\"\` all \`.ts\` files are still treated as CJS and \`tsc\` emits the same \`require()\` shape as \`module: \"CommonJS\"\`.
- No \`.cts\` / \`.mts\` files exist in the codebase.
- Bare relative imports (\`./foo\`) continue to resolve under CJS-via-node16.
- Renderer tsconfigs already use \`moduleResolution: \"bundler\"\` and are untouched.
- \`tsconfig.test.json\` extends \`tsconfig.json\`, so it picks up the change transparently.

## Test plan

- [x] \`npm run build:main\` — clean.
- [x] \`npm run build:e2e\` (renderer + main) — clean.
- [x] \`npm run typecheck\` — same **36 pre-existing errors** as on \`develop\`, **zero new errors** introduced. (All pre-existing errors are in \`*.test.ts\` files, which \`build:main\` excludes and which vitest transpiles via esbuild without typechecking — they're latent on develop. Tracking the cleanup as a follow-up.)
- [x] \`npm test\` — **429/429 tests pass across 41 files**.
- [ ] Dependency sweep — not applicable, no changes under \`pdv-python/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)