### PR TITLE
feat: add Clear recent projects button to splash screen (#191)

### DIFF
--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -329,6 +329,7 @@ const App: React.FC = () => {
   // doesn't re-subscribe on every kernelStatus change (handlers defined later).
   const handleOpenWithPickerRef = useRef<() => Promise<void>>();
   const handleOpenRecentRef = useRef<(path: string) => Promise<void>>();
+  const handleClearRecentsRef = useRef<() => void>();
   useEffect(() => {
     if (!window.pdv?.menu) return;
     const unsub = window.pdv.menu.onAction((payload) => {
@@ -363,10 +364,7 @@ const App: React.FC = () => {
           setForceWelcome(true);
         });
       } else if (payload.action === 'recentProjects:clear') {
-        void window.pdv.config.set({ recentProjects: [] }).then((updated) => {
-          if (updated) setConfig((prev) => (prev ? { ...prev, recentProjects: [] } : prev));
-        });
-        void window.pdv.menu.updateRecentProjects([]);
+        handleClearRecentsRef.current?.();
       }
     });
     return unsub;
@@ -1274,9 +1272,19 @@ const App: React.FC = () => {
     }
   }, [setLastError, refreshRecoverableSessions]);
 
+  // Shared between the WelcomeScreen "Clear" button and the native
+  // File → Clear Menu action (see the menuAction useEffect below).
+  const handleClearRecents = useCallback(() => {
+    void window.pdv.config.set({ recentProjects: [] }).then((updated) => {
+      if (updated) setConfig((prev) => (prev ? { ...prev, recentProjects: [] } : prev));
+    });
+    void window.pdv.menu.updateRecentProjects([]);
+  }, []);
+
   // Keep refs in sync so the menu-action effect (subscribed once) calls the latest handlers.
   handleOpenWithPickerRef.current = handleOpenWithPicker;
   handleOpenRecentRef.current = handleOpenRecent;
+  handleClearRecentsRef.current = handleClearRecents;
 
   // Execute deferred project action once the kernel becomes ready.
   useEffect(() => {
@@ -1726,6 +1734,7 @@ const App: React.FC = () => {
            onOpenRecent={handleOpenRecent}
            onRecoverSession={handleRecoverSession}
            onDiscardSession={handleDiscardSession}
+           onClearRecents={handleClearRecents}
          />
        )}
 

--- a/electron/renderer/src/components/WelcomeScreen/index.test.tsx
+++ b/electron/renderer/src/components/WelcomeScreen/index.test.tsx
@@ -36,25 +36,25 @@ function renderWelcome(overrides: Partial<Parameters<typeof WelcomeScreen>[0]> =
 describe('WelcomeScreen — Clear recents button (#191)', () => {
   it('renders the Clear button when there are recent projects', () => {
     renderWelcome();
-    expect(screen.getByRole('button', { name: 'Clear' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Clear recent projects list' })).toBeTruthy();
   });
 
   it('does not render the Clear button when there are no recent projects', () => {
     renderWelcome({ recentProjects: [] });
-    expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Clear recent projects list' })).toBeNull();
   });
 
   it('calls onClearRecents after the user confirms', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     const { onClearRecents } = renderWelcome();
-    await userEvent.setup().click(screen.getByRole('button', { name: 'Clear' }));
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Clear recent projects list' }));
     expect(onClearRecents).toHaveBeenCalledTimes(1);
   });
 
   it('does not call onClearRecents when the user cancels the confirm', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(false);
     const { onClearRecents } = renderWelcome();
-    await userEvent.setup().click(screen.getByRole('button', { name: 'Clear' }));
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Clear recent projects list' }));
     expect(onClearRecents).not.toHaveBeenCalled();
   });
 });

--- a/electron/renderer/src/components/WelcomeScreen/index.test.tsx
+++ b/electron/renderer/src/components/WelcomeScreen/index.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WelcomeScreen, type RecentProject } from './index';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderWelcome(overrides: Partial<Parameters<typeof WelcomeScreen>[0]> = {}) {
+  const recentProjects: RecentProject[] = overrides.recentProjects ?? [
+    { path: '/home/me/project-a', language: 'python', name: 'project-a' },
+  ];
+  const handlers = {
+    onNewProject: vi.fn(),
+    onOpenProject: vi.fn(),
+    onOpenRecent: vi.fn(),
+    onRecoverSession: vi.fn(),
+    onDiscardSession: vi.fn(),
+    onClearRecents: vi.fn(),
+  };
+  render(
+    <WelcomeScreen
+      recentProjects={recentProjects}
+      recoverableSessions={[]}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+  return handlers;
+}
+
+describe('WelcomeScreen — Clear recents button (#191)', () => {
+  it('renders the Clear button when there are recent projects', () => {
+    renderWelcome();
+    expect(screen.getByRole('button', { name: 'Clear' })).toBeTruthy();
+  });
+
+  it('does not render the Clear button when there are no recent projects', () => {
+    renderWelcome({ recentProjects: [] });
+    expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
+  });
+
+  it('calls onClearRecents after the user confirms', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const { onClearRecents } = renderWelcome();
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Clear' }));
+    expect(onClearRecents).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClearRecents when the user cancels the confirm', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const { onClearRecents } = renderWelcome();
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Clear' }));
+    expect(onClearRecents).not.toHaveBeenCalled();
+  });
+});

--- a/electron/renderer/src/components/WelcomeScreen/index.tsx
+++ b/electron/renderer/src/components/WelcomeScreen/index.tsx
@@ -42,6 +42,8 @@ interface WelcomeScreenProps {
   onRecoverSession: (orphanDir: string) => void;
   /** Called when the user clicks "Discard" on an orphan autosave. */
   onDiscardSession: (orphanDir: string) => void;
+  /** Called when the user clicks "Clear" beneath the recent-projects list. */
+  onClearRecents: () => void;
 }
 
 /** Short language badge for the recent projects list. */
@@ -85,12 +87,19 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
   onOpenRecent,
   onRecoverSession,
   onDiscardSession,
+  onClearRecents,
 }) => {
   const handleDiscard = (dir: string): void => {
     if (window.confirm(
       "Permanently discard this unsaved session? This cannot be undone.",
     )) {
       onDiscardSession(dir);
+    }
+  };
+
+  const handleClearRecents = (): void => {
+    if (window.confirm("Clear the list of recent projects? Your project files are not affected.")) {
+      onClearRecents();
     }
   };
 
@@ -187,7 +196,16 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
 
         {recentProjects.length > 0 && (
           <div className="welcome-recent">
-            <h2 className="welcome-recent-heading">Recent Projects</h2>
+            <div className="welcome-recent-header">
+              <h2 className="welcome-recent-heading">Recent Projects</h2>
+              <button
+                type="button"
+                className="welcome-recent-clear"
+                onClick={handleClearRecents}
+              >
+                Clear
+              </button>
+            </div>
             <ul className="welcome-recent-list">
               {recentProjects.map((entry) => (
                 <li key={entry.path}>

--- a/electron/renderer/src/components/WelcomeScreen/index.tsx
+++ b/electron/renderer/src/components/WelcomeScreen/index.tsx
@@ -202,6 +202,7 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
                 type="button"
                 className="welcome-recent-clear"
                 onClick={handleClearRecents}
+                aria-label="Clear recent projects list"
               >
                 Clear
               </button>

--- a/electron/renderer/src/styles/welcome.css
+++ b/electron/renderer/src/styles/welcome.css
@@ -68,13 +68,41 @@
   overflow-y: auto;
 }
 
+.welcome-recent-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
 .welcome-recent-heading {
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-secondary);
-  margin-bottom: 8px;
+}
+
+.welcome-recent-clear {
+  background: transparent;
+  border: none;
+  padding: 2px 4px;
+  font-size: 11px;
+  font-family: inherit;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: 3px;
+  transition: color 0.12s ease, background-color 0.12s ease;
+}
+
+.welcome-recent-clear:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+}
+
+.welcome-recent-clear:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
 }
 
 .welcome-recent-list {


### PR DESCRIPTION
## Summary

Closes #191. Adds a subtle **\"Clear\"** button in the Recent Projects header of the welcome/splash screen. When the recents list grows large the splash becomes cluttered; clicking the button prompts to confirm and empties the list. Project files are not affected.

## Implementation

- **WelcomeScreen** (\`electron/renderer/src/components/WelcomeScreen/index.tsx\`): new \`onClearRecents\` prop, a header row that pairs the section heading with the Clear button. The button only renders when \`recentProjects.length > 0\`. Confirmation dialog wording: \"Clear the list of recent projects? Your project files are not affected.\" (parity with the existing Discard-session dialog pattern.)
- **app/index.tsx**: extracted the existing inline \`recentProjects:clear\` menu-action branch into a shared \`handleClearRecents\` \`useCallback\`. Both the native File menu action and the new splash button now route through the same path (config update + native menu rebuild), so they can't drift. Wired via a ref to keep the menu-action \`useEffect\`'s subscribed-once invariant intact.
- **welcome.css**: new \`.welcome-recent-header\` flex container; new \`.welcome-recent-clear\` styling using theme tokens — \`var(--text-secondary)\` → \`var(--text-primary)\` on hover, \`var(--bg-hover)\` hover background, \`var(--accent)\` focus ring. No hardcoded colors.
- **No new IPC channels.** The infrastructure (\`config.set\` + \`menu.updateRecentProjects\`) already exists; this PR just adds a second consumer.

## Test plan

- [x] **New unit tests** in \`WelcomeScreen/index.test.tsx\` — 4 cases:
  - Renders the Clear button when recents are non-empty.
  - Hides the Clear button when recents are empty.
  - Calls \`onClearRecents\` after the user confirms.
  - Does **not** call \`onClearRecents\` when the user cancels.
- [x] \`npm test\` — **433/433 pass across 42 files** (was 429/41 on develop; +4 new tests).
- [x] \`npm run build:e2e\` (renderer Vite + main \`tsc\`) — clean.
- [ ] **Not run locally**: visual smoke in a live Electron window. The Playwright E2E job in CI will exercise the splash screen on the built app.
- [ ] Dependency sweep — N/A, no changes under \`pdv-python/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)