### PR TITLE
feat: MCP server Phase 2 — mutating/execution/cell tools

### DIFF
--- a/electron/main/app.ts
+++ b/electron/main/app.ts
@@ -23,6 +23,7 @@ import { ConfigStore } from "./config";
 import { registerIpcHandlers } from "./index";
 import { initializeAppMenu } from "./menu";
 import { IPC } from "./ipc";
+import type { CellRpcClient } from "./mcp/cell-rpc";
 import type { PdvMcpServer } from "./mcp/mcp-server";
 
 /**
@@ -330,11 +331,13 @@ export function clearQuitRequestPending(): void {
  *
  * @param getKernelManager - Lazy getter for the current kernel manager.
  * @param getMcpServer - Lazy getter for the MCP server, stopped on quit.
+ * @param getCellRpc - Lazy getter for the cell-RPC client, stopped on quit.
  * @returns Nothing.
  */
 export function wireAppEvents(
   getKernelManager: () => KernelManager | null,
-  getMcpServer: () => PdvMcpServer | null
+  getMcpServer: () => PdvMcpServer | null,
+  getCellRpc: () => CellRpcClient | null = () => null
 ): void {
   app.on("before-quit", () => {
     isQuittingGlobal = true;
@@ -355,8 +358,9 @@ export function wireAppEvents(
   // have completed, so save-on-quit can still reach the active kernel.
   app.on("will-quit", (event) => {
     // Stop the MCP server first — it is independent of kernel shutdown and
-    // closes its loopback socket quickly.
+    // closes its loopback socket quickly. Then detach the cell-RPC handler.
     void getMcpServer()?.stop();
+    getCellRpc()?.stop();
     const kernelManager = getKernelManager();
     const kernelCount = kernelManager
       ? Array.from((kernelManager as unknown as { kernels: Map<string, unknown> }).kernels?.keys() ?? []).length

--- a/electron/main/bootstrap.ts
+++ b/electron/main/bootstrap.ts
@@ -48,6 +48,7 @@ import * as fs from "fs";
 
 import { createWindow, wireAppEvents } from "./app";
 import { getMcpServerHooks } from "./index";
+import { CellRpcClient } from "./mcp/cell-rpc";
 import { PdvMcpServer } from "./mcp/mcp-server";
 import { CommRouter } from "./comm-router";
 import { QueryRouter } from "./query-router";
@@ -72,6 +73,7 @@ let mainWindow: BrowserWindow | null = null;
 let openingWindow: Promise<void> | null = null;
 let configStore: ConfigStore | null = null;
 let mcpServer: PdvMcpServer | null = null;
+let cellRpc: CellRpcClient | null = null;
 
 const commRouter = new CommRouter();
 const queryRouter = new QueryRouter();
@@ -114,6 +116,10 @@ async function openMainWindow(): Promise<void> {
     if (!mcpServer) {
       const hooks = getMcpServerHooks();
       if (hooks) {
+        if (!cellRpc) {
+          cellRpc = new CellRpcClient(() => mainWindow);
+          cellRpc.start();
+        }
         mcpServer = new PdvMcpServer({
           kernelManager: km,
           commRouter,
@@ -122,6 +128,8 @@ async function openMainWindow(): Promise<void> {
           configStore: cfg,
           hooks,
           appVersion: app.getVersion(),
+          cellRpc,
+          getRendererWindow: () => mainWindow,
         });
         try {
           await mcpServer.start();
@@ -148,7 +156,7 @@ const hasSingleInstanceLock = app.requestSingleInstanceLock();
 if (!hasSingleInstanceLock) {
   app.quit();
 } else {
-  wireAppEvents(() => kernelManager, () => mcpServer);
+  wireAppEvents(() => kernelManager, () => mcpServer, () => cellRpc);
   app.on("second-instance", () => {
     if (mainWindow && !mainWindow.isDestroyed()) {
       if (mainWindow.isMinimized()) {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -60,6 +60,11 @@ import {
 } from "./ipc";
 import { PDVMessage, PDVMessageType, setAppVersion } from "./pdv-protocol";
 import type { McpServerHooks } from "./mcp/mcp-context";
+import {
+  allocateAndRegisterLib,
+  allocateAndRegisterNote,
+  allocateAndRegisterScript,
+} from "./tree-create";
 
 // ---------------------------------------------------------------------------
 // Unified version — set once before any handler uses getAppVersion()
@@ -579,6 +584,21 @@ export function registerIpcHandlers(
     bindActiveProjectModules,
   });
 
+  // Aggregate module aliases from the active on-disk manifest plus any
+  // in-memory pending imports (the latter carries in-session modules
+  // created by modules:createEmpty before the first save). Both the tree
+  // create* IPC handlers and the MCP `create_tree_node` tool consume this
+  // to route module-owned files through the `<workdir>/<alias>/...` layout
+  // with `source_rel_path` set.
+  const getKnownModuleAliases = async (): Promise<Set<string>> => {
+    const manifest = await readActiveProjectManifest();
+    const disk = manifest?.modules ?? [];
+    return new Set([
+      ...disk.map((m) => m.alias),
+      ...pendingModuleImports.map((m) => m.alias),
+    ]);
+  };
+
   registerTreeNamespaceScriptIpcHandlers({
     kernelManager,
     commRouter,
@@ -586,19 +606,7 @@ export function registerIpcHandlers(
     projectManager,
     configStore,
     kernelWorkingDirs,
-    // Aggregate module aliases from the active on-disk manifest plus any
-    // in-memory pending imports (the latter carries in-session modules
-    // created by modules:createEmpty before the first save). The tree
-    // create* handlers use this to route module-owned files through the
-    // ``<workdir>/<alias>/...`` layout with source_rel_path set.
-    getKnownModuleAliases: async (): Promise<Set<string>> => {
-      const manifest = await readActiveProjectManifest();
-      const disk = manifest?.modules ?? [];
-      return new Set([
-        ...disk.map((m) => m.alias),
-        ...pendingModuleImports.map((m) => m.alias),
-      ]);
-    },
+    getKnownModuleAliases,
     readConfig,
     toNamespaceQueryPayload,
     toNamespaceInspectPayload,
@@ -946,11 +954,53 @@ export function registerIpcHandlers(
   }
 
   // Publish the lifecycle hooks the MCP server reads (ARCHITECTURE.md §15).
+  const treeCreateBaseDeps = {
+    kernelManager,
+    commRouter,
+    projectManager,
+    configStore,
+    kernelWorkingDirs,
+    readConfig,
+  };
   mcpServerHooks = {
     getActiveKernelId: () => activeKernelId,
     getActiveProjectDir: () => activeProjectDir,
+    getActiveWorkingDir: () =>
+      activeKernelId ? (kernelWorkingDirs.get(activeKernelId) ?? null) : null,
     getGeneration: () => generation,
     bumpGeneration,
+    treeCreate: {
+      script: (kernelId, parentPath, scriptName) =>
+        allocateAndRegisterScript(
+          {
+            ...treeCreateBaseDeps,
+            getKnownModuleAliases,
+            sanitizeScriptName,
+            ensureScriptFile,
+          },
+          kernelId,
+          parentPath,
+          scriptName,
+        ),
+      note: (kernelId, parentPath, noteName) =>
+        allocateAndRegisterNote(
+          treeCreateBaseDeps,
+          kernelId,
+          parentPath,
+          noteName,
+        ),
+      lib: (kernelId, parentPath, libName) =>
+        allocateAndRegisterLib(
+          {
+            ...treeCreateBaseDeps,
+            getKnownModuleAliases,
+            ensureLibFile,
+          },
+          kernelId,
+          parentPath,
+          libName,
+        ),
+    },
   };
 
   return resetSessionState;

--- a/electron/main/ipc-register-coverage.test.ts
+++ b/electron/main/ipc-register-coverage.test.ts
@@ -149,14 +149,16 @@ function listExpectedHandlerChannels(): string[] {
 
 /**
  * Channels that are NOT registered by any of the 7 `ipc-register-*` files —
- * instead they are registered inline in `electron/main/index.ts`, or, for
- * `mcp:getStatus`, by `PdvMcpServer.start()`. Track them here so the
- * meta-test only asserts on what the dedicated register functions own.
+ * instead they are registered inline in `electron/main/index.ts`, or by the
+ * MCP subsystem (`mcp:getStatus` by `PdvMcpServer.start()`, `cells:respond`
+ * by `CellRpcClient.start()`). Track them here so the meta-test only asserts
+ * on what the dedicated register functions own.
  */
 const CHANNELS_REGISTERED_IN_INDEX = [
   ...Object.values(IPC.autosave),
   ...Object.values(IPC.environment),
   ...Object.values(IPC.mcp),
+  ...Object.values(IPC.cells),
 ];
 
 function setupAll(): void {

--- a/electron/main/ipc-register-kernels.ts
+++ b/electron/main/ipc-register-kernels.ts
@@ -21,6 +21,7 @@ import { EnvironmentDetector } from "./environment-detector";
 import { IPC } from "./ipc";
 import { KernelManager, type KernelInfo } from "./kernel-manager";
 import { initializeKernelSession } from "./kernel-session";
+import { executeAndTranscribe, TranscriptWriter } from "./mcp/transcript";
 import type { ModuleManager } from "./module-manager";
 import { setupProjectModuleNamespaces } from "./module-runtime";
 import { copyFilesForLoad } from "./project-file-sync";
@@ -236,10 +237,15 @@ export function registerKernelIpcHandlers(
   });
 
   ipcMain.handle(IPC.kernels.execute, async (event, kernelId, request) => {
-    return kernelManager.execute(
-      kernelId as string,
+    const id = kernelId as string;
+    const workingDir = kernelWorkingDirs.get(id);
+    const transcript = workingDir ? new TranscriptWriter(workingDir) : null;
+    return executeAndTranscribe(
+      kernelManager.execute.bind(kernelManager),
+      transcript,
+      id,
       request as Parameters<KernelManager["execute"]>[1],
-      (chunk) => event.sender.send(IPC.push.executeOutput, chunk)
+      (chunk) => event.sender.send(IPC.push.executeOutput, chunk),
     );
   });
 

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -21,8 +21,14 @@ import type { QueryRouter } from "./query-router";
 import type { ConfigStore, PDVConfig } from "./config";
 import { IPC, type HandlerInvokeResult, type NamelistReadResult, type NamelistWriteResult, type NamespaceInspectResult, type NamespaceInspectTarget, type NamespaceInspectorNode, type NamespaceQueryOptions, type NamespaceVariable, type ScriptParameter, type ScriptRunRequest, type ScriptRunResult, type TreeAddFileResult, type TreeCreateGuiResult, type TreeCreateLibResult, type TreeCreateNodeResult, type TreeCreateNoteResult, type TreeCreateScriptResult, type TreeDuplicateResult, type TreeMoveResult, type TreeRenameResult } from "./ipc";
 import type { KernelManager } from "./kernel-manager";
+import { executeAndTranscribe, TranscriptWriter } from "./mcp/transcript";
 import { PDVMessageType, generateNodeUuid, resolveNodeDir, resolveNodePath, type PDVFileRegisterPayload } from "./pdv-protocol";
 import type { ProjectManager } from "./project-manager";
+import {
+  allocateAndRegisterNote,
+  allocateAndRegisterScript,
+  analyseModuleTarget,
+} from "./tree-create";
 
 interface RegisterTreeNamespaceScriptIpcHandlersOptions {
   kernelManager: KernelManager;
@@ -83,19 +89,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  *   Empty when the target equals the module root.
  * Returns ``null`` when ``targetPath`` is not inside any known module.
  */
-function analyseModuleTarget(
-  targetPath: string,
-  knownAliases: Set<string>,
-): { moduleAlias: string; sourceRelDir: string } | null {
-  const segments = targetPath.split(".").filter(Boolean);
-  if (segments.length === 0) return null;
-  const [alias, ...rest] = segments;
-  if (!knownAliases.has(alias)) return null;
-  return {
-    moduleAlias: alias,
-    sourceRelDir: rest.join("/"),
-  };
-}
+// `analyseModuleTarget` lives in `./tree-create` — imported above.
 
 function toNamespaceVariable(
   name: string,
@@ -261,50 +255,24 @@ export function registerTreeNamespaceScriptIpcHandlers(
       _event,
       kernelId: string,
       targetPath: string,
-      scriptName: string
-    ): Promise<TreeCreateScriptResult> => {
-      const kernel = kernelManager.getKernel(kernelId);
-      if (!kernel) {
-        throw new Error(`Kernel not found: ${kernelId}`);
-      }
-      const language = kernel.language;
-      let workingDir = kernelWorkingDirs.get(kernelId);
-      if (!workingDir) {
-        workingDir = await projectManager.createWorkingDir(readConfig(configStore).workingDirBase);
-        kernelWorkingDirs.set(kernelId, workingDir);
-      }
-      const safeName = sanitizeScriptName(scriptName, language);
-      const scriptNodeName = path.parse(safeName).name;
-
-      const knownAliases = await getKnownModuleAliases();
-      const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
-
-      const nodeUuid = generateNodeUuid();
-      const scriptPath = resolveNodePath(workingDir, nodeUuid, safeName);
-      await fs.mkdir(resolveNodeDir(workingDir, nodeUuid), { recursive: true });
-      await ensureScriptFile(scriptPath, language);
-
-      let sourceRelPath: string | undefined;
-      let moduleId: string | undefined;
-      if (moduleInfo) {
-        sourceRelPath = moduleInfo.sourceRelDir
-          ? `${moduleInfo.sourceRelDir}/${safeName}`
-          : safeName;
-        moduleId = moduleInfo.moduleAlias;
-      }
-
-      const treePath = targetPath ? `${targetPath}.${scriptNodeName}` : scriptNodeName;
-      await commRouter.request(PDVMessageType.SCRIPT_REGISTER, {
-        parent_path: targetPath,
-        name: scriptNodeName,
-        uuid: nodeUuid,
-        filename: safeName,
-        language,
-        module_id: moduleId,
-        source_rel_path: sourceRelPath,
-      });
-      return { success: true, scriptPath, treePath };
-    }
+      scriptName: string,
+    ): Promise<TreeCreateScriptResult> =>
+      allocateAndRegisterScript(
+        {
+          kernelManager,
+          commRouter,
+          projectManager,
+          configStore,
+          kernelWorkingDirs,
+          readConfig,
+          getKnownModuleAliases,
+          sanitizeScriptName,
+          ensureScriptFile,
+        },
+        kernelId,
+        targetPath,
+        scriptName,
+      ),
   );
 
   ipcMain.handle(
@@ -313,38 +281,21 @@ export function registerTreeNamespaceScriptIpcHandlers(
       _event,
       kernelId: string,
       targetPath: string,
-      noteName: string
-    ): Promise<TreeCreateNoteResult> => {
-      if (!kernelManager.getKernel(kernelId)) {
-        throw new Error(`Kernel not found: ${kernelId}`);
-      }
-      let workingDir = kernelWorkingDirs.get(kernelId);
-      if (!workingDir) {
-        workingDir = await projectManager.createWorkingDir(readConfig(configStore).workingDirBase);
-        kernelWorkingDirs.set(kernelId, workingDir);
-      }
-      const safeName = noteName.trim().replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_-]/g, "");
-      const nodeUuid = generateNodeUuid();
-      const noteFilename = safeName + ".md";
-      const notePath = resolveNodePath(workingDir, nodeUuid, noteFilename);
-      await fs.mkdir(resolveNodeDir(workingDir, nodeUuid), { recursive: true });
-
-      // Create the .md file if it doesn't exist
-      try {
-        await fs.access(notePath);
-      } catch {
-        await fs.writeFile(notePath, "", "utf-8");
-      }
-
-      const treePath = targetPath ? `${targetPath}.${safeName}` : safeName;
-      await commRouter.request(PDVMessageType.NOTE_REGISTER, {
-        parent_path: targetPath,
-        name: safeName,
-        uuid: nodeUuid,
-        filename: noteFilename,
-      });
-      return { success: true, notePath, treePath };
-    }
+      noteName: string,
+    ): Promise<TreeCreateNoteResult> =>
+      allocateAndRegisterNote(
+        {
+          kernelManager,
+          commRouter,
+          projectManager,
+          configStore,
+          kernelWorkingDirs,
+          readConfig,
+        },
+        kernelId,
+        targetPath,
+        noteName,
+      ),
   );
 
   ipcMain.handle(
@@ -617,7 +568,14 @@ export function registerTreeNamespaceScriptIpcHandlers(
         : `pdv_tree[${JSON.stringify(treePath)}].run()`;
     }
 
-    const result = await kernelManager.execute(kernelId, { code, executionId, origin });
+    const workingDir = kernelWorkingDirs.get(kernelId);
+    const transcript = workingDir ? new TranscriptWriter(workingDir) : null;
+    const result = await executeAndTranscribe(
+      kernelManager.execute.bind(kernelManager),
+      transcript,
+      kernelId,
+      { code, executionId, origin },
+    );
     return { code, executionId, origin, result };
   });
 

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -201,6 +201,15 @@ export const IPC = {
     load: "codeCells:load",
     save: "codeCells:save",
   },
+  /**
+   * Code-cell round-trip channels used by the MCP cell tools (ARCHITECTURE.md
+   * §15.8). Cells live only in renderer React state, so the main process
+   * asks the renderer to report on (or accept writes to) its live cell tabs.
+   */
+  cells: {
+    /** Renderer's reply for a {@link IPCPushChannels.cellsRequest} push. */
+    respond: "cells:respond",
+  },
   /** Main → renderer push channels forwarded from CommRouter push messages. */
   push: {
     treeChanged: "pdv.tree.changed",
@@ -248,6 +257,31 @@ export const IPC = {
      */
     autosaveStarted: "pdv.autosave.started",
     autosaveEnded: "pdv.autosave.ended",
+    /**
+     * Main → renderer. Request the renderer to report on its live code-cell
+     * state (list / read). Used by the MCP `cell_list` / `cell_read` tools.
+     * The renderer replies on {@link IPCChannels.cells.respond}.
+     */
+    cellsRequest: "pdv.cells.request",
+    /**
+     * Main → renderer, one-way. Apply an update to the renderer's code-cell
+     * tabs. Used by the MCP `cell_write` tool.
+     */
+    cellWrite: "pdv.cells.write",
+    /**
+     * Main → renderer. Fired immediately before a main-initiated kernel
+     * execution starts (e.g. an MCP agent tool run). Lets the renderer seed
+     * a Console log entry so subsequent `executeOutput` chunks have a row
+     * to attach to. The renderer's own `kernels.execute` invocations seed
+     * their log entry locally and do not emit this push.
+     */
+    executeBegin: "pdv.execute.begin",
+    /**
+     * Main → renderer. Companion to {@link executeBegin} — fired after the
+     * run resolves so the renderer can finalize the seeded log entry with
+     * duration / error info that does not arrive via streaming chunks.
+     */
+    executeFinish: "pdv.execute.finish",
   },
   /** App-level lifecycle channels (close confirmation, etc.). */
   app: {
@@ -1417,6 +1451,103 @@ export interface McpStatus {
   generation: number;
 }
 
+/**
+ * Push payload for {@link IPCPushChannels.cellsRequest} — a main → renderer
+ * RPC for read-side access to renderer-owned code-cell state.
+ * The renderer answers on {@link IPCChannels.cells.respond} keyed by `requestId`.
+ */
+export interface CellsRequestPush {
+  /** Correlates this request with its response. */
+  requestId: string;
+  /** Which renderer operation to perform. */
+  op: "list" | "read";
+  /**
+   * Required for `op === "read"`. The id of the cell tab whose code is wanted.
+   */
+  tabId?: number;
+}
+
+/** One tab entry returned by `cell_list`. */
+export interface CellListEntry {
+  id: number;
+  name?: string;
+  /** Number of characters in the cell's source (cheap size hint). */
+  length: number;
+}
+
+/** Result body for `op === "list"`. */
+export interface CellListResult {
+  tabs: CellListEntry[];
+  activeTabId: number | null;
+}
+
+/** Result body for `op === "read"`. */
+export interface CellReadResult {
+  id: number;
+  name?: string;
+  code: string;
+}
+
+/** Renderer's reply to a {@link CellsRequestPush}, sent via `cells.respond`. */
+export interface CellsResponse {
+  /** Matches the request's `requestId`. */
+  requestId: string;
+  /** Whether the renderer successfully fulfilled the op. */
+  ok: boolean;
+  /** Operation-specific result body (absent on error). */
+  result?: CellListResult | CellReadResult;
+  /** Human-readable error message when `ok === false`. */
+  error?: string;
+}
+
+/**
+ * Push payload for {@link IPCPushChannels.cellWrite} — one-way main → renderer
+ * update used by the MCP `cell_write` tool. The renderer applies it directly
+ * to its tab state.
+ */
+/**
+ * Push payload for {@link IPCPushChannels.executeBegin}: a main-initiated run
+ * is about to start. The renderer seeds a Console log entry keyed by
+ * `executionId` so streamed `executeOutput` chunks have a row to attach to.
+ */
+export interface ExecuteBeginPayload {
+  /** Correlates with the chunks pushed on `executeOutput`. */
+  executionId: string;
+  /** Source code being executed (so the log entry can render it). */
+  code: string;
+  /** Origin metadata (kind, agentTool, scriptPath, etc.). */
+  origin: import("./kernel-manager").KernelExecutionOrigin;
+  /** Wall-clock start time (ms since epoch). */
+  timestamp: number;
+}
+
+/**
+ * Push payload for {@link IPCPushChannels.executeFinish}: a main-initiated run
+ * has resolved. Carries the final duration and any error so the renderer can
+ * finalize the seeded log entry.
+ */
+export interface ExecuteFinishPayload {
+  executionId: string;
+  /** Duration in milliseconds. */
+  duration: number;
+  /** Error string when the run failed. */
+  error?: string;
+  /** Structured error details, when available. */
+  errorDetails?: import("./kernel-manager").KernelExecutionError;
+}
+
+export interface CellWritePush {
+  /**
+   * Existing tab id to update. When omitted (or when no tab has this id), a
+   * new tab is appended; the new tab's id is allocated by the renderer.
+   */
+  tabId?: number;
+  /** New source code for the cell. */
+  code: string;
+  /** Optional tab display name. */
+  name?: string;
+}
+
 export interface PDVApi {
   /** Kernel lifecycle and execution methods. */
   kernels: {
@@ -1509,6 +1640,26 @@ export interface PDVApi {
      * @returns Unsubscribe function.
      */
     onOutput(callback: (chunk: ExecuteOutputChunk) => void): () => void;
+    /**
+     * Subscribe to "execution starting" pushes from the main process. Fires
+     * for main-initiated runs (e.g. MCP agent tools) immediately before the
+     * first output chunk; the renderer should seed a Console log entry keyed
+     * by `executionId`. The renderer's own `kernels.execute` calls do not
+     * emit this push — they seed their log entry locally.
+     *
+     * @param callback - Receives the begin payload.
+     * @returns Unsubscribe function.
+     */
+    onExecuteBegin(callback: (payload: ExecuteBeginPayload) => void): () => void;
+    /**
+     * Subscribe to "execution finished" pushes from the main process.
+     * Companion to {@link onExecuteBegin}; carries duration + error info
+     * that does not arrive via streaming chunks.
+     *
+     * @param callback - Receives the finish payload.
+     * @returns Unsubscribe function.
+     */
+    onExecuteFinish(callback: (payload: ExecuteFinishPayload) => void): () => void;
     /**
      * Subscribe to kernel crash push notifications. Fires only when the
      * kernel subprocess exits unexpectedly.
@@ -2127,6 +2278,37 @@ export interface PDVApi {
      * @returns Unsubscribe function.
      */
     onInFlightChange(callback: (inFlight: boolean) => void): () => void;
+  };
+
+  /**
+   * Code-cell round-trip used by the MCP cell tools (ARCHITECTURE.md §15.8).
+   * Cells live only in renderer state, so the main process pushes a request
+   * and the renderer replies; for writes, the main process pushes one-way
+   * and the renderer applies the update.
+   */
+  cells: {
+    /**
+     * Subscribe to cell read requests pushed from the main process. The
+     * renderer should answer by invoking {@link respond} with the matching
+     * `requestId`.
+     *
+     * @param callback - Receives the request payload.
+     * @returns Unsubscribe function.
+     */
+    onRequest(callback: (req: CellsRequestPush) => void): () => void;
+    /**
+     * Subscribe to one-way cell-write pushes from the main process.
+     *
+     * @param callback - Applies the write to the renderer's cell tabs.
+     * @returns Unsubscribe function.
+     */
+    onWrite(callback: (write: CellWritePush) => void): () => void;
+    /**
+     * Reply to a previously-received {@link CellsRequestPush}.
+     *
+     * @param response - The response, carrying the request's `requestId`.
+     */
+    respond(response: CellsResponse): Promise<void>;
   };
 
   /** App info accessors. */

--- a/electron/main/kernel-error-parser.ts
+++ b/electron/main/kernel-error-parser.ts
@@ -261,6 +261,12 @@ function formatExecutionSource(source: KernelExecutionOrigin | undefined): strin
   if (source.kind === "tree-script") {
     return label ? `Script "${label}"` : "Script";
   }
+  if (source.kind === "agent") {
+    const tool = source.agentTool;
+    if (tool && label) return `Agent ${tool} "${label}"`;
+    if (tool) return `Agent ${tool}`;
+    return label ? `Agent "${label}"` : "Agent";
+  }
   return label ? `Execution "${label}"` : "Execution";
 }
 

--- a/electron/main/kernel-manager.ts
+++ b/electron/main/kernel-manager.ts
@@ -66,13 +66,19 @@ export interface KernelInfo {
 /** Input to KernelManager.execute(). */
 export interface KernelExecutionOrigin {
   /** High-level execution source category. */
-  kind: "code-cell" | "tree-script" | "unknown";
+  kind: "code-cell" | "tree-script" | "agent" | "unknown";
   /** Human-readable source label (for example tab name or script path). */
   label?: string;
   /** Optional code-cell tab id when `kind === "code-cell"`. */
   tabId?: number;
   /** Optional script path when `kind === "tree-script"`. */
   scriptPath?: string;
+  /**
+   * Optional MCP tool name when `kind === "agent"` (e.g. `"pdv_run"`,
+   * `"script_run"`, `"cell_run"`). Used by the transcript writer and
+   * the Console's agent-styled labels (ARCHITECTURE.md §15.7, §15.9).
+   */
+  agentTool?: string;
 }
 
 /** Structured execution error details derived from iopub `error` payloads. */

--- a/electron/main/mcp/cell-rpc.test.ts
+++ b/electron/main/mcp/cell-rpc.test.ts
@@ -1,0 +1,174 @@
+/**
+ * cell-rpc.test.ts — Unit tests for the main-side cell-state RPC client.
+ *
+ * Verifies the request/response/timeout shape of the renderer round-trip used
+ * by the MCP cell tools (ARCHITECTURE.md §15.8) without spinning up a real
+ * BrowserWindow — the WebContents `send` is stubbed.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ipcRegistry = vi.hoisted(() => ({
+  handlers: new Map<
+    string,
+    (event: unknown, ...args: unknown[]) => unknown
+  >(),
+  handle: vi.fn(
+    (channel: string, handler: (event: unknown, ...args: unknown[]) => unknown) => {
+      ipcRegistry.handlers.set(channel, handler);
+    },
+  ),
+  removeHandler: vi.fn((channel: string) => ipcRegistry.handlers.delete(channel)),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: ipcRegistry.handle,
+    removeHandler: ipcRegistry.removeHandler,
+  },
+}));
+
+import type { BrowserWindow } from "electron";
+
+import { IPC } from "../ipc";
+import { CellRpcClient } from "./cell-rpc";
+
+interface FakeWindowState {
+  sent: Array<{ channel: string; payload: unknown }>;
+  win: BrowserWindow;
+}
+
+/** Build a stub BrowserWindow whose `webContents.send` records all calls. */
+function makeFakeWindow(): FakeWindowState {
+  const sent: FakeWindowState["sent"] = [];
+  const win = {
+    webContents: {
+      send: (channel: string, payload: unknown) => {
+        sent.push({ channel, payload });
+      },
+    },
+  } as unknown as BrowserWindow;
+  return { sent, win };
+}
+
+/** Synchronously invoke the registered `cells:respond` handler. */
+function invokeRespond(payload: unknown): void {
+  const handler = ipcRegistry.handlers.get(IPC.cells.respond);
+  if (!handler) throw new Error("cells:respond handler not registered");
+  handler({}, payload);
+}
+
+describe("CellRpcClient", () => {
+  afterEach(() => {
+    ipcRegistry.handlers.clear();
+    vi.clearAllMocks();
+  });
+
+  it("registers an `ipcMain.handle` on start and removes it on stop", () => {
+    const { win } = makeFakeWindow();
+    const client = new CellRpcClient(() => win);
+    client.start();
+    expect(ipcRegistry.handle).toHaveBeenCalledWith(
+      IPC.cells.respond,
+      expect.any(Function),
+    );
+    client.stop();
+    expect(ipcRegistry.removeHandler).toHaveBeenCalledWith(IPC.cells.respond);
+  });
+
+  it("list() pushes a request and resolves on the matching response", async () => {
+    const { sent, win } = makeFakeWindow();
+    const client = new CellRpcClient(() => win);
+    client.start();
+
+    const promise = client.list();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].channel).toBe(IPC.push.cellsRequest);
+    const req = sent[0].payload as { requestId: string; op: string };
+    expect(req.op).toBe("list");
+    expect(typeof req.requestId).toBe("string");
+
+    invokeRespond({
+      requestId: req.requestId,
+      ok: true,
+      result: { tabs: [{ id: 1, length: 5 }], activeTabId: 1 },
+    });
+
+    const result = await promise;
+    expect(result.tabs).toHaveLength(1);
+    expect(result.activeTabId).toBe(1);
+    client.stop();
+  });
+
+  it("read(tabId) pushes a read request and resolves on the matching response", async () => {
+    const { sent, win } = makeFakeWindow();
+    const client = new CellRpcClient(() => win);
+    client.start();
+
+    const promise = client.read(7);
+    const req = sent[0].payload as { requestId: string; op: string; tabId?: number };
+    expect(req.op).toBe("read");
+    expect(req.tabId).toBe(7);
+
+    invokeRespond({
+      requestId: req.requestId,
+      ok: true,
+      result: { id: 7, code: "print('hi')" },
+    });
+
+    const result = await promise;
+    expect(result.id).toBe(7);
+    expect(result.code).toBe("print('hi')");
+    client.stop();
+  });
+
+  it("rejects when the renderer reports `ok: false`", async () => {
+    const { sent, win } = makeFakeWindow();
+    const client = new CellRpcClient(() => win);
+    client.start();
+
+    const promise = client.read(99);
+    const req = sent[0].payload as { requestId: string };
+    invokeRespond({ requestId: req.requestId, ok: false, error: "No tab 99" });
+
+    await expect(promise).rejects.toThrow(/No tab 99/);
+    client.stop();
+  });
+
+  it("write(payload) is one-way (no response awaited)", () => {
+    const { sent, win } = makeFakeWindow();
+    const client = new CellRpcClient(() => win);
+    client.start();
+    client.write({ tabId: 2, code: "x = 1" });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].channel).toBe(IPC.push.cellWrite);
+    expect(sent[0].payload).toEqual({ tabId: 2, code: "x = 1" });
+    client.stop();
+  });
+
+  it("rejects late after the configured timeout and does not leak pending state", async () => {
+    vi.useFakeTimers();
+    try {
+      const { win } = makeFakeWindow();
+      const client = new CellRpcClient(() => win);
+      client.start();
+      const promise = client.list();
+      promise.catch(() => undefined); // prevent unhandled-rejection during fast-forward
+      vi.advanceTimersByTime(11_000);
+      await expect(promise).rejects.toThrow(/timed out/);
+      client.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throws synchronously when no renderer window is available", async () => {
+    const client = new CellRpcClient(() => null);
+    client.start();
+    await expect(client.list()).rejects.toThrow(/no renderer window/);
+    expect(() => client.write({ tabId: 1, code: "x" })).toThrow(
+      /no renderer window/,
+    );
+    client.stop();
+  });
+});

--- a/electron/main/mcp/cell-rpc.ts
+++ b/electron/main/mcp/cell-rpc.ts
@@ -1,0 +1,167 @@
+/**
+ * cell-rpc.ts — Main-side RPC client for the renderer's code-cell state.
+ *
+ * Code cells live only in the renderer's React state (ARCHITECTURE.md §15.8).
+ * The MCP cell tools therefore use a request/response pattern: main pushes a
+ * request to the renderer, the renderer answers via `cells:respond` keyed by
+ * the request id. One-way pushes apply writes.
+ *
+ * Responsibilities
+ * - Owns the `ipcMain.handle(IPC.cells.respond)` handler — the renderer's
+ *   reply lands here and resolves the matching pending promise.
+ * - Provides typed `list()` / `read(tabId)` / `write(payload)` methods for
+ *   tool code that does not want to think about request ids or timeouts.
+ *
+ * What it does NOT do
+ * - It is not an MCP tool itself; it is a helper consumed by the cell tools
+ *   in `tools/execution.ts` (Phase 2).
+ * - It does not interpret cell content beyond the renderer-shape types.
+ *
+ * See Also
+ * --------
+ * ARCHITECTURE.md §15.8 — Renderer Interaction
+ */
+
+import { BrowserWindow, ipcMain } from "electron";
+
+import { randomUUID } from "node:crypto";
+
+import {
+  type CellListResult,
+  type CellReadResult,
+  type CellWritePush,
+  type CellsResponse,
+  IPC,
+} from "../ipc";
+
+/** How long a cell request waits before failing if the renderer never replies. */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+interface PendingRequest {
+  resolve: (result: CellListResult | CellReadResult) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+/**
+ * Bridges main-process callers (the MCP cell tools) to renderer code-cell state.
+ *
+ * The client is window-bound — it sends pushes via the supplied BrowserWindow
+ * accessor and matches responses back to pending requests by `requestId`. Call
+ * {@link start} once at app boot to register the IPC handler; call {@link stop}
+ * during shutdown so the handler is detached cleanly.
+ */
+export class CellRpcClient {
+  private readonly getWindow: () => BrowserWindow | null;
+  private readonly pending = new Map<string, PendingRequest>();
+  private started = false;
+
+  /**
+   * @param getWindow - Accessor for the renderer window that owns the cell
+   *   tabs. Returns `null` when no window is open — calls in that state are
+   *   rejected rather than throwing synchronously.
+   */
+  constructor(getWindow: () => BrowserWindow | null) {
+    this.getWindow = getWindow;
+  }
+
+  /**
+   * Register the `cells:respond` IPC handler. Idempotent.
+   *
+   * @returns Nothing.
+   */
+  start(): void {
+    if (this.started) return;
+    ipcMain.handle(IPC.cells.respond, (_event, response: CellsResponse) => {
+      this.deliver(response);
+    });
+    this.started = true;
+  }
+
+  /**
+   * Detach the IPC handler and reject any in-flight requests.
+   *
+   * @returns Nothing.
+   */
+  stop(): void {
+    if (!this.started) return;
+    ipcMain.removeHandler(IPC.cells.respond);
+    this.started = false;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("Cell RPC client stopped"));
+    }
+    this.pending.clear();
+  }
+
+  /**
+   * Ask the renderer for the current list of cell tabs.
+   *
+   * @returns Tabs + active-tab metadata.
+   * @throws {Error} When the renderer is unreachable or does not reply.
+   */
+  async list(): Promise<CellListResult> {
+    return (await this.request({ op: "list" })) as CellListResult;
+  }
+
+  /**
+   * Ask the renderer for one cell tab's full source.
+   *
+   * @param tabId - The cell tab id.
+   * @returns The tab's id, optional name, and source code.
+   * @throws {Error} When no tab matches or the renderer does not reply.
+   */
+  async read(tabId: number): Promise<CellReadResult> {
+    return (await this.request({ op: "read", tabId })) as CellReadResult;
+  }
+
+  /**
+   * One-way: update a cell tab's source (or append a new tab).
+   *
+   * @param payload - The write payload.
+   * @returns Nothing.
+   * @throws {Error} When no renderer window is available.
+   */
+  write(payload: CellWritePush): void {
+    const win = this.getWindow();
+    if (!win) {
+      throw new Error("Cell write failed: no renderer window");
+    }
+    win.webContents.send(IPC.push.cellWrite, payload);
+  }
+
+  private async request(
+    body: { op: "list" | "read"; tabId?: number },
+  ): Promise<CellListResult | CellReadResult> {
+    const win = this.getWindow();
+    if (!win) {
+      throw new Error(`Cell ${body.op} failed: no renderer window`);
+    }
+    return new Promise<CellListResult | CellReadResult>((resolve, reject) => {
+      const requestId = randomUUID();
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(
+          new Error(
+            `Cell ${body.op} timed out after ${DEFAULT_TIMEOUT_MS}ms ` +
+              `(renderer did not reply)`,
+          ),
+        );
+      }, DEFAULT_TIMEOUT_MS);
+      this.pending.set(requestId, { resolve, reject, timer });
+      win.webContents.send(IPC.push.cellsRequest, { requestId, ...body });
+    });
+  }
+
+  private deliver(response: CellsResponse): void {
+    const pending = this.pending.get(response.requestId);
+    if (!pending) return; // late reply after timeout — drop silently
+    this.pending.delete(response.requestId);
+    clearTimeout(pending.timer);
+    if (response.ok && response.result) {
+      pending.resolve(response.result);
+    } else {
+      pending.reject(new Error(response.error ?? "Cell request failed"));
+    }
+  }
+}

--- a/electron/main/mcp/mcp-context.ts
+++ b/electron/main/mcp/mcp-context.ts
@@ -14,11 +14,19 @@
  * mcp-server.ts — constructs the context and owns the session registry
  */
 
+import type { BrowserWindow } from "electron";
+
 import type { CommRouter } from "../comm-router";
 import type { ConfigStore } from "../config";
+import type {
+  TreeCreateLibResult,
+  TreeCreateNoteResult,
+  TreeCreateScriptResult,
+} from "../ipc";
 import type { KernelManager } from "../kernel-manager";
 import type { ProjectManager } from "../project-manager";
 import type { QueryRouter } from "../query-router";
+import type { CellRpcClient } from "./cell-rpc";
 
 /**
  * Lifecycle accessors the MCP server needs from the IPC-handler closure in
@@ -30,6 +38,12 @@ export interface McpServerHooks {
   getActiveKernelId(): string | null;
   /** Absolute save directory of the active project, or `null` when none is open. */
   getActiveProjectDir(): string | null;
+  /**
+   * Kernel working directory for the active kernel, or `null` when no kernel
+   * has been started yet. Used by execution tools to construct the per-run
+   * `TranscriptWriter` (ARCHITECTURE.md §15.7).
+   */
+  getActiveWorkingDir(): string | null;
   /** Current project/kernel generation counter (ARCHITECTURE.md §15.3). */
   getGeneration(): number;
   /**
@@ -37,6 +51,32 @@ export interface McpServerHooks {
    * kernel, or environment changes so connected MCP sessions become stale.
    */
   bumpGeneration(): void;
+  /**
+   * Pre-bound helpers for file-backed tree-node creation. Implementations
+   * live in `index.ts` so they can close over the kernel working-dir map and
+   * the project's module aliases; the MCP `create_tree_node` tool calls them
+   * via the hooks without needing to know any of that wiring.
+   */
+  treeCreate: {
+    /** Allocate a UUID-backed script file and register it with the kernel. */
+    script(
+      kernelId: string,
+      parentPath: string,
+      scriptName: string,
+    ): Promise<TreeCreateScriptResult>;
+    /** Allocate a UUID-backed Markdown note and register it with the kernel. */
+    note(
+      kernelId: string,
+      parentPath: string,
+      noteName: string,
+    ): Promise<TreeCreateNoteResult>;
+    /** Allocate a UUID-backed importable lib file and register it with the kernel. */
+    lib(
+      kernelId: string,
+      parentPath: string,
+      libName: string,
+    ): Promise<TreeCreateLibResult>;
+  };
 }
 
 /**
@@ -59,6 +99,19 @@ export interface McpToolContext {
   hooks: McpServerHooks;
   /** App version string (`app.getVersion()`), surfaced by `project_info`. */
   appVersion: string;
+  /**
+   * Renderer code-cell RPC client (ARCHITECTURE.md §15.8). Used by the MCP
+   * cell tools to read and write the renderer's live cell tabs.
+   */
+  cellRpc: CellRpcClient;
+  /**
+   * Accessor for the renderer window an agent run's output should stream
+   * into. Returns `null` when no window is open. Used by execution tools to
+   * forward iopub chunks to the Console via `IPC.push.executeOutput` so
+   * agent-initiated runs are visible alongside user runs (ARCHITECTURE.md
+   * §15.9).
+   */
+  getRendererWindow(): BrowserWindow | null;
   /**
    * Generation a given MCP session connected at, or `undefined` for an
    * unknown session. Used by tools to reject calls from a session that

--- a/electron/main/mcp/mcp-server.test.ts
+++ b/electron/main/mcp/mcp-server.test.ts
@@ -25,8 +25,14 @@ function makeHooks(generation = 0): McpServerHooks {
   return {
     getActiveKernelId: () => null,
     getActiveProjectDir: () => null,
+    getActiveWorkingDir: () => null,
     getGeneration: () => generation,
     bumpGeneration: () => undefined,
+    treeCreate: {
+      script: () => Promise.reject(new Error("not implemented in tests")),
+      note: () => Promise.reject(new Error("not implemented in tests")),
+      lib: () => Promise.reject(new Error("not implemented in tests")),
+    },
   };
 }
 
@@ -61,6 +67,8 @@ function makeDeps(
     configStore,
     hooks: makeHooks(),
     appVersion: "0.0.0-test",
+    cellRpc: {} as PdvMcpServerDeps["cellRpc"],
+    getRendererWindow: () => null,
   };
 }
 

--- a/electron/main/mcp/mcp-server.test.ts
+++ b/electron/main/mcp/mcp-server.test.ts
@@ -196,6 +196,8 @@ describe("assertCurrentGeneration", () => {
       configStore: {} as McpToolContext["configStore"],
       hooks: makeHooks(currentGen),
       appVersion: "0.0.0-test",
+      cellRpc: {} as McpToolContext["cellRpc"],
+      getRendererWindow: () => null,
       getSessionGeneration: () => sessionGen,
     };
   }

--- a/electron/main/mcp/mcp-server.ts
+++ b/electron/main/mcp/mcp-server.ts
@@ -38,6 +38,7 @@ import { IPC, type McpStatus } from "../ipc";
 import type { KernelManager } from "../kernel-manager";
 import type { ProjectManager } from "../project-manager";
 import type { QueryRouter } from "../query-router";
+import type { CellRpcClient } from "./cell-rpc";
 import { generateBearerToken, requestHasValidToken } from "./mcp-auth";
 import type { McpServerHooks, McpToolContext } from "./mcp-context";
 import { MCP_INSTRUCTIONS } from "./mcp-instructions";
@@ -65,6 +66,10 @@ export interface PdvMcpServerDeps {
   hooks: McpServerHooks;
   /** App version string (`app.getVersion()`). */
   appVersion: string;
+  /** Renderer cell-state RPC client (ARCHITECTURE.md §15.8). */
+  cellRpc: CellRpcClient;
+  /** Accessor for the renderer window agent runs stream output to. */
+  getRendererWindow: () => import("electron").BrowserWindow | null;
 }
 
 /** One connected MCP client session. */
@@ -105,6 +110,8 @@ export class PdvMcpServer {
       configStore: deps.configStore,
       hooks: deps.hooks,
       appVersion: deps.appVersion,
+      cellRpc: deps.cellRpc,
+      getRendererWindow: deps.getRendererWindow,
       getSessionGeneration: (sessionId) =>
         sessionId ? this.sessions.get(sessionId)?.generation : undefined,
     };

--- a/electron/main/mcp/tools/_helpers.test.ts
+++ b/electron/main/mcp/tools/_helpers.test.ts
@@ -1,0 +1,71 @@
+/**
+ * tools/_helpers.test.ts — Unit tests for the mutating-tier gate helpers
+ * (`assertMutatingToolsEnabled` / `assertPdvRunEnabled`) and the related
+ * `requireKernel` shape implicit in `kernelMutate`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { McpToolContext } from "../mcp-context";
+import {
+  assertMutatingToolsEnabled,
+  assertPdvRunEnabled,
+} from "./_helpers";
+
+/** Minimal context exposing only the configStore needed by the gate helpers. */
+function makeCtx(mcp: Record<string, unknown> | undefined): McpToolContext {
+  return {
+    configStore: {
+      get: (key: string) => (key === "mcp" ? mcp : undefined),
+    },
+  } as unknown as McpToolContext;
+}
+
+describe("assertMutatingToolsEnabled", () => {
+  it("returns silently when `mutatingToolsEnabled` is true", () => {
+    expect(() =>
+      assertMutatingToolsEnabled(makeCtx({ mutatingToolsEnabled: true })),
+    ).not.toThrow();
+  });
+
+  it("throws when the toggle is missing entirely (default off)", () => {
+    expect(() => assertMutatingToolsEnabled(makeCtx(undefined))).toThrow(
+      /disabled/i,
+    );
+    expect(() => assertMutatingToolsEnabled(makeCtx({}))).toThrow(/disabled/i);
+  });
+
+  it("throws when the toggle is explicitly false", () => {
+    expect(() =>
+      assertMutatingToolsEnabled(makeCtx({ mutatingToolsEnabled: false })),
+    ).toThrow(/Settings → Agents/);
+  });
+});
+
+describe("assertPdvRunEnabled", () => {
+  it("returns silently when `pdvRunEnabled` is true", () => {
+    expect(() =>
+      assertPdvRunEnabled(makeCtx({ pdvRunEnabled: true })),
+    ).not.toThrow();
+  });
+
+  it("throws when the toggle is missing or false", () => {
+    expect(() => assertPdvRunEnabled(makeCtx(undefined))).toThrow(
+      /pdv_run.*disabled/i,
+    );
+    expect(() => assertPdvRunEnabled(makeCtx({ pdvRunEnabled: false }))).toThrow(
+      /pdv_run.*disabled/i,
+    );
+  });
+
+  it("is independent of `mutatingToolsEnabled`", () => {
+    // pdv_run callers MUST also call assertMutatingToolsEnabled; this helper
+    // does not enforce that on its own (and shouldn't — separation of
+    // concerns lets each gate be tested in isolation).
+    expect(() =>
+      assertPdvRunEnabled(
+        makeCtx({ pdvRunEnabled: true, mutatingToolsEnabled: false }),
+      ),
+    ).not.toThrow();
+  });
+});

--- a/electron/main/mcp/tools/_helpers.ts
+++ b/electron/main/mcp/tools/_helpers.ts
@@ -70,6 +70,67 @@ export function assertCurrentGeneration(ctx: McpToolContext, extra: ToolExtra): 
 }
 
 /**
+ * Send a write/mutation message to the kernel. Mutating messages always go
+ * through `CommRouter`; the read-only query socket whitelist would reject
+ * them (`query.not_allowed`).
+ *
+ * @param ctx - The MCP tool context.
+ * @param type - PDV message type (e.g. `'pdv.tree.delete'`).
+ * @param payload - Request payload.
+ * @returns The kernel's response message.
+ * @throws {Error} When no kernel is running, or the kernel reports an error.
+ */
+export async function kernelMutate(
+  ctx: McpToolContext,
+  type: string,
+  payload: Record<string, unknown> = {},
+): Promise<PDVMessage> {
+  const kernelId = ctx.hooks.getActiveKernelId();
+  if (!kernelId || !ctx.kernelManager.getKernel(kernelId)) {
+    throw new Error(
+      "No active PDV kernel. Open a project in PDV before using this tool.",
+    );
+  }
+  return ctx.commRouter.request(type, payload);
+}
+
+/**
+ * Throw the "disabled in Settings" error a mutating MCP tool must raise when
+ * the `mcp.mutatingToolsEnabled` config toggle is off. The tool stays
+ * registered (stable schema) so the agent's client sees a clear, actionable
+ * error rather than a missing-tool failure.
+ *
+ * @param ctx - The MCP tool context.
+ * @throws {Error} When mutating tools are disabled.
+ */
+export function assertMutatingToolsEnabled(ctx: McpToolContext): void {
+  const cfg = ctx.configStore.get("mcp");
+  if (!cfg?.mutatingToolsEnabled) {
+    throw new Error(
+      "Mutating MCP tools are disabled. Enable them in PDV under " +
+        "Settings → Agents → Allow mutating tools.",
+    );
+  }
+}
+
+/**
+ * Companion to {@link assertMutatingToolsEnabled} for the most-powerful tool,
+ * `pdv_run`, which is gated by its own switch (`mcp.pdvRunEnabled`).
+ *
+ * @param ctx - The MCP tool context.
+ * @throws {Error} When `pdv_run` is disabled.
+ */
+export function assertPdvRunEnabled(ctx: McpToolContext): void {
+  const cfg = ctx.configStore.get("mcp");
+  if (!cfg?.pdvRunEnabled) {
+    throw new Error(
+      "The pdv_run tool is disabled. Enable it in PDV under " +
+        "Settings → Agents → Allow pdv_run (arbitrary kernel code).",
+    );
+  }
+}
+
+/**
  * Wrap plain text as a successful MCP tool result.
  *
  * @param text - The result text.

--- a/electron/main/mcp/tools/execution.test.ts
+++ b/electron/main/mcp/tools/execution.test.ts
@@ -1,0 +1,127 @@
+/**
+ * tools/execution.test.ts — Unit tests for the execution MCP tools.
+ *
+ * Focused on the gating contract — pdv_run requires BOTH
+ * `mutatingToolsEnabled` AND `pdvRunEnabled` — and the kwarg formatting
+ * helpers' handling of None / null. The full script_run / cell_run paths
+ * exercise the live kernel and are covered by the smoke-test sweep.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+}));
+
+import type { McpToolContext } from "../mcp-context";
+import type { ToolExtra } from "./_helpers";
+import { registerExecutionTools } from "./execution";
+
+type ToolCallback = (
+  args: Record<string, unknown>,
+  extra: ToolExtra,
+) => Promise<CallToolResult>;
+
+function captureTools(): { server: McpServer; tools: Map<string, ToolCallback> } {
+  const tools = new Map<string, ToolCallback>();
+  const server = {
+    registerTool: (name: string, _config: unknown, cb: ToolCallback) => {
+      tools.set(name, cb);
+    },
+  } as unknown as McpServer;
+  return { server, tools };
+}
+
+interface CtxOpts {
+  mutatingEnabled?: boolean;
+  pdvRunEnabled?: boolean;
+}
+
+function makeCtx(opts: CtxOpts = {}): McpToolContext {
+  return {
+    kernelManager: {
+      getKernel: () => ({ id: "k1", language: "python" }),
+      execute: vi.fn(async () => ({ stdout: "", duration: 0 })),
+    } as unknown as McpToolContext["kernelManager"],
+    commRouter: { request: vi.fn() } as unknown as McpToolContext["commRouter"],
+    queryRouter: {
+      isAttached: () => false,
+      request: vi.fn(),
+    } as unknown as McpToolContext["queryRouter"],
+    projectManager: {} as McpToolContext["projectManager"],
+    configStore: {
+      get: (key: string) =>
+        key === "mcp"
+          ? {
+              mutatingToolsEnabled: opts.mutatingEnabled ?? false,
+              pdvRunEnabled: opts.pdvRunEnabled ?? false,
+            }
+          : undefined,
+    } as unknown as McpToolContext["configStore"],
+    hooks: {
+      getActiveKernelId: () => "k1",
+      getActiveProjectDir: () => "/proj",
+      getActiveWorkingDir: () => null,
+      getGeneration: () => 0,
+      bumpGeneration: () => undefined,
+      treeCreate: {
+        script: vi.fn(),
+        note: vi.fn(),
+        lib: vi.fn(),
+      },
+    } as unknown as McpToolContext["hooks"],
+    appVersion: "0.0.0-test",
+    cellRpc: {} as McpToolContext["cellRpc"],
+    getRendererWindow: () => null,
+    getSessionGeneration: () => 0,
+  };
+}
+
+const extra = { sessionId: "s1" } as ToolExtra;
+
+describe("pdv_run gating", () => {
+  it("requires BOTH `mutatingToolsEnabled` AND `pdvRunEnabled`", async () => {
+    // Only pdvRunEnabled — mutating off. Should still refuse.
+    const { server, tools } = captureTools();
+    registerExecutionTools(
+      server,
+      makeCtx({ mutatingEnabled: false, pdvRunEnabled: true }),
+    );
+    await expect(
+      tools.get("pdv_run")!({ code: "print(1)" }, extra),
+    ).rejects.toThrow(/Mutating MCP tools are disabled/);
+  });
+
+  it("refuses when only the mutating-tier is on but pdv_run is off", async () => {
+    const { server, tools } = captureTools();
+    registerExecutionTools(
+      server,
+      makeCtx({ mutatingEnabled: true, pdvRunEnabled: false }),
+    );
+    await expect(
+      tools.get("pdv_run")!({ code: "print(1)" }, extra),
+    ).rejects.toThrow(/pdv_run.*disabled/i);
+  });
+
+  it("script_run requires only the mutating-tier toggle (no pdvRunEnabled)", async () => {
+    // Mutating on, pdv_run off — script_run should still be reachable.
+    // We can't run end-to-end without a kernel, but the gate check must
+    // not raise the pdv_run-specific error message.
+    const { server, tools } = captureTools();
+    registerExecutionTools(
+      server,
+      makeCtx({ mutatingEnabled: true, pdvRunEnabled: false }),
+    );
+    // script_run will reach the script-invocation codegen path and call
+    // executeAndTranscribe with the stubbed kernelManager.execute — we
+    // only care that it does NOT throw a gating error.
+    await expect(
+      tools.get("script_run")!(
+        { tree_path: "scripts.fit", params: {} },
+        extra,
+      ),
+    ).resolves.toBeDefined();
+  });
+});

--- a/electron/main/mcp/tools/execution.ts
+++ b/electron/main/mcp/tools/execution.ts
@@ -124,6 +124,11 @@ export function registerExecutionTools(server: McpServer, ctx: McpToolContext): 
     },
     async ({ code }, extra) => {
       assertCurrentGeneration(ctx, extra);
+      // pdv_run requires BOTH gates: it is a mutating-tier tool (it can
+      // write the Tree, files, and run subprocess), so a user who toggled
+      // the mutating tier off should not be exposed to it just because
+      // pdv_run's own switch happens to still be on.
+      assertMutatingToolsEnabled(ctx);
       assertPdvRunEnabled(ctx);
       requireKernel(ctx);
       const origin: KernelExecutionOrigin = {
@@ -303,12 +308,14 @@ function buildScriptInvocation(
 }
 
 function formatPythonKwarg(key: string, value: unknown): string {
+  if (value === null || value === undefined) return `${key}=None`;
   if (typeof value === "string") return `${key}=${JSON.stringify(value)}`;
   if (typeof value === "boolean") return `${key}=${value ? "True" : "False"}`;
   return `${key}=${String(value)}`;
 }
 
 function formatJuliaKwarg(key: string, value: unknown): string {
+  if (value === null || value === undefined) return `${key}=nothing`;
   if (typeof value === "string") return `${key}=${JSON.stringify(value)}`;
   if (typeof value === "boolean") return `${key}=${value ? "true" : "false"}`;
   return `${key}=${String(value)}`;
@@ -335,6 +342,7 @@ async function runOnKernel(
   // begin/finish pushes — the renderer needs a seeded log entry before
   // streaming chunks attach to it.
   const executionId = randomUUID();
+  const start = Date.now();
   const sendToRenderer = (channel: string, payload: unknown): void => {
     if (win && !win.isDestroyed()) {
       win.webContents.send(channel, payload);
@@ -344,7 +352,7 @@ async function runOnKernel(
     executionId,
     code,
     origin,
-    timestamp: Date.now(),
+    timestamp: start,
   });
   try {
     const result = await executeAndTranscribe(
@@ -356,15 +364,18 @@ async function runOnKernel(
     );
     sendToRenderer(IPC.push.executeFinish, {
       executionId,
-      duration: result.duration ?? 0,
+      duration: result.duration ?? Date.now() - start,
       error: result.error,
       errorDetails: result.errorDetails,
     });
     return result;
   } catch (err) {
+    // A throw can happen far into a long-running execution (kernel timeout,
+    // transport error). Report the elapsed wall time so the Console doesn't
+    // claim a 30-second failure took 0 ms.
     sendToRenderer(IPC.push.executeFinish, {
       executionId,
-      duration: 0,
+      duration: Date.now() - start,
       error: err instanceof Error ? err.message : String(err),
     });
     throw err;

--- a/electron/main/mcp/tools/execution.ts
+++ b/electron/main/mcp/tools/execution.ts
@@ -1,0 +1,449 @@
+/**
+ * tools/execution.ts — MCP tools that run code in the live PDV kernel.
+ *
+ * Surface (ARCHITECTURE.md §15.5):
+ * - `script_run`  — run a `PDVScript` via the existing `script.run()` path,
+ *   tagged with `origin: agent`.
+ * - `pdv_run`     — execute a raw Python (or Julia) string in the kernel.
+ *   Gated behind its own settings switch (`mcp.pdvRunEnabled`).
+ * - `cell_list`   — list the renderer's code-cell tabs.
+ * - `cell_read`   — read one cell tab's source.
+ * - `cell_write`  — overwrite one cell tab's source (or append a new tab).
+ * - `cell_run`    — read a cell tab and run its code (origin: agent).
+ *
+ * Every execution flows through {@link executeAndTranscribe} so the
+ * §15.7 transcript captures it. The structured summary returned to the
+ * agent carries status, duration, the final lines of output, and a
+ * pointer to the transcript file for full-output grepping.
+ *
+ * See Also
+ * --------
+ * ARCHITECTURE.md §15.5 — Tool surface
+ * ARCHITECTURE.md §15.7 — Execution output and the transcript
+ * ARCHITECTURE.md §15.8 — Renderer interaction
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { randomUUID } from "node:crypto";
+
+import { IPC } from "../../ipc";
+import type {
+  KernelExecuteResult,
+  KernelExecutionOrigin,
+} from "../../kernel-manager";
+import { PDVMessageType } from "../../pdv-protocol";
+import type { McpToolContext } from "../mcp-context";
+import { executeAndTranscribe, TranscriptWriter } from "../transcript";
+import {
+  assertCurrentGeneration,
+  assertMutatingToolsEnabled,
+  assertPdvRunEnabled,
+  textResult,
+} from "./_helpers";
+
+/** Maximum number of trailing output lines included in a tool summary. */
+const SUMMARY_TAIL_LINES = 50;
+
+/**
+ * Register the execution tools (`script_run`, `pdv_run`, and the cell tools).
+ *
+ * @param server - The MCP server to register on.
+ * @param ctx - The shared tool context.
+ * @returns Nothing.
+ */
+export function registerExecutionTools(server: McpServer, ctx: McpToolContext): void {
+  // ---------------------------------------------------------------------------
+  // script_run
+  // ---------------------------------------------------------------------------
+  server.registerTool(
+    "script_run",
+    {
+      title: "Run PDV script",
+      description:
+        "Run a PDVScript at the given Tree path with the given params, " +
+        "exactly like the user clicking Run. The run is tagged " +
+        "`origin: agent` so the console and transcript attribute it to the " +
+        "agent. Returns a structured summary plus a pointer to the full " +
+        "transcript file (read it with your own grep/tail).",
+      inputSchema: {
+        tree_path: z
+          .string()
+          .describe(
+            "Dot-delimited Tree path of the script node (e.g. `scripts.fit`).",
+          ),
+        params: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe(
+            "Keyword arguments forwarded to the script's `run(...)` call.",
+          ),
+      },
+    },
+    async ({ tree_path, params }, extra) => {
+      assertCurrentGeneration(ctx, extra);
+      assertMutatingToolsEnabled(ctx);
+      const kernelId = requireKernel(ctx);
+      const kernel = ctx.kernelManager.getKernel(kernelId);
+      if (!kernel) throw new Error("Kernel disappeared during call.");
+
+      await runLibReloadPreflight(ctx, tree_path);
+      const code = buildScriptInvocation(
+        kernel.language,
+        tree_path,
+        params ?? {},
+      );
+      const origin: KernelExecutionOrigin = {
+        kind: "agent",
+        agentTool: "script_run",
+        scriptPath: tree_path,
+      };
+      const result = await runOnKernel(ctx, code, origin);
+      return textResult(formatExecutionSummary(result, ctx, origin));
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // pdv_run
+  // ---------------------------------------------------------------------------
+  server.registerTool(
+    "pdv_run",
+    {
+      title: "Run code in the PDV kernel",
+      description:
+        "Execute one or more lines of code in the live PDV kernel and " +
+        "return a summary. The kernel is the same one the user is working " +
+        "in — variables persist. Output and code are recorded in the " +
+        "transcript and visible in the Console. Use this for one-off " +
+        "experiments; persistent code belongs in a `script` or `cell`. " +
+        "This tool can be disabled in Settings → Agents.",
+      inputSchema: {
+        code: z.string().describe("Source code to execute (Python or Julia)."),
+      },
+    },
+    async ({ code }, extra) => {
+      assertCurrentGeneration(ctx, extra);
+      assertPdvRunEnabled(ctx);
+      requireKernel(ctx);
+      const origin: KernelExecutionOrigin = {
+        kind: "agent",
+        agentTool: "pdv_run",
+      };
+      const result = await runOnKernel(ctx, code, origin);
+      return textResult(formatExecutionSummary(result, ctx, origin));
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // cell_list / cell_read / cell_write / cell_run
+  // ---------------------------------------------------------------------------
+  server.registerTool(
+    "cell_list",
+    {
+      title: "List PDV code cells",
+      annotations: { readOnlyHint: true },
+      description:
+        "List the renderer's code-cell tabs (id, optional name, source " +
+        "length). Use `cell_read` to fetch a cell's full source.",
+      inputSchema: {},
+    },
+    async (_args, extra) => {
+      assertCurrentGeneration(ctx, extra);
+      const listed = await ctx.cellRpc.list();
+      if (listed.tabs.length === 0) {
+        return textResult("(no code cells)");
+      }
+      const lines = listed.tabs.map((t) => {
+        const name = t.name ? ` "${t.name}"` : "";
+        const active = listed.activeTabId === t.id ? "  (active)" : "";
+        return `id ${t.id}${name}  [${t.length} chars]${active}`;
+      });
+      return textResult(lines.join("\n"));
+    },
+  );
+
+  server.registerTool(
+    "cell_read",
+    {
+      title: "Read a PDV code cell",
+      annotations: { readOnlyHint: true },
+      description:
+        "Read the full source of one cell tab by id.",
+      inputSchema: {
+        tab_id: z.number().int().describe("Cell tab id (see `cell_list`)."),
+      },
+    },
+    async ({ tab_id }, extra) => {
+      assertCurrentGeneration(ctx, extra);
+      const cell = await ctx.cellRpc.read(tab_id);
+      const header =
+        `cell id: ${cell.id}` + (cell.name ? `  (${cell.name})` : "");
+      return textResult(`${header}\n\n${cell.code}`);
+    },
+  );
+
+  server.registerTool(
+    "cell_write",
+    {
+      title: "Write a PDV code cell",
+      description:
+        "Overwrite a cell tab's source, or append a new tab when `tab_id` " +
+        "is omitted or matches no existing tab. The renderer updates its " +
+        "live tab state on receipt.",
+      inputSchema: {
+        tab_id: z
+          .number()
+          .int()
+          .optional()
+          .describe("Existing tab id; omit to append a new tab."),
+        code: z.string().describe("New source code for the cell."),
+        name: z.string().optional().describe("Optional tab display name."),
+      },
+    },
+    async ({ tab_id, code, name }, extra) => {
+      assertCurrentGeneration(ctx, extra);
+      assertMutatingToolsEnabled(ctx);
+      ctx.cellRpc.write({ tabId: tab_id, code, name });
+      return textResult(
+        tab_id !== undefined
+          ? `Wrote ${code.length} chars to cell ${tab_id}`
+          : `Appended new cell (${code.length} chars)`,
+      );
+    },
+  );
+
+  server.registerTool(
+    "cell_run",
+    {
+      title: "Run a PDV code cell",
+      description:
+        "Read a cell tab and run its source in the live kernel. The run is " +
+        "tagged `origin: agent` so the console and transcript attribute it " +
+        "to the agent.",
+      inputSchema: {
+        tab_id: z.number().int().describe("Cell tab id to run."),
+      },
+    },
+    async ({ tab_id }, extra) => {
+      assertCurrentGeneration(ctx, extra);
+      assertMutatingToolsEnabled(ctx);
+      requireKernel(ctx);
+      const cell = await ctx.cellRpc.read(tab_id);
+      const origin: KernelExecutionOrigin = {
+        kind: "agent",
+        agentTool: "cell_run",
+        tabId: cell.id,
+        label: cell.name,
+      };
+      const result = await runOnKernel(ctx, cell.code, origin);
+      return textResult(formatExecutionSummary(result, ctx, origin));
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** Verify an active kernel and return its id, or throw a clear error. */
+function requireKernel(ctx: McpToolContext): string {
+  const kernelId = ctx.hooks.getActiveKernelId();
+  if (!kernelId || !ctx.kernelManager.getKernel(kernelId)) {
+    throw new Error(
+      "No active PDV kernel. Open a project in PDV before using this tool.",
+    );
+  }
+  return kernelId;
+}
+
+/**
+ * Mirror of the lib-reload preflight in the script:run IPC handler — when a
+ * tree path is inside a module, ask the kernel to `importlib.reload` the
+ * module's lib files so an agent's edit to a lib takes effect on the next
+ * script run. Errors are swallowed: a reload failure must not block the run.
+ */
+async function runLibReloadPreflight(
+  ctx: McpToolContext,
+  treePath: string,
+): Promise<void> {
+  const firstDot = treePath.indexOf(".");
+  if (firstDot <= 0) return;
+  const alias = treePath.slice(0, firstDot);
+  try {
+    await ctx.commRouter.request(PDVMessageType.MODULE_RELOAD_LIBS, { alias });
+  } catch (err) {
+    console.warn(`[mcp] reload_libs preflight failed for ${alias}:`, err);
+  }
+}
+
+/**
+ * Build the language-appropriate `pdv_tree[...].run(...)` invocation string.
+ * Mirrors the codegen in the `script:run` IPC handler.
+ */
+function buildScriptInvocation(
+  language: "python" | "julia",
+  treePath: string,
+  params: Record<string, unknown>,
+): string {
+  const entries = Object.entries(params);
+  if (language === "julia") {
+    const kwargs = entries
+      .map(([k, v]) => formatJuliaKwarg(k, v))
+      .join(", ");
+    const pathStr = JSON.stringify(treePath);
+    return kwargs
+      ? `PDVKernel.run_tree_script(pdv_tree, ${pathStr}; ${kwargs})`
+      : `PDVKernel.run_tree_script(pdv_tree, ${pathStr})`;
+  }
+  const kwargs = entries.map(([k, v]) => formatPythonKwarg(k, v)).join(", ");
+  return kwargs
+    ? `pdv_tree[${JSON.stringify(treePath)}].run(${kwargs})`
+    : `pdv_tree[${JSON.stringify(treePath)}].run()`;
+}
+
+function formatPythonKwarg(key: string, value: unknown): string {
+  if (typeof value === "string") return `${key}=${JSON.stringify(value)}`;
+  if (typeof value === "boolean") return `${key}=${value ? "True" : "False"}`;
+  return `${key}=${String(value)}`;
+}
+
+function formatJuliaKwarg(key: string, value: unknown): string {
+  if (typeof value === "string") return `${key}=${JSON.stringify(value)}`;
+  if (typeof value === "boolean") return `${key}=${value ? "true" : "false"}`;
+  return `${key}=${String(value)}`;
+}
+
+/**
+ * Execute one code string on the active kernel with the given origin. Every
+ * such run is recorded to the §15.7 transcript (via
+ * {@link executeAndTranscribe}) AND streams its iopub chunks to the
+ * renderer's Console (via `IPC.push.executeOutput`) so agent-initiated runs
+ * are visible alongside user-initiated ones (ARCHITECTURE.md §15.9).
+ */
+async function runOnKernel(
+  ctx: McpToolContext,
+  code: string,
+  origin: KernelExecutionOrigin,
+): Promise<KernelExecuteResult> {
+  const kernelId = ctx.hooks.getActiveKernelId();
+  if (!kernelId) throw new Error("No active kernel for execution.");
+  const workingDir = ctx.hooks.getActiveWorkingDir();
+  const transcript = workingDir ? new TranscriptWriter(workingDir) : null;
+  const win = ctx.getRendererWindow();
+  // Generate the executionId up front so we can bracket the run with
+  // begin/finish pushes — the renderer needs a seeded log entry before
+  // streaming chunks attach to it.
+  const executionId = randomUUID();
+  const sendToRenderer = (channel: string, payload: unknown): void => {
+    if (win && !win.isDestroyed()) {
+      win.webContents.send(channel, payload);
+    }
+  };
+  sendToRenderer(IPC.push.executeBegin, {
+    executionId,
+    code,
+    origin,
+    timestamp: Date.now(),
+  });
+  try {
+    const result = await executeAndTranscribe(
+      ctx.kernelManager.execute.bind(ctx.kernelManager),
+      transcript,
+      kernelId,
+      { code, executionId, origin },
+      (chunk) => sendToRenderer(IPC.push.executeOutput, chunk),
+    );
+    sendToRenderer(IPC.push.executeFinish, {
+      executionId,
+      duration: result.duration ?? 0,
+      error: result.error,
+      errorDetails: result.errorDetails,
+    });
+    return result;
+  } catch (err) {
+    sendToRenderer(IPC.push.executeFinish, {
+      executionId,
+      duration: 0,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}
+
+/**
+ * Render the structured execution summary an agent gets back from
+ * `script_run` / `pdv_run` / `cell_run`. Per §15.7: status, duration, the
+ * final lines of output inline (capped), the transcript-file path, and full
+ * error + traceback when failure.
+ */
+function formatExecutionSummary(
+  result: KernelExecuteResult,
+  ctx: McpToolContext,
+  origin: KernelExecutionOrigin,
+): string {
+  const status = result.error ? "error" : "ok";
+  const durationSec =
+    typeof result.duration === "number"
+      ? (result.duration / 1000).toFixed(2)
+      : "?";
+  const workingDir = ctx.hooks.getActiveWorkingDir();
+  const transcriptPath = workingDir
+    ? `${workingDir}/execution-transcript.txt`
+    : "(no transcript — working dir unavailable)";
+  const lines: string[] = [
+    `status: ${status}`,
+    `duration: ${durationSec}s`,
+    `origin: agent:${origin.agentTool ?? "?"}`,
+    `transcript: ${transcriptPath}`,
+  ];
+  if (result.error) {
+    lines.push("", `error: ${result.error}`);
+    const tb = result.errorDetails?.traceback;
+    if (tb && tb.length > 0) {
+      lines.push("", "traceback:", ...tb);
+    }
+  }
+  // Surface the run()'s return value inline. Scripts often write into
+  // pdv_tree and return a summary dict; without this, a `script_run`
+  // that doesn't print() leaves the agent staring at an empty `output`
+  // section even though useful data is in `result.result`.
+  if (result.result !== undefined && result.result !== null) {
+    lines.push("", `return value: ${formatReturnValue(result.result)}`);
+  }
+  const stdoutTail = tailLines(result.stdout, SUMMARY_TAIL_LINES);
+  const stderrTail = tailLines(result.stderr, SUMMARY_TAIL_LINES);
+  if (stdoutTail) {
+    lines.push("", `output (last ${SUMMARY_TAIL_LINES} lines):`, stdoutTail);
+  }
+  if (stderrTail && !result.error) {
+    lines.push("", "stderr:", stderrTail);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Render the kernel's return value for the structured summary. Compact JSON
+ * when it serializes cleanly; capped so a huge dict doesn't blow context.
+ */
+function formatReturnValue(value: unknown): string {
+  const MAX_LEN = 1200;
+  let text: string;
+  try {
+    text = JSON.stringify(value);
+  } catch {
+    text = String(value);
+  }
+  if (text.length > MAX_LEN) {
+    return `${text.slice(0, MAX_LEN)}… (truncated; ${text.length - MAX_LEN} more chars)`;
+  }
+  return text;
+}
+
+/** Return the last `n` lines of `text` (whole string when shorter). */
+function tailLines(text: string | undefined, n: number): string {
+  if (!text) return "";
+  const lines = text.split("\n");
+  if (lines.length <= n) return text;
+  return lines.slice(-n).join("\n");
+}

--- a/electron/main/mcp/tools/index.ts
+++ b/electron/main/mcp/tools/index.ts
@@ -12,8 +12,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { McpToolContext } from "../mcp-context";
+import { registerExecutionTools } from "./execution";
 import { registerIntrospectionTools } from "./introspection";
 import { registerTranslationTools } from "./translation";
+import { registerTreeMutateTools } from "./tree-mutate";
 import { registerTreeReadTools } from "./tree-read";
 
 /**
@@ -26,5 +28,7 @@ import { registerTreeReadTools } from "./tree-read";
 export function registerAllTools(server: McpServer, ctx: McpToolContext): void {
   registerTranslationTools(server, ctx);
   registerTreeReadTools(server, ctx);
+  registerTreeMutateTools(server, ctx);
+  registerExecutionTools(server, ctx);
   registerIntrospectionTools(server, ctx);
 }

--- a/electron/main/mcp/tools/introspection.ts
+++ b/electron/main/mcp/tools/introspection.ts
@@ -31,7 +31,10 @@ export function registerIntrospectionTools(server: McpServer, ctx: McpToolContex
       title: "List kernel namespace",
       annotations: { readOnlyHint: true },
       description:
-        "List the variables currently defined in the PDV kernel namespace.",
+        "List user-defined variables in the PDV kernel namespace. PDV's " +
+        "always-injected names (`pdv_tree`, `pdv`) are filtered out — they " +
+        "are always present, so listing them is noise; inspect them with " +
+        "`tree_list` / `tree_get_data` and `pdv_help(\"pdv\")` instead.",
       inputSchema: {
         include_private: z
           .boolean()

--- a/electron/main/mcp/tools/tree-mutate.test.ts
+++ b/electron/main/mcp/tools/tree-mutate.test.ts
@@ -1,0 +1,372 @@
+/**
+ * tools/tree-mutate.test.ts — Unit tests for the mutating Tree MCP tools.
+ *
+ * Verifies the dispatch shape of `create_tree_node`, the
+ * mutating-tools-enabled gate, the rename-vs-move branching of
+ * `move_tree_node`, and the native delete-confirmation round-trip of
+ * `delete_tree_node` (with `electron.dialog` stubbed).
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dialogMock = vi.hoisted(() => ({
+  showMessageBox: vi.fn(async () => ({ response: 0 })),
+}));
+
+vi.mock("electron", () => ({
+  dialog: dialogMock,
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+}));
+
+import type { McpToolContext } from "../mcp-context";
+import type { ToolExtra } from "./_helpers";
+import { registerTreeMutateTools } from "./tree-mutate";
+
+/** A captured tool callback. */
+type ToolCallback = (
+  args: Record<string, unknown>,
+  extra: ToolExtra,
+) => Promise<CallToolResult>;
+
+/** Build a fake McpServer that captures registered tool callbacks. */
+function captureTools(): { server: McpServer; tools: Map<string, ToolCallback> } {
+  const tools = new Map<string, ToolCallback>();
+  const server = {
+    registerTool: (name: string, _config: unknown, cb: ToolCallback) => {
+      tools.set(name, cb);
+    },
+  } as unknown as McpServer;
+  return { server, tools };
+}
+
+interface CtxOpts {
+  /** Whether `mcp.mutatingToolsEnabled` is on (default: true). */
+  mutatingEnabled?: boolean;
+  /** Whether `mcp.pdvRunEnabled` is on (default: false). */
+  pdvRunEnabled?: boolean;
+  /** Active kernel id (default: "k1"; pass null to simulate no kernel). */
+  activeKernelId?: string | null;
+  /** Override the kernelMutate transport (defaults to a vi.fn that returns ok). */
+  commRequest?: (
+    type: string,
+    payload: Record<string, unknown>,
+  ) => Promise<unknown>;
+  /** Override treeCreate.script (defaults to a vi.fn returning success). */
+  treeCreateScript?: McpToolContext["hooks"]["treeCreate"]["script"];
+  /** Override treeCreate.note. */
+  treeCreateNote?: McpToolContext["hooks"]["treeCreate"]["note"];
+  /** Override treeCreate.lib. */
+  treeCreateLib?: McpToolContext["hooks"]["treeCreate"]["lib"];
+}
+
+function makeCtx(opts: CtxOpts = {}): {
+  ctx: McpToolContext;
+  commRequest: ReturnType<typeof vi.fn>;
+} {
+  const commRequest = vi.fn(
+    opts.commRequest
+      ? opts.commRequest
+      : async (type: string, _payload: Record<string, unknown>) => ({
+          pdv_version: "0",
+          msg_id: "m",
+          in_reply_to: "r",
+          type: `${type}.response`,
+          status: "ok",
+          payload: {},
+        }),
+  );
+  const activeKernelId =
+    opts.activeKernelId === undefined ? "k1" : opts.activeKernelId;
+  const ctx = {
+    kernelManager: {
+      getKernel: () => (activeKernelId ? { id: activeKernelId } : undefined),
+    } as unknown as McpToolContext["kernelManager"],
+    commRouter: {
+      request: commRequest,
+    } as unknown as McpToolContext["commRouter"],
+    queryRouter: {
+      isAttached: () => false,
+      request: vi.fn(),
+    } as unknown as McpToolContext["queryRouter"],
+    projectManager: {} as McpToolContext["projectManager"],
+    configStore: {
+      get: (key: string) =>
+        key === "mcp"
+          ? {
+              mutatingToolsEnabled: opts.mutatingEnabled ?? true,
+              pdvRunEnabled: opts.pdvRunEnabled ?? false,
+            }
+          : undefined,
+    } as unknown as McpToolContext["configStore"],
+    hooks: {
+      getActiveKernelId: () => activeKernelId,
+      getActiveProjectDir: () => "/proj",
+      getActiveWorkingDir: () => "/tmp/wd-test",
+      getGeneration: () => 0,
+      bumpGeneration: () => undefined,
+      treeCreate: {
+        script:
+          opts.treeCreateScript ??
+          (vi.fn(async () => ({
+            success: true,
+            scriptPath: "/tmp/wd-test/tree/uuid1/fit.py",
+            treePath: "analysis.fit",
+          })) as McpToolContext["hooks"]["treeCreate"]["script"]),
+        note:
+          opts.treeCreateNote ??
+          (vi.fn(async () => ({
+            success: true,
+            notePath: "/tmp/wd-test/tree/uuid2/readme.md",
+            treePath: "analysis.readme",
+          })) as McpToolContext["hooks"]["treeCreate"]["note"]),
+        lib:
+          opts.treeCreateLib ??
+          (vi.fn(async () => ({
+            success: true,
+            libPath: "/tmp/wd-test/tree/uuid3/helpers.py",
+            treePath: "analysis.helpers",
+          })) as McpToolContext["hooks"]["treeCreate"]["lib"]),
+      },
+    },
+    appVersion: "0.0.0-test",
+    cellRpc: {} as McpToolContext["cellRpc"],
+    getRendererWindow: () => null,
+    getSessionGeneration: () => 0,
+  };
+  return { ctx, commRequest };
+}
+
+function textOf(result: CallToolResult): string {
+  const block = result.content[0];
+  return block.type === "text" ? block.text : "";
+}
+
+const extra = { sessionId: "s1" } as ToolExtra;
+
+beforeEach(() => {
+  dialogMock.showMessageBox.mockReset();
+});
+
+describe("create_tree_node", () => {
+  it("type='dict' issues TREE_CREATE_NODE with parent_path + name", async () => {
+    const { server, tools } = captureTools();
+    const { ctx, commRequest } = makeCtx();
+    registerTreeMutateTools(server, ctx);
+    commRequest.mockResolvedValueOnce({
+      payload: { path: "analysis.equilibrium" },
+    });
+
+    const result = await tools.get("create_tree_node")!(
+      { type: "dict", parent_path: "analysis", name: "equilibrium" },
+      extra,
+    );
+
+    expect(commRequest).toHaveBeenCalledWith("pdv.tree.create_node", {
+      parent_path: "analysis",
+      name: "equilibrium",
+    });
+    expect(textOf(result)).toContain("Created dict node at analysis.equilibrium");
+  });
+
+  it("type='script' delegates to hooks.treeCreate.script and inlines the stub", async () => {
+    // Stage a real stub file on disk so the response includes its contents.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pdv-mutate-test-"));
+    const stubPath = path.join(dir, "fit.py");
+    await fs.writeFile(stubPath, "def run(pdv_tree, **kw):\n    return {}\n");
+
+    const scriptStub = vi.fn(async () => ({
+      success: true,
+      scriptPath: stubPath,
+      treePath: "analysis.fit",
+    })) as McpToolContext["hooks"]["treeCreate"]["script"];
+    const { server, tools } = captureTools();
+    const { ctx } = makeCtx({ treeCreateScript: scriptStub });
+    registerTreeMutateTools(server, ctx);
+
+    const result = await tools.get("create_tree_node")!(
+      { type: "script", parent_path: "analysis", name: "fit" },
+      extra,
+    );
+
+    expect(scriptStub).toHaveBeenCalledWith("k1", "analysis", "fit");
+    const text = textOf(result);
+    expect(text).toContain("Created script");
+    expect(text).toContain("analysis.fit");
+    expect(text).toContain("current stub:\ndef run(pdv_tree, **kw):");
+    expect(text).toContain("Read this file before Write");
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("type='note' delegates to hooks.treeCreate.note", async () => {
+    const { server, tools } = captureTools();
+    const { ctx } = makeCtx();
+    registerTreeMutateTools(server, ctx);
+
+    const result = await tools.get("create_tree_node")!(
+      { type: "note", parent_path: "analysis", name: "readme" },
+      extra,
+    );
+    const text = textOf(result);
+    expect(text).toContain("Created note");
+    expect(text).toContain("analysis.readme");
+    expect(text).toContain("current contents: (empty)");
+    expect(text).toContain("Read this file before Write");
+  });
+
+  it("type='lib' delegates to hooks.treeCreate.lib", async () => {
+    const { server, tools } = captureTools();
+    const { ctx } = makeCtx();
+    registerTreeMutateTools(server, ctx);
+
+    const result = await tools.get("create_tree_node")!(
+      { type: "lib", parent_path: "analysis", name: "helpers" },
+      extra,
+    );
+    const text = textOf(result);
+    expect(text).toContain("Created lib");
+    expect(text).toContain("analysis.helpers");
+    expect(text).toContain("Read this file before Write");
+  });
+
+  it("throws when mutating tools are disabled", async () => {
+    const { server, tools } = captureTools();
+    const { ctx } = makeCtx({ mutatingEnabled: false });
+    registerTreeMutateTools(server, ctx);
+
+    await expect(
+      tools.get("create_tree_node")!(
+        { type: "dict", parent_path: "", name: "x" },
+        extra,
+      ),
+    ).rejects.toThrow(/Mutating MCP tools are disabled/);
+  });
+
+  it("throws when no kernel is active", async () => {
+    const { server, tools } = captureTools();
+    const { ctx } = makeCtx({ activeKernelId: null });
+    registerTreeMutateTools(server, ctx);
+
+    await expect(
+      tools.get("create_tree_node")!(
+        { type: "dict", parent_path: "", name: "x" },
+        extra,
+      ),
+    ).rejects.toThrow(/No active PDV kernel/);
+  });
+
+  it("rejects an empty `name`", async () => {
+    const { server, tools } = captureTools();
+    const { ctx } = makeCtx();
+    registerTreeMutateTools(server, ctx);
+    await expect(
+      tools.get("create_tree_node")!(
+        { type: "dict", parent_path: "", name: "   " },
+        extra,
+      ),
+    ).rejects.toThrow(/non-empty string/);
+  });
+});
+
+describe("delete_tree_node", () => {
+  it("does NOT send TREE_DELETE when the user cancels the dialog", async () => {
+    dialogMock.showMessageBox.mockResolvedValueOnce({ response: 0 });
+    const { server, tools } = captureTools();
+    const { ctx, commRequest } = makeCtx();
+    registerTreeMutateTools(server, ctx);
+
+    await expect(
+      tools.get("delete_tree_node")!({ path: "analysis.draft" }, extra),
+    ).rejects.toThrow(/User refused/);
+    expect(commRequest).not.toHaveBeenCalled();
+  });
+
+  it("sends TREE_DELETE only when the user clicks Delete", async () => {
+    dialogMock.showMessageBox.mockResolvedValueOnce({ response: 1 });
+    const { server, tools } = captureTools();
+    const { ctx, commRequest } = makeCtx();
+    registerTreeMutateTools(server, ctx);
+
+    const result = await tools.get("delete_tree_node")!(
+      { path: "analysis.draft" },
+      extra,
+    );
+    expect(commRequest).toHaveBeenCalledWith("pdv.tree.delete", {
+      path: "analysis.draft",
+    });
+    expect(textOf(result)).toContain("Deleted analysis.draft");
+  });
+
+  it("is gated by the mutating-tools toggle", async () => {
+    const { server, tools } = captureTools();
+    const { ctx, commRequest } = makeCtx({ mutatingEnabled: false });
+    registerTreeMutateTools(server, ctx);
+
+    await expect(
+      tools.get("delete_tree_node")!({ path: "analysis.draft" }, extra),
+    ).rejects.toThrow(/Mutating MCP tools are disabled/);
+    expect(commRequest).not.toHaveBeenCalled();
+    expect(dialogMock.showMessageBox).not.toHaveBeenCalled();
+  });
+});
+
+describe("move_tree_node", () => {
+  let cleanups: Array<() => Promise<void>>;
+  beforeEach(() => {
+    cleanups = [];
+  });
+  afterEach(async () => {
+    for (const fn of cleanups) await fn();
+  });
+
+  it("emits TREE_RENAME when the parent path is unchanged", async () => {
+    const { server, tools } = captureTools();
+    const { ctx, commRequest } = makeCtx();
+    registerTreeMutateTools(server, ctx);
+
+    const result = await tools.get("move_tree_node")!(
+      { from_path: "analysis.draft", to_path: "analysis.final" },
+      extra,
+    );
+    expect(commRequest).toHaveBeenCalledWith("pdv.tree.rename", {
+      path: "analysis.draft",
+      new_name: "final",
+    });
+    expect(textOf(result)).toContain("Renamed analysis.draft → analysis.final");
+  });
+
+  it("emits TREE_MOVE when the parent path changes", async () => {
+    const { server, tools } = captureTools();
+    const { ctx, commRequest } = makeCtx();
+    registerTreeMutateTools(server, ctx);
+
+    const result = await tools.get("move_tree_node")!(
+      { from_path: "scratch.draft", to_path: "analysis.final" },
+      extra,
+    );
+    expect(commRequest).toHaveBeenCalledWith("pdv.tree.move", {
+      path: "scratch.draft",
+      new_path: "analysis.final",
+    });
+    expect(textOf(result)).toContain("Moved scratch.draft → analysis.final");
+  });
+
+  it("is gated by the mutating-tools toggle", async () => {
+    const { server, tools } = captureTools();
+    const { ctx, commRequest } = makeCtx({ mutatingEnabled: false });
+    registerTreeMutateTools(server, ctx);
+
+    await expect(
+      tools.get("move_tree_node")!(
+        { from_path: "a.b", to_path: "a.c" },
+        extra,
+      ),
+    ).rejects.toThrow(/Mutating MCP tools are disabled/);
+    expect(commRequest).not.toHaveBeenCalled();
+  });
+});

--- a/electron/main/mcp/tools/tree-mutate.ts
+++ b/electron/main/mcp/tools/tree-mutate.ts
@@ -229,11 +229,20 @@ async function promptDeleteConfirmation(path: string): Promise<boolean> {
     defaultId: 0,
     cancelId: 0,
   });
-  const timeoutPromise = new Promise<{ response: number }>((resolve) =>
-    setTimeout(() => resolve({ response: 0 }), 60_000),
-  );
-  const result = await Promise.race([dialogPromise, timeoutPromise]);
-  return result.response === 1;
+  // Promise.race doesn't cancel the losing promise, so an idle 60s
+  // setTimeout would keep the process from quitting cleanly between a
+  // user's quick click and the timer's expiry. Clear the timer when the
+  // dialog resolves first.
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<{ response: number }>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve({ response: 0 }), 60_000);
+  });
+  try {
+    const result = await Promise.race([dialogPromise, timeoutPromise]);
+    return result.response === 1;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
 }
 
 /**

--- a/electron/main/mcp/tools/tree-mutate.ts
+++ b/electron/main/mcp/tools/tree-mutate.ts
@@ -1,0 +1,278 @@
+/**
+ * tools/tree-mutate.ts — Mutating PDV Tree MCP tools.
+ *
+ * `create_tree_node` (dispatches by node type), `delete_tree_node` (gated
+ * behind a PDV-side native confirmation dialog), and `move_tree_node`
+ * (rename + relocate via the same tool — UUID storage decouples the tree
+ * path from the on-disk path).
+ *
+ * Mutating tools are register-but-throw gated by the
+ * `mcp.mutatingToolsEnabled` setting (ARCHITECTURE.md §15.5, §15.10): every
+ * tool is registered so the schema is stable, but each call first calls
+ * `assertMutatingToolsEnabled` and throws a clear "disabled in Settings"
+ * error when the toggle is off.
+ *
+ * See Also
+ * --------
+ * ARCHITECTURE.md §15.5 — Tool surface (mutating tier)
+ * ARCHITECTURE.md §15.10 — Settings: the Agents pane
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dialog } from "electron";
+import { promises as fs } from "node:fs";
+import { z } from "zod";
+
+import { PDVMessageType } from "../../pdv-protocol";
+import type { McpToolContext } from "../mcp-context";
+import {
+  assertCurrentGeneration,
+  assertMutatingToolsEnabled,
+  kernelMutate,
+  textResult,
+} from "./_helpers";
+
+/**
+ * Register the mutating Tree tools.
+ *
+ * @param server - The MCP server to register on.
+ * @param ctx - The shared tool context.
+ * @returns Nothing.
+ */
+export function registerTreeMutateTools(server: McpServer, ctx: McpToolContext): void {
+  server.registerTool(
+    "create_tree_node",
+    {
+      title: "Create tree node",
+      description:
+        "Create a PDV Tree node at `parent_path` named `name`. For file-" +
+        "backed types (`script`, `note`) the backing file is allocated under " +
+        "`tree/<uuid>/` and its absolute path is returned; the agent then " +
+        "edits the file with its own tools. `dict` creates an empty sub-tree.",
+      inputSchema: {
+        type: z
+          .enum(["dict", "script", "note", "lib"])
+          .describe(
+            "Node type. `dict` = empty sub-tree; `script` = Python/Julia " +
+              "PDVScript; `note` = Markdown note; `lib` = importable " +
+              "Python module other scripts can `from … import`.",
+          ),
+        parent_path: z
+          .string()
+          .describe(
+            "Dot-delimited Tree path of the parent. Empty string for root.",
+          ),
+        name: z
+          .string()
+          .describe(
+            "Name of the new node (used as the key under `parent_path`).",
+          ),
+      },
+    },
+    async ({ type, parent_path, name }, extra) => {
+      assertCurrentGeneration(ctx, extra);
+      assertMutatingToolsEnabled(ctx);
+      const kernelId = ctx.hooks.getActiveKernelId();
+      if (!kernelId) {
+        throw new Error(
+          "No active PDV kernel. Open a project in PDV before creating nodes.",
+        );
+      }
+      if (!name.trim()) {
+        throw new Error("`name` must be a non-empty string.");
+      }
+
+      if (type === "dict") {
+        const res = await kernelMutate(ctx, PDVMessageType.TREE_CREATE_NODE, {
+          parent_path,
+          name,
+        });
+        const newPath = (res.payload as { path?: string }).path;
+        return textResult(
+          `Created dict node at ${newPath ?? `${parent_path}.${name}`}`,
+        );
+      }
+      if (type === "script") {
+        const result = await ctx.hooks.treeCreate.script(
+          kernelId,
+          parent_path,
+          name,
+        );
+        if (!result.success || !result.scriptPath || !result.treePath) {
+          throw new Error(result.error ?? "Script creation failed.");
+        }
+        const stub = await readFileSafe(result.scriptPath);
+        const stubBlock = stub === null ? "" : `\n\ncurrent stub:\n${stub}`;
+        return textResult(
+          `Created script:\n  tree path: ${result.treePath}\n  file path: ${result.scriptPath}\n` +
+            `Edit the file with your file tools; it already has a ` +
+            `run(pdv_tree, **params) -> dict stub.${stubBlock}\n\n` +
+            FILE_BACKED_HINT,
+        );
+      }
+      if (type === "lib") {
+        const result = await ctx.hooks.treeCreate.lib(
+          kernelId,
+          parent_path,
+          name,
+        );
+        if (!result.success || !result.libPath || !result.treePath) {
+          throw new Error(result.error ?? "Lib creation failed.");
+        }
+        const stub = await readFileSafe(result.libPath);
+        const stubBlock = stub === null ? "" : `\n\ncurrent contents:\n${stub}`;
+        return textResult(
+          `Created lib:\n  tree path: ${result.treePath}\n  file path: ${result.libPath}\n` +
+            `Edit the file with your file tools; importable from other PDV ` +
+            `scripts as a Python module.${stubBlock}\n\n${FILE_BACKED_HINT}`,
+        );
+      }
+      // type === "note"
+      const result = await ctx.hooks.treeCreate.note(kernelId, parent_path, name);
+      if (!result.success || !result.notePath || !result.treePath) {
+        throw new Error(result.error ?? "Note creation failed.");
+      }
+      return textResult(
+        `Created note:\n  tree path: ${result.treePath}\n  file path: ${result.notePath}\n` +
+          `current contents: (empty)\n\n${FILE_BACKED_HINT}`,
+      );
+    },
+  );
+
+  server.registerTool(
+    "delete_tree_node",
+    {
+      title: "Delete tree node",
+      description:
+        "Delete a PDV Tree node by path. PDV ALWAYS shows the user a native " +
+        "confirmation dialog before the deletion is sent to the kernel — the " +
+        "agent cannot bypass this. The tool returns only after the user " +
+        "responds (or after a 60-second timeout, treated as a refusal).",
+      inputSchema: {
+        path: z
+          .string()
+          .describe("Dot-delimited Tree path of the node to delete."),
+      },
+    },
+    async ({ path }, extra) => {
+      assertCurrentGeneration(ctx, extra);
+      assertMutatingToolsEnabled(ctx);
+      const confirmed = await promptDeleteConfirmation(path);
+      if (!confirmed) {
+        throw new Error(
+          `User refused to delete "${path}" (or did not respond within 60s).`,
+        );
+      }
+      await kernelMutate(ctx, PDVMessageType.TREE_DELETE, { path });
+      return textResult(`Deleted ${path}`);
+    },
+  );
+
+  server.registerTool(
+    "move_tree_node",
+    {
+      title: "Move tree node",
+      description:
+        "Move or rename a PDV Tree node. UUID storage decouples the tree " +
+        "path from the on-disk path — this tool reshuffles the tree only; " +
+        "file paths under `tree/<uuid>/` are unaffected. If the parent path " +
+        "is unchanged the operation is a rename; otherwise it is a move.",
+      inputSchema: {
+        from_path: z
+          .string()
+          .describe("Dot-delimited Tree path of the node to move."),
+        to_path: z
+          .string()
+          .describe("Target dot-delimited Tree path (parent + new name)."),
+      },
+    },
+    async ({ from_path, to_path }, extra) => {
+      assertCurrentGeneration(ctx, extra);
+      assertMutatingToolsEnabled(ctx);
+      const fromParent = parentOf(from_path);
+      const toParent = parentOf(to_path);
+      const toName = leafOf(to_path);
+      if (fromParent === toParent) {
+        // Same parent → rename to the new leaf name.
+        await kernelMutate(ctx, PDVMessageType.TREE_RENAME, {
+          path: from_path,
+          new_name: toName,
+        });
+        return textResult(`Renamed ${from_path} → ${to_path}`);
+      }
+      await kernelMutate(ctx, PDVMessageType.TREE_MOVE, {
+        path: from_path,
+        new_path: to_path,
+      });
+      return textResult(`Moved ${from_path} → ${to_path}`);
+    },
+  );
+}
+
+/**
+ * Show the user a native delete-confirmation dialog. Returns `true` only when
+ * the user explicitly clicks "Delete". Closing the dialog or letting it sit
+ * for 60 seconds is treated as a refusal so an agent cannot wait the user out.
+ *
+ * @param path - The dot-delimited tree path the agent wants to delete.
+ * @returns `true` if the user confirmed, `false` otherwise.
+ */
+async function promptDeleteConfirmation(path: string): Promise<boolean> {
+  const dialogPromise = dialog.showMessageBox({
+    type: "warning",
+    title: "Confirm Tree Node Deletion",
+    message: `An AI agent is requesting to delete "${path}".`,
+    detail:
+      "This permanently removes the node from the PDV Tree (and its " +
+      "backing file, if any). Click Delete to confirm, or Cancel to refuse.",
+    buttons: ["Cancel", "Delete"],
+    defaultId: 0,
+    cancelId: 0,
+  });
+  const timeoutPromise = new Promise<{ response: number }>((resolve) =>
+    setTimeout(() => resolve({ response: 0 }), 60_000),
+  );
+  const result = await Promise.race([dialogPromise, timeoutPromise]);
+  return result.response === 1;
+}
+
+/**
+ * Hint included in every file-backed `create_tree_node` response so an agent
+ * whose file-write tool requires a prior Read of the file (Claude Code etc.)
+ * knows to do that before overwriting the freshly-allocated stub.
+ */
+const FILE_BACKED_HINT =
+  "Tip: if your file-write tool requires a prior Read of the path, Read this " +
+  "file before Write — it exists on disk now but your harness's read-cache " +
+  "doesn't know about it yet.";
+
+/**
+ * Read the contents of a freshly-created stub file. Best-effort: if the read
+ * fails (the file disappeared, permission, etc.) we return null and the
+ * caller omits the inline-contents block. Capped so a huge templated file
+ * (none exist today, but be safe) doesn't bloat the tool response.
+ */
+async function readFileSafe(filePath: string): Promise<string | null> {
+  const MAX_LEN = 4000;
+  try {
+    const text = await fs.readFile(filePath, "utf-8");
+    if (text.length > MAX_LEN) {
+      return `${text.slice(0, MAX_LEN)}\n… (truncated; ${text.length - MAX_LEN} more chars)`;
+    }
+    return text;
+  } catch {
+    return null;
+  }
+}
+
+/** Parent path of a dot-delimited tree path (`"a.b.c"` → `"a.b"`). */
+function parentOf(treePath: string): string {
+  const dot = treePath.lastIndexOf(".");
+  return dot < 0 ? "" : treePath.slice(0, dot);
+}
+
+/** Leaf name of a dot-delimited tree path (`"a.b.c"` → `"c"`). */
+function leafOf(treePath: string): string {
+  const dot = treePath.lastIndexOf(".");
+  return dot < 0 ? treePath : treePath.slice(dot + 1);
+}

--- a/electron/main/mcp/tools/tree-read.test.ts
+++ b/electron/main/mcp/tools/tree-read.test.ts
@@ -63,10 +63,18 @@ function makeCtx(query: QueryFn, kernelRunning = true): McpToolContext {
     hooks: {
       getActiveKernelId: () => "k1",
       getActiveProjectDir: () => "/proj",
+      getActiveWorkingDir: () => null,
       getGeneration: () => 0,
       bumpGeneration: () => undefined,
+      treeCreate: {
+        script: () => Promise.reject(new Error("not implemented in tests")),
+        note: () => Promise.reject(new Error("not implemented in tests")),
+        lib: () => Promise.reject(new Error("not implemented in tests")),
+      },
     },
     appVersion: "0.0.0-test",
+    cellRpc: {} as McpToolContext["cellRpc"],
+    getRendererWindow: () => null,
     getSessionGeneration: () => 0,
   };
 }

--- a/electron/main/mcp/transcript.test.ts
+++ b/electron/main/mcp/transcript.test.ts
@@ -1,0 +1,340 @@
+/**
+ * transcript.test.ts — Coverage for the §15.7 execution transcript writer.
+ *
+ * Verifies the greppability invariants the agent UX depends on (`grep '^═══'`
+ * indexes every execution, `grep ' · agent:'` filters to agent runs), the
+ * origin-string mapping, and that I/O failures don't propagate.
+ */
+
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ExecuteOutputChunk,
+  KernelExecuteRequest,
+  KernelExecuteResult,
+  KernelExecutionOrigin,
+} from "../kernel-manager";
+import {
+  executeAndTranscribe,
+  formatBlock,
+  formatOrigin,
+  TRANSCRIPT_FILENAME,
+  TranscriptWriter,
+} from "./transcript";
+
+const FIXED_TIMESTAMP = new Date("2026-05-18T14:32:09Z");
+
+describe("formatOrigin", () => {
+  it("formats a code-cell origin with the tab id", () => {
+    expect(formatOrigin({ kind: "code-cell", tabId: 2 })).toBe("user:cell-2");
+  });
+
+  it("falls back to `user:cell` when no tab id is present", () => {
+    expect(formatOrigin({ kind: "code-cell" })).toBe("user:cell");
+  });
+
+  it("formats a tree-script origin with the script path", () => {
+    expect(formatOrigin({ kind: "tree-script", scriptPath: "scripts.fit" })).toBe(
+      "user:script:scripts.fit",
+    );
+  });
+
+  it("formats an agent origin with just the tool name", () => {
+    expect(formatOrigin({ kind: "agent", agentTool: "pdv_run" })).toBe(
+      "agent:pdv_run",
+    );
+  });
+
+  it("formats an agent origin with tool + script path", () => {
+    expect(
+      formatOrigin({
+        kind: "agent",
+        agentTool: "script_run",
+        scriptPath: "scripts.fit",
+      }),
+    ).toBe("agent:script_run:scripts.fit");
+  });
+
+  it("defaults to `user:unknown` for undefined / unknown origins", () => {
+    expect(formatOrigin(undefined)).toBe("user:unknown");
+    expect(formatOrigin({ kind: "unknown" })).toBe("user:unknown");
+  });
+});
+
+describe("formatBlock", () => {
+  const baseEntry = {
+    executionId: "7f3b1a2c",
+    code: "1/0",
+    output:
+      "Traceback (most recent call last):\n  ...\nZeroDivisionError: division by zero\n",
+    status: "error" as const,
+    durationSeconds: 0.02,
+    timestamp: FIXED_TIMESTAMP,
+  };
+
+  it("emits a greppable header line starting with `═══ exec`", () => {
+    const block = formatBlock({
+      ...baseEntry,
+      origin: { kind: "code-cell", tabId: 2 },
+    });
+    const lines = block.split("\n");
+    expect(lines[0]).toMatch(/^═══ exec 7f3b1a2c /);
+    // `grep '^═══ exec'` must find exactly one match per block.
+    const headerHits = lines.filter((l) => l.startsWith("═══ exec"));
+    expect(headerHits).toHaveLength(1);
+  });
+
+  it("includes origin, status, and duration in the header in order", () => {
+    const block = formatBlock({
+      ...baseEntry,
+      origin: { kind: "agent", agentTool: "pdv_run" },
+    });
+    const header = block.split("\n", 1)[0];
+    expect(header).toContain(" · 2026-05-18T14:32:09 · ");
+    expect(header).toContain(" · agent:pdv_run · ");
+    expect(header).toContain(" · error · ");
+    expect(header).toMatch(/· 0\.02s ═══$/);
+  });
+
+  it("separates `--- code ---` and `--- output ---` blocks", () => {
+    const block = formatBlock({
+      ...baseEntry,
+      origin: { kind: "code-cell", tabId: 2 },
+    });
+    expect(block).toContain("\n--- code ---\n1/0\n--- output ---\n");
+    expect(block).toContain("ZeroDivisionError: division by zero\n");
+  });
+
+  it("normalizes output to end with a single newline before the separator", () => {
+    const block = formatBlock({
+      ...baseEntry,
+      output: "no trailing newline",
+      origin: { kind: "code-cell", tabId: 2 },
+    });
+    // The line after the output is blank, then the next block's header would
+    // start fresh — so the verbatim output is followed by `\n\n`.
+    expect(block.endsWith("no trailing newline\n\n")).toBe(true);
+  });
+
+  it("filters cleanly: `grep ' · agent:'` matches only agent blocks", () => {
+    const userBlock = formatBlock({
+      ...baseEntry,
+      origin: { kind: "code-cell", tabId: 2 },
+    });
+    const agentBlock = formatBlock({
+      ...baseEntry,
+      origin: { kind: "agent", agentTool: "pdv_run" },
+    });
+    const combined = userBlock + agentBlock;
+    const matched = combined
+      .split("\n")
+      .filter((line) => line.includes(" · agent:"));
+    expect(matched).toHaveLength(1);
+    expect(matched[0]).toMatch(/agent:pdv_run/);
+  });
+});
+
+describe("TranscriptWriter", () => {
+  let workingDir: string;
+
+  beforeEach(async () => {
+    workingDir = await fs.mkdtemp(path.join(os.tmpdir(), "pdv-transcript-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(workingDir, { recursive: true, force: true });
+  });
+
+  it("writes blocks to `<workingDir>/execution-transcript.txt`", async () => {
+    const writer = new TranscriptWriter(workingDir);
+    expect(writer.path).toBe(path.join(workingDir, TRANSCRIPT_FILENAME));
+
+    await writer.recordExecution({
+      executionId: "abc12345",
+      origin: { kind: "code-cell", tabId: 1 },
+      code: "x = 1",
+      output: "",
+      status: "ok",
+      durationSeconds: 0.01,
+      timestamp: FIXED_TIMESTAMP,
+    });
+
+    const contents = await fs.readFile(writer.path, "utf8");
+    expect(contents).toMatch(/^═══ exec abc12345 /);
+    expect(contents).toContain("user:cell-1");
+  });
+
+  it("appends successive blocks (preserves earlier entries)", async () => {
+    const writer = new TranscriptWriter(workingDir);
+    const make = (id: string, tool: string) => ({
+      executionId: id,
+      origin: { kind: "agent" as const, agentTool: tool },
+      code: `print('${id}')`,
+      output: `${id}\n`,
+      status: "ok" as const,
+      durationSeconds: 0.01,
+      timestamp: FIXED_TIMESTAMP,
+    });
+
+    await writer.recordExecution(make("11111111", "pdv_run"));
+    await writer.recordExecution(make("22222222", "script_run"));
+
+    const contents = await fs.readFile(writer.path, "utf8");
+    const headers = contents
+      .split("\n")
+      .filter((line) => line.startsWith("═══ exec"));
+    expect(headers).toHaveLength(2);
+    expect(headers[0]).toContain("11111111");
+    expect(headers[1]).toContain("22222222");
+  });
+
+  it("swallows I/O errors so a failed append never breaks execution", async () => {
+    // Point the writer at a path inside a non-existent parent directory.
+    const writer = new TranscriptWriter(path.join(workingDir, "missing-subdir"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(
+      writer.recordExecution({
+        executionId: "deadbeef",
+        origin: { kind: "code-cell", tabId: 1 },
+        code: "x = 1",
+        output: "",
+        status: "ok",
+        durationSeconds: 0.01,
+        timestamp: FIXED_TIMESTAMP,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[mcp] transcript append failed:",
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
+  });
+});
+
+describe("executeAndTranscribe", () => {
+  let workingDir: string;
+
+  beforeEach(async () => {
+    workingDir = await fs.mkdtemp(path.join(os.tmpdir(), "pdv-eat-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(workingDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Build a stub execute() that streams the supplied chunks and resolves
+   * with the given result. Mirrors KernelManager.execute's contract that
+   * deletes `stdout`/`stderr` from the result when an `onChunk` is given
+   * (kernel-manager.ts:757-759).
+   */
+  function makeStubExecute(opts: {
+    chunks: ExecuteOutputChunk[];
+    result: KernelExecuteResult;
+  }): (
+    kernelId: string,
+    request: KernelExecuteRequest,
+    onChunk?: (chunk: ExecuteOutputChunk) => void,
+  ) => Promise<KernelExecuteResult> {
+    return async (_kernelId, _request, onChunk) => {
+      for (const chunk of opts.chunks) onChunk?.(chunk);
+      const result = { ...opts.result };
+      if (onChunk) {
+        // Mirror kernel-manager: when streaming, stdout/stderr are deleted.
+        delete result.stdout;
+        delete result.stderr;
+      }
+      return result;
+    };
+  }
+
+  it("restores stdout from streamed chunks so the transcript records output", async () => {
+    const writer = new TranscriptWriter(workingDir);
+    const stubExecute = makeStubExecute({
+      chunks: [
+        { executionId: "abc", type: "stdout", text: "hello\n" },
+        { executionId: "abc", type: "stdout", text: "world\n" },
+      ],
+      result: { duration: 10 },
+    });
+
+    // Tool-shape onChunk: forwards to the renderer (we just observe it here).
+    const forwarded: ExecuteOutputChunk[] = [];
+    const result = await executeAndTranscribe(
+      stubExecute,
+      writer,
+      "k1",
+      {
+        code: "print('hello'); print('world')",
+        executionId: "abc",
+        origin: { kind: "agent", agentTool: "pdv_run" },
+      },
+      (chunk) => forwarded.push(chunk),
+    );
+
+    // The MCP tool's structured summary needs result.stdout populated.
+    expect(result.stdout).toBe("hello\nworld\n");
+    // The renderer forwarder still saw every chunk live.
+    expect(forwarded).toHaveLength(2);
+    // The transcript block carries the verbatim output.
+    const contents = await fs.readFile(writer.path, "utf8");
+    expect(contents).toContain("--- output ---\nhello\nworld\n");
+    expect(contents).toContain("agent:pdv_run");
+  });
+
+  it("handles a no-onChunk run (no streaming) by reading result.stdout directly", async () => {
+    const writer = new TranscriptWriter(workingDir);
+    const stubExecute = makeStubExecute({
+      chunks: [], // not consumed when onChunk is undefined
+      result: { stdout: "direct\n", duration: 5 },
+    });
+
+    const result = await executeAndTranscribe(
+      stubExecute,
+      writer,
+      "k1",
+      {
+        code: "print('direct')",
+        executionId: "def",
+        origin: { kind: "code-cell", tabId: 1 },
+      },
+      // no onChunk
+    );
+
+    expect(result.stdout).toBe("direct\n");
+    const contents = await fs.readFile(writer.path, "utf8");
+    expect(contents).toContain("--- output ---\ndirect\n");
+  });
+
+  it("forwards stderr accumulation alongside stdout", async () => {
+    const writer = new TranscriptWriter(workingDir);
+    const stubExecute = makeStubExecute({
+      chunks: [
+        { executionId: "x", type: "stdout", text: "ok\n" },
+        { executionId: "x", type: "stderr", text: "warn\n" },
+      ],
+      result: { duration: 2 },
+    });
+
+    const result = await executeAndTranscribe(
+      stubExecute,
+      writer,
+      "k1",
+      {
+        code: "print('ok'); print('warn', file=sys.stderr)",
+        executionId: "x",
+        origin: { kind: "agent", agentTool: "pdv_run" },
+      },
+      () => undefined,
+    );
+
+    expect(result.stdout).toBe("ok\n");
+    expect(result.stderr).toBe("warn\n");
+  });
+});

--- a/electron/main/mcp/transcript.ts
+++ b/electron/main/mcp/transcript.ts
@@ -1,0 +1,269 @@
+/**
+ * transcript.ts — Session execution transcript writer (ARCHITECTURE.md §15.7).
+ *
+ * Appends one greppable plain-text block per kernel execution (user- and
+ * agent-initiated alike) to `<workingDir>/execution-transcript.txt`. The
+ * transcript is session-scoped scratch — it lives in the kernel working
+ * directory next to `code-cells.json`, is never copied into the project
+ * save directory, is not loaded with a project, and is discarded when the
+ * working directory is torn down on shutdown.
+ *
+ * Why plain text rather than JSON-lines?
+ * The primary consumer is an MCP agent running `grep` / `head` / `tail`
+ * over the file. JSON escaping of multi-line output would break that
+ * line-oriented workflow (§15.7).
+ *
+ * Block format:
+ *
+ *     ═══ exec <id> · <iso> · <origin> · <status> · <duration>s ═══
+ *     --- code ---
+ *     <code>
+ *     --- output ---
+ *     <output verbatim>
+ *
+ * `grep '^═══ exec'` returns a full execution index;
+ * `grep ' · agent:'` filters to agent-initiated runs.
+ *
+ * See Also
+ * --------
+ * ARCHITECTURE.md §15.7 — Execution output and the transcript
+ */
+
+import { randomBytes } from "node:crypto";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+
+import type {
+  ExecuteOutputChunk,
+  KernelExecuteRequest,
+  KernelExecuteResult,
+  KernelExecutionOrigin,
+} from "../kernel-manager";
+
+/** File name for the session transcript inside the kernel working directory. */
+export const TRANSCRIPT_FILENAME = "execution-transcript.txt";
+
+/** One execution's data, as fed to {@link TranscriptWriter.recordExecution}. */
+export interface TranscriptEntry {
+  /** Caller-supplied execution id (correlates with `KernelExecuteRequest.executionId`). */
+  executionId: string;
+  /** Origin metadata (user code cell, user script, or an MCP-agent run). */
+  origin: KernelExecutionOrigin | undefined;
+  /** The source code that ran, verbatim. */
+  code: string;
+  /** The execution's output, verbatim. */
+  output: string;
+  /** Execution outcome. */
+  status: "ok" | "error";
+  /** Wall-clock duration in seconds (e.g. `0.42`). */
+  durationSeconds: number;
+  /** Optional override for the header timestamp; defaults to `new Date()`. */
+  timestamp?: Date;
+}
+
+/**
+ * Append-only writer for the session execution transcript.
+ *
+ * One instance per kernel session — its `path` is exposed in run results and
+ * in `project_info` so agents can `grep` it directly.
+ */
+export class TranscriptWriter {
+  /** Absolute path to the transcript file. */
+  readonly path: string;
+
+  /**
+   * Construct a writer rooted at the kernel working directory.
+   *
+   * @param workingDir - Absolute path to the kernel's working directory.
+   */
+  constructor(workingDir: string) {
+    this.path = path.join(workingDir, TRANSCRIPT_FILENAME);
+  }
+
+  /**
+   * Append one execution block to the transcript.
+   *
+   * I/O errors are caught and logged — transcript failure must never break
+   * the user's execution flow. The header is constructed even if `entry` is
+   * partially populated so the block remains greppable.
+   *
+   * @param entry - All data for the block to record.
+   * @returns Resolves once the block is on disk (or the error is logged).
+   */
+  async recordExecution(entry: TranscriptEntry): Promise<void> {
+    const block = formatBlock(entry);
+    try {
+      await fs.appendFile(this.path, block, "utf8");
+    } catch (err) {
+      console.error("[mcp] transcript append failed:", err);
+    }
+  }
+}
+
+/**
+ * Format one execution as a single transcript block (header + code + output).
+ *
+ * Exported for testing — production code goes through
+ * {@link TranscriptWriter.recordExecution}.
+ *
+ * @param entry - The execution data.
+ * @returns The block as a string, including its trailing blank-line
+ *   separator from the next block.
+ */
+export function formatBlock(entry: TranscriptEntry): string {
+  const timestamp = (entry.timestamp ?? new Date()).toISOString().slice(0, 19);
+  const origin = formatOrigin(entry.origin);
+  const duration = entry.durationSeconds.toFixed(2);
+  const header =
+    `═══ exec ${entry.executionId} · ${timestamp} · ${origin} · ` +
+    `${entry.status} · ${duration}s ═══`;
+  // Output is verbatim; we guarantee one trailing newline before the blank
+  // separator so `grep '^═══'` always finds the next header on its own line.
+  const output = entry.output.endsWith("\n") ? entry.output : `${entry.output}\n`;
+  return `${header}\n--- code ---\n${entry.code}\n--- output ---\n${output}\n`;
+}
+
+/**
+ * Function shape of `KernelManager.execute` — narrowed so the wrapper does
+ * not need to import the full manager (and so tests can stub it cheaply).
+ */
+export type KernelExecuteFn = (
+  kernelId: string,
+  request: KernelExecuteRequest,
+  onChunk?: (chunk: ExecuteOutputChunk) => void,
+) => Promise<KernelExecuteResult>;
+
+/**
+ * Execute on the kernel and record the run to the session transcript
+ * (ARCHITECTURE.md §15.7). Designed as a wrapper around the bare
+ * `KernelManager.execute` so every user- and agent-initiated call site can
+ * adopt it with a one-line change. The silent kernel bootstrap exec at
+ * `kernel-session.ts` is the one intentional exception — it does not flow
+ * through this wrapper.
+ *
+ * The wrapper is fail-safe: a transcript I/O error never blocks the user's
+ * execution result from returning.
+ *
+ * @param execute - Bound `kernelManager.execute` (or a stub in tests).
+ * @param transcript - The session writer, or `null` to skip recording
+ *   (e.g. before the working dir is established).
+ * @param kernelId - The kernel to run on.
+ * @param request - The execute request (forwarded verbatim).
+ * @param onChunk - Optional streaming-output listener (forwarded verbatim).
+ * @returns The kernel's execute result.
+ */
+export async function executeAndTranscribe(
+  execute: KernelExecuteFn,
+  transcript: TranscriptWriter | null,
+  kernelId: string,
+  request: KernelExecuteRequest,
+  onChunk?: (chunk: ExecuteOutputChunk) => void,
+): Promise<KernelExecuteResult> {
+  const start = Date.now();
+  // kernelManager.execute deletes `result.stdout`/`stderr`/`images` whenever
+  // an `onChunk` is supplied (defensive against renderer double-render — see
+  // kernel-manager.ts:752-761). The transcript and the MCP-tool structured
+  // summary both need the accumulated text, so we accumulate it ourselves
+  // here and patch it back onto the result before returning. The renderer
+  // is unaffected because its handler reads `l.stdout ?? result.stdout` —
+  // when streaming, `l.stdout` is already populated and shadows ours.
+  let accumulatedStdout = "";
+  let accumulatedStderr = "";
+  const composedOnChunk: ((chunk: ExecuteOutputChunk) => void) | undefined =
+    onChunk
+      ? (chunk) => {
+          if (chunk.type === "stdout" && chunk.text) {
+            accumulatedStdout += chunk.text;
+          } else if (chunk.type === "stderr" && chunk.text) {
+            accumulatedStderr += chunk.text;
+          }
+          onChunk(chunk);
+        }
+      : undefined;
+  const result = await execute(kernelId, request, composedOnChunk);
+  if (composedOnChunk) {
+    if (result.stdout === undefined && accumulatedStdout) {
+      result.stdout = accumulatedStdout;
+    }
+    if (result.stderr === undefined && accumulatedStderr) {
+      result.stderr = accumulatedStderr;
+    }
+  }
+  if (transcript) {
+    const durationSeconds =
+      typeof result.duration === "number"
+        ? result.duration / 1000
+        : (Date.now() - start) / 1000;
+    await transcript.recordExecution({
+      executionId: shortenExecutionId(request.executionId),
+      origin: request.origin,
+      code: request.code,
+      output: buildTranscriptOutput(result),
+      status: result.error ? "error" : "ok",
+      durationSeconds,
+    });
+  }
+  return result;
+}
+
+/** Build the verbatim output payload (stdout, stderr, traceback) for one run. */
+function buildTranscriptOutput(result: KernelExecuteResult): string {
+  const parts: string[] = [];
+  if (result.stdout) parts.push(result.stdout);
+  if (result.stderr) parts.push(result.stderr);
+  if (result.error) {
+    if (result.errorDetails?.traceback?.length) {
+      parts.push(result.errorDetails.traceback.join("\n"));
+    } else {
+      parts.push(result.error);
+    }
+  }
+  return parts.join("");
+}
+
+/**
+ * Short, header-friendly id for the transcript. Caller-supplied ids
+ * (typically full UUIDs) are truncated; absent ids get 8 random hex chars.
+ * 32 bits of entropy is more than enough for a session-scoped log.
+ */
+function shortenExecutionId(id: string | undefined): string {
+  if (typeof id === "string" && id.length > 0) {
+    return id.replace(/-/g, "").slice(0, 8);
+  }
+  return randomBytes(4).toString("hex");
+}
+
+/**
+ * Format a {@link KernelExecutionOrigin} as the transcript header's origin field.
+ *
+ * Examples (matching ARCHITECTURE.md §15.7):
+ * - `user:cell-2` — a code-cell run from tab 2
+ * - `user:script:scripts.fit` — a user-triggered tree script
+ * - `agent:pdv_run` — an MCP `pdv_run` tool call
+ * - `agent:script_run:scripts.fit` — an MCP `script_run` tool call
+ * - `user:unknown` — unattributed execution (e.g. legacy code paths)
+ *
+ * @param origin - The execution origin, or undefined for legacy callers.
+ * @returns The origin string for the header line.
+ */
+export function formatOrigin(origin: KernelExecutionOrigin | undefined): string {
+  if (!origin) return "user:unknown";
+  switch (origin.kind) {
+    case "code-cell":
+      return typeof origin.tabId === "number"
+        ? `user:cell-${origin.tabId}`
+        : "user:cell";
+    case "tree-script":
+      return origin.scriptPath
+        ? `user:script:${origin.scriptPath}`
+        : "user:script";
+    case "agent": {
+      const tool = origin.agentTool;
+      if (tool && origin.scriptPath) return `agent:${tool}:${origin.scriptPath}`;
+      if (tool) return `agent:${tool}`;
+      return "agent";
+    }
+    case "unknown":
+      return "user:unknown";
+  }
+}

--- a/electron/main/tree-create.ts
+++ b/electron/main/tree-create.ts
@@ -1,0 +1,302 @@
+/**
+ * tree-create.ts — Standalone helpers for creating tree-backed file nodes.
+ *
+ * The same allocate-uuid → mkdir → write-template → `*_REGISTER` flow is used
+ * by two different callers: the renderer IPC handlers
+ * (`ipc-register-tree-namespace-script.ts`) and the MCP `create_tree_node`
+ * tool (Phase 2, ARCHITECTURE.md §15.5). Both go through these helpers so the
+ * tree-create logic lives in exactly one place.
+ *
+ * What it does NOT do
+ * - It does not register IPC channels — it is a pure helper.
+ * - It does not understand non-file-backed nodes (plain dict, module). Those
+ *   take a different path through `pdv.module.*` / `pdv.tree.create_node`.
+ *
+ * See Also
+ * --------
+ * ARCHITECTURE.md §6.3 — UUID-based file storage
+ */
+
+import * as fs from "fs/promises";
+
+import type { CommRouter } from "./comm-router";
+import type { ConfigStore, PDVConfig } from "./config";
+import type {
+  TreeCreateLibResult,
+  TreeCreateNoteResult,
+  TreeCreateScriptResult,
+} from "./ipc";
+import type { KernelManager } from "./kernel-manager";
+import {
+  PDVMessageType,
+  generateNodeUuid,
+  resolveNodeDir,
+  resolveNodePath,
+  type PDVFileRegisterPayload,
+} from "./pdv-protocol";
+import type { ProjectManager } from "./project-manager";
+
+/**
+ * Analyse a tree target path against the set of known module aliases. Returns
+ * `null` when the target is not inside any known module; otherwise returns
+ * the owning module alias and the relative subdirectory inside that module
+ * where a new file should land.
+ *
+ * Example: with `knownAliases = {"toy"}` and `targetPath = "toy.scripts.fit"`,
+ * returns `{ moduleAlias: "toy", sourceRelDir: "scripts/fit" }`.
+ *
+ * @param targetPath - Dot-delimited tree path the new node will live under.
+ * @param knownAliases - Set of module aliases registered with the project.
+ * @returns Module placement info, or `null` when not in a module.
+ */
+export function analyseModuleTarget(
+  targetPath: string,
+  knownAliases: Set<string>,
+): { moduleAlias: string; sourceRelDir: string } | null {
+  const segments = targetPath.split(".").filter(Boolean);
+  if (segments.length === 0) return null;
+  const [alias, ...rest] = segments;
+  if (!knownAliases.has(alias)) return null;
+  return { moduleAlias: alias, sourceRelDir: rest.join("/") };
+}
+
+/** Shared parts of {@link AllocateScriptDeps} and {@link AllocateNoteDeps}. */
+interface CreateBaseDeps {
+  kernelManager: KernelManager;
+  commRouter: CommRouter;
+  projectManager: ProjectManager;
+  configStore: ConfigStore;
+  /** Map of kernel id → kernel working dir. May be mutated to add a new entry. */
+  kernelWorkingDirs: Map<string, string>;
+  /** Read the full config, applying defaults. */
+  readConfig: (store: ConfigStore) => PDVConfig;
+}
+
+/** Dependencies for {@link allocateAndRegisterScript}. */
+export interface AllocateScriptDeps extends CreateBaseDeps {
+  /** Module aliases the project knows about (disk manifest + in-memory pending). */
+  getKnownModuleAliases: () => Promise<Set<string>>;
+  /** Sanitize a user-supplied script file name. */
+  sanitizeScriptName: (scriptName: string, language?: "python" | "julia") => string;
+  /** Write the language-appropriate `run(...)` stub if the file is absent. */
+  ensureScriptFile: (scriptPath: string, language?: "python" | "julia") => Promise<void>;
+}
+
+/** Dependencies for {@link allocateAndRegisterNote}. */
+export type AllocateNoteDeps = CreateBaseDeps;
+
+/** Dependencies for {@link allocateAndRegisterLib}. */
+export interface AllocateLibDeps extends CreateBaseDeps {
+  /** Module aliases the project knows about (disk manifest + in-memory pending). */
+  getKnownModuleAliases: () => Promise<Set<string>>;
+  /** Write the language-appropriate lib template if the file is absent. */
+  ensureLibFile: (
+    libPath: string,
+    language: "python" | "julia",
+    moduleAlias?: string,
+  ) => Promise<void>;
+}
+
+/**
+ * Allocate a UUID-backed `.py` (or `.jl`) script under the kernel working dir,
+ * write its run-stub, and register the node with the kernel.
+ *
+ * Mirrors the body of the `IPC.tree.createScript` handler so both that
+ * handler and the MCP `create_tree_node` tool reuse one path.
+ *
+ * @param deps - Dependency bag (managers + injected helpers).
+ * @param kernelId - The kernel whose working dir owns the new file.
+ * @param targetPath - Parent tree path. Empty string for the root.
+ * @param scriptName - User-supplied script name (sanitized).
+ * @returns The script's absolute file path and the new tree path.
+ * @throws {Error} When the kernel is not found.
+ */
+export async function allocateAndRegisterScript(
+  deps: AllocateScriptDeps,
+  kernelId: string,
+  targetPath: string,
+  scriptName: string,
+): Promise<TreeCreateScriptResult> {
+  const kernel = deps.kernelManager.getKernel(kernelId);
+  if (!kernel) {
+    throw new Error(`Kernel not found: ${kernelId}`);
+  }
+  const language = kernel.language;
+  const workingDir = await ensureWorkingDir(deps, kernelId);
+  const safeName = deps.sanitizeScriptName(scriptName, language);
+  const scriptNodeName = stripExtension(safeName);
+
+  const knownAliases = await deps.getKnownModuleAliases();
+  const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
+
+  const nodeUuid = generateNodeUuid();
+  const scriptPath = resolveNodePath(workingDir, nodeUuid, safeName);
+  await fs.mkdir(resolveNodeDir(workingDir, nodeUuid), { recursive: true });
+  await deps.ensureScriptFile(scriptPath, language);
+
+  let sourceRelPath: string | undefined;
+  let moduleId: string | undefined;
+  if (moduleInfo) {
+    sourceRelPath = moduleInfo.sourceRelDir
+      ? `${moduleInfo.sourceRelDir}/${safeName}`
+      : safeName;
+    moduleId = moduleInfo.moduleAlias;
+  }
+
+  const treePath = targetPath ? `${targetPath}.${scriptNodeName}` : scriptNodeName;
+  await deps.commRouter.request(PDVMessageType.SCRIPT_REGISTER, {
+    parent_path: targetPath,
+    name: scriptNodeName,
+    uuid: nodeUuid,
+    filename: safeName,
+    language,
+    module_id: moduleId,
+    source_rel_path: sourceRelPath,
+  });
+  return { success: true, scriptPath, treePath };
+}
+
+/**
+ * Allocate a UUID-backed `.md` note under the kernel working dir, write an
+ * empty file, and register the node with the kernel.
+ *
+ * @param deps - Dependency bag.
+ * @param kernelId - The kernel whose working dir owns the new file.
+ * @param targetPath - Parent tree path. Empty string for the root.
+ * @param noteName - User-supplied note name. Sanitized inline.
+ * @returns The note's absolute file path and the new tree path.
+ * @throws {Error} When the kernel is not found.
+ */
+export async function allocateAndRegisterNote(
+  deps: AllocateNoteDeps,
+  kernelId: string,
+  targetPath: string,
+  noteName: string,
+): Promise<TreeCreateNoteResult> {
+  if (!deps.kernelManager.getKernel(kernelId)) {
+    throw new Error(`Kernel not found: ${kernelId}`);
+  }
+  const workingDir = await ensureWorkingDir(deps, kernelId);
+  const safeName = sanitizeNoteName(noteName);
+  const nodeUuid = generateNodeUuid();
+  const noteFilename = `${safeName}.md`;
+  const notePath = resolveNodePath(workingDir, nodeUuid, noteFilename);
+  await fs.mkdir(resolveNodeDir(workingDir, nodeUuid), { recursive: true });
+  try {
+    await fs.access(notePath);
+  } catch {
+    await fs.writeFile(notePath, "", "utf-8");
+  }
+  const treePath = targetPath ? `${targetPath}.${safeName}` : safeName;
+  await deps.commRouter.request(PDVMessageType.NOTE_REGISTER, {
+    parent_path: targetPath,
+    name: safeName,
+    uuid: nodeUuid,
+    filename: noteFilename,
+  });
+  return { success: true, notePath, treePath };
+}
+
+/**
+ * Allocate a UUID-backed lib file (`.py` today) under the kernel working dir,
+ * write its template, and register it via the file-register comm with
+ * `node_type: "lib"`. Lib files are importable Python modules other PDV
+ * scripts can `from <project>.<lib> import …` from.
+ *
+ * @param deps - Dependency bag.
+ * @param kernelId - The kernel whose working dir owns the new file.
+ * @param targetPath - Parent tree path. Empty string for the root.
+ * @param libName - User-supplied lib name (sanitized to a Python identifier).
+ * @returns The lib's absolute file path and the new tree path.
+ * @throws {Error} When the kernel is not found or the name is empty after sanitization.
+ */
+export async function allocateAndRegisterLib(
+  deps: AllocateLibDeps,
+  kernelId: string,
+  targetPath: string,
+  libName: string,
+): Promise<TreeCreateLibResult> {
+  const kernel = deps.kernelManager.getKernel(kernelId);
+  if (!kernel) {
+    throw new Error(`Kernel not found: ${kernelId}`);
+  }
+  const language = kernel.language;
+  const workingDir = await ensureWorkingDir(deps, kernelId);
+  const stem = libName
+    .trim()
+    .replace(/\.py$/i, "")
+    .replace(/\s+/g, "_")
+    .replace(/[^a-zA-Z0-9_]/g, "");
+  if (!stem) {
+    throw new Error("Lib name must contain at least one letter or number.");
+  }
+  const filename = `${stem}.py`;
+
+  const knownAliases = await deps.getKnownModuleAliases();
+  const moduleInfo = analyseModuleTarget(targetPath, knownAliases);
+
+  const nodeUuid = generateNodeUuid();
+  const libPath = resolveNodePath(workingDir, nodeUuid, filename);
+  await fs.mkdir(resolveNodeDir(workingDir, nodeUuid), { recursive: true });
+  await deps.ensureLibFile(libPath, language, moduleInfo?.moduleAlias);
+
+  await deps.commRouter.request(PDVMessageType.FILE_REGISTER, {
+    tree_path: targetPath,
+    filename,
+    uuid: nodeUuid,
+    node_type: "lib",
+    name: stem,
+    ...(moduleInfo
+      ? {
+          module_id: moduleInfo.moduleAlias,
+          source_rel_path: moduleInfo.sourceRelDir
+            ? `${moduleInfo.sourceRelDir}/${filename}`
+            : filename,
+        }
+      : {}),
+  } satisfies PDVFileRegisterPayload);
+
+  if (moduleInfo) {
+    await deps.commRouter.request(PDVMessageType.MODULES_SETUP, {
+      modules: [{ alias: moduleInfo.moduleAlias }],
+    });
+  }
+
+  const treePath = targetPath ? `${targetPath}.${stem}` : stem;
+  return { success: true, libPath, treePath };
+}
+
+/**
+ * Ensure the kernel has a working dir; create one (and record it) on first use.
+ *
+ * @param deps - Dependency bag.
+ * @param kernelId - The kernel id.
+ * @returns The kernel's working dir path.
+ */
+async function ensureWorkingDir(
+  deps: CreateBaseDeps,
+  kernelId: string,
+): Promise<string> {
+  let workingDir = deps.kernelWorkingDirs.get(kernelId);
+  if (!workingDir) {
+    workingDir = await deps.projectManager.createWorkingDir(
+      deps.readConfig(deps.configStore).workingDirBase,
+    );
+    deps.kernelWorkingDirs.set(kernelId, workingDir);
+  }
+  return workingDir;
+}
+
+/** Sanitize a user-supplied note name to a filesystem-safe slug. */
+function sanitizeNoteName(noteName: string): string {
+  return noteName
+    .trim()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-zA-Z0-9_-]/g, "");
+}
+
+/** Strip the file extension from `filename` (`"fit.py"` → `"fit"`). */
+function stripExtension(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  return dot > 0 ? filename.slice(0, dot) : filename;
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -53,6 +53,8 @@ const api: PDVApi = {
     validate: (executablePath, language) =>
       ipcRenderer.invoke(IPC.kernels.validate, executablePath, language),
     onOutput: (callback) => onPush(IPC.push.executeOutput, callback),
+    onExecuteBegin: (callback) => onPush(IPC.push.executeBegin, callback),
+    onExecuteFinish: (callback) => onPush(IPC.push.executeFinish, callback),
     onKernelCrashed: (callback) => onPush(IPC.push.kernelCrashed, callback),
     onReconnected: (callback) => onPush(IPC.push.kernelReconnected, callback),
     onMemory: (callback) => onPush(IPC.push.kernelMemory, callback),
@@ -173,6 +175,11 @@ const api: PDVApi = {
       const offEnd = onPush<void>(IPC.push.autosaveEnded, () => cb(false));
       return () => { offStart(); offEnd(); };
     },
+  },
+  cells: {
+    onRequest: (cb) => onPush(IPC.push.cellsRequest, cb),
+    onWrite: (cb) => onPush(IPC.push.cellWrite, cb),
+    respond: (response) => ipcRenderer.invoke(IPC.cells.respond, response),
   },
   about: {
     getVersion: () => ipcRenderer.invoke(IPC.about.getVersion),

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -1024,12 +1024,13 @@ const App: React.FC = () => {
       }
     });
     const offWrite = window.pdv.cells.onWrite((write) => {
-      let createdId: number | null = null;
+      let activatedId: number | null = null;
       setCellTabs((prev) => {
         if (
           typeof write.tabId === 'number' &&
           prev.some((t) => t.id === write.tabId)
         ) {
+          activatedId = write.tabId;
           return prev.map((t) =>
             t.id === write.tabId
               ? { ...t, code: write.code, name: write.name ?? t.name }
@@ -1038,17 +1039,18 @@ const App: React.FC = () => {
         }
         const nextId =
           prev.length === 0 ? 1 : Math.max(...prev.map((t) => t.id)) + 1;
-        createdId = nextId;
+        activatedId = nextId;
         return [
           ...prev,
           { id: nextId, code: write.code, name: write.name },
         ];
       });
-      // Activating the new tab takes the user's focus to where the agent
-      // just wrote — without this, an agent-appended cell stays out of view
-      // and feels like nothing happened.
-      if (createdId !== null) {
-        setActiveCellTab(createdId);
+      // Bring focus to whichever tab the agent just wrote — both append and
+      // overwrite. Without this on overwrite, an agent edit to a non-active
+      // tab is silent ("agent rewrote cell 3, user was on cell 5"), which is
+      // the same surprise the append case would have without activation.
+      if (activatedId !== null) {
+        setActiveCellTab(activatedId);
       }
     });
     return () => {

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -983,6 +983,80 @@ const App: React.FC = () => {
     return unsub;
   }, [activeCellTab]);
 
+  // MCP cell tools (ARCHITECTURE.md §15.8): the main process pushes cell
+  // read requests for `cell_list`/`cell_read` and one-way `cell_write`
+  // pushes. Mirrors the autosave round-trip pattern above.
+  useEffect(() => {
+    if (!window.pdv?.cells) return;
+    const offRequest = window.pdv.cells.onRequest((req) => {
+      const tabs = cellTabsRef.current;
+      const respond = window.pdv.cells.respond;
+      if (req.op === 'list') {
+        void respond({
+          requestId: req.requestId,
+          ok: true,
+          result: {
+            tabs: tabs.map((t) => ({
+              id: t.id,
+              name: t.name,
+              length: t.code.length,
+            })),
+            activeTabId: activeCellTab ?? null,
+          },
+        });
+        return;
+      }
+      if (req.op === 'read') {
+        const tab = tabs.find((t) => t.id === req.tabId);
+        if (!tab) {
+          void respond({
+            requestId: req.requestId,
+            ok: false,
+            error: `No cell tab with id ${req.tabId}`,
+          });
+          return;
+        }
+        void respond({
+          requestId: req.requestId,
+          ok: true,
+          result: { id: tab.id, name: tab.name, code: tab.code },
+        });
+      }
+    });
+    const offWrite = window.pdv.cells.onWrite((write) => {
+      let createdId: number | null = null;
+      setCellTabs((prev) => {
+        if (
+          typeof write.tabId === 'number' &&
+          prev.some((t) => t.id === write.tabId)
+        ) {
+          return prev.map((t) =>
+            t.id === write.tabId
+              ? { ...t, code: write.code, name: write.name ?? t.name }
+              : t,
+          );
+        }
+        const nextId =
+          prev.length === 0 ? 1 : Math.max(...prev.map((t) => t.id)) + 1;
+        createdId = nextId;
+        return [
+          ...prev,
+          { id: nextId, code: write.code, name: write.name },
+        ];
+      });
+      // Activating the new tab takes the user's focus to where the agent
+      // just wrote — without this, an agent-appended cell stays out of view
+      // and feels like nothing happened.
+      if (createdId !== null) {
+        setActiveCellTab(createdId);
+      }
+    });
+    return () => {
+      offRequest();
+      offWrite();
+    };
+  }, [activeCellTab]);
+
   // Whether the session has no user work (no project, no code, no logs, no notes).
   const isPristine = currentProjectDir === null
     && cellTabs.every((t) => !t.code.trim())

--- a/electron/renderer/src/app/useKernelSubscriptions.ts
+++ b/electron/renderer/src/app/useKernelSubscriptions.ts
@@ -1,6 +1,7 @@
 import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
 import type { CellTab, LogEntry, TreeChangeInfo } from '../types';
 import type { ProgressPayload } from '../types/pdv';
+import { MAX_LOG_ENTRIES } from './constants';
 
 /** Options for {@link useKernelSubscriptions}. Manages push-subscription lifecycle. */
 interface UseKernelSubscriptionsOptions {
@@ -58,6 +59,50 @@ export function useKernelSubscriptions({
       );
     });
     return unsubscribe;
+  }, [setLogs]);
+
+  // Main-initiated runs (MCP agent tools) push a `begin` event before the
+  // first chunk so we can seed a log entry — without that, `onOutput`
+  // chunks find no row to attach to and the Console stays empty for agent
+  // activity. `finish` carries duration/error info that does not arrive
+  // via streaming chunks. The renderer's own `kernels.execute` calls do
+  // not emit these pushes; they seed their log entries locally.
+  useEffect(() => {
+    const offBegin = window.pdv.kernels.onExecuteBegin((payload) => {
+      setLogs((prev) => {
+        if (prev.some((l) => l.id === payload.executionId)) return prev;
+        const next: LogEntry[] = [
+          ...prev,
+          {
+            id: payload.executionId,
+            timestamp: payload.timestamp,
+            code: payload.code,
+            origin: payload.origin,
+          },
+        ];
+        return next.length > MAX_LOG_ENTRIES
+          ? next.slice(next.length - MAX_LOG_ENTRIES)
+          : next;
+      });
+    });
+    const offFinish = window.pdv.kernels.onExecuteFinish((payload) => {
+      setLogs((prev) =>
+        prev.map((l) =>
+          l.id === payload.executionId
+            ? {
+                ...l,
+                duration: payload.duration,
+                error: payload.error,
+                errorDetails: payload.errorDetails,
+              }
+            : l,
+        ),
+      );
+    });
+    return () => {
+      offBegin();
+      offFinish();
+    };
   }, [setLogs]);
 
   useEffect(() => {

--- a/electron/renderer/src/components/Console/index.tsx
+++ b/electron/renderer/src/components/Console/index.tsx
@@ -162,6 +162,12 @@ function formatSourceLabel(source: LogEntry['origin']): string | undefined {
   if (source.kind === 'tree-script') {
     return source.label ? `Script: ${source.label}` : 'Script';
   }
+  if (source.kind === 'agent') {
+    const tool = source.agentTool;
+    if (tool && source.label) return `Agent · ${tool}: ${source.label}`;
+    if (tool) return `Agent · ${tool}`;
+    return source.label ? `Agent: ${source.label}` : 'Agent';
+  }
   return source.label ? `Execution: ${source.label}` : 'Execution';
 }
 

--- a/electron/renderer/src/test-fixtures/pdv-mock.ts
+++ b/electron/renderer/src/test-fixtures/pdv-mock.ts
@@ -50,6 +50,8 @@ function buildBase() {
       inspect: stub<PDVApi["kernels"]["inspect"]>(async () => ({ found: false })),
       validate: stub<PDVApi["kernels"]["validate"]>(async () => ({ valid: true })),
       onOutput: subStub<PDVApi["kernels"]["onOutput"]>(),
+      onExecuteBegin: subStub<PDVApi["kernels"]["onExecuteBegin"]>(),
+      onExecuteFinish: subStub<PDVApi["kernels"]["onExecuteFinish"]>(),
       onKernelCrashed: subStub<PDVApi["kernels"]["onKernelCrashed"]>(),
       onReconnected: subStub<PDVApi["kernels"]["onReconnected"]>(),
       onMemory: subStub<PDVApi["kernels"]["onMemory"]>(),
@@ -150,6 +152,11 @@ function buildBase() {
       deleteOrphan: stub<PDVApi["autosave"]["deleteOrphan"]>(async () => undefined),
       onTrigger: subStub<PDVApi["autosave"]["onTrigger"]>(),
       onInFlightChange: subStub<PDVApi["autosave"]["onInFlightChange"]>(),
+    },
+    cells: {
+      onRequest: subStub<PDVApi["cells"]["onRequest"]>(),
+      onWrite: subStub<PDVApi["cells"]["onWrite"]>(),
+      respond: stub<PDVApi["cells"]["respond"]>(async () => undefined),
     },
     about: {
       getVersion: stub<PDVApi["about"]["getVersion"]>(async () => "0.0.0-test"),

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -62,10 +62,12 @@ export interface KernelSpec {
 
 /** Execution source metadata attached to execute requests/results. */
 export interface KernelExecutionOrigin {
-  kind: "code-cell" | "tree-script" | "unknown";
+  kind: "code-cell" | "tree-script" | "agent" | "unknown";
   label?: string;
   tabId?: number;
   scriptPath?: string;
+  /** MCP tool name when `kind === "agent"` (e.g. "pdv_run", "script_run"). */
+  agentTool?: string;
 }
 
 /** Parsed traceback location metadata surfaced in execution errors. */
@@ -694,6 +696,63 @@ export interface McpStatus {
   generation: number;
 }
 
+/**
+ * Cell-tool RPC payloads mirroring the types in `main/ipc.ts`. The main
+ * process drives reads via `cellsRequest`/`respond` and writes via
+ * `cellWrite` (ARCHITECTURE.md §15.8).
+ */
+export interface CellsRequestPush {
+  requestId: string;
+  op: "list" | "read";
+  tabId?: number;
+}
+
+export interface CellListEntry {
+  id: number;
+  name?: string;
+  length: number;
+}
+
+export interface CellListResult {
+  tabs: CellListEntry[];
+  activeTabId: number | null;
+}
+
+export interface CellReadResult {
+  id: number;
+  name?: string;
+  code: string;
+}
+
+export interface CellsResponse {
+  requestId: string;
+  ok: boolean;
+  result?: CellListResult | CellReadResult;
+  error?: string;
+}
+
+/** Mirrors `ExecuteBeginPayload` in `main/ipc.ts`. */
+export interface ExecuteBeginPayload {
+  executionId: string;
+  code: string;
+  origin: KernelExecutionOrigin;
+  timestamp: number;
+}
+
+/** Mirrors `ExecuteFinishPayload` in `main/ipc.ts`. */
+export interface ExecuteFinishPayload {
+  executionId: string;
+  duration: number;
+  error?: string;
+  errorDetails?: KernelExecutionError;
+}
+
+export interface CellWritePush {
+  tabId?: number;
+  code: string;
+  name?: string;
+}
+
 export interface PDVApi {
   kernels: {
     list(): Promise<KernelInfo[]>;
@@ -722,6 +781,8 @@ export interface PDVApi {
       language: "python" | "julia"
     ): Promise<{ valid: boolean; error?: string }>;
     onOutput(callback: (chunk: ExecuteOutputChunk) => void): () => void;
+    onExecuteBegin(callback: (payload: ExecuteBeginPayload) => void): () => void;
+    onExecuteFinish(callback: (payload: ExecuteFinishPayload) => void): () => void;
     onKernelCrashed(callback: (payload: { kernelId: string }) => void): () => void;
     onReconnected(callback: (payload: { kernelId: string }) => void): () => void;
     onMemory(callback: (payload: KernelMemoryPayload) => void): () => void;
@@ -897,6 +958,16 @@ export interface PDVApi {
     deleteOrphan(orphanDir: string): Promise<void>;
     onTrigger(callback: () => void): () => void;
     onInFlightChange(callback: (inFlight: boolean) => void): () => void;
+  };
+  /**
+   * MCP cell-tool round-trip (ARCHITECTURE.md §15.8). The main process pushes
+   * `cells.onRequest` and reads the renderer's reply via `cells.respond`;
+   * `cells.onWrite` is one-way main → renderer.
+   */
+  cells: {
+    onRequest(callback: (req: CellsRequestPush) => void): () => void;
+    onWrite(callback: (write: CellWritePush) => void): () => void;
+    respond(response: CellsResponse): Promise<void>;
   };
   about: {
     getVersion(): Promise<string>;

--- a/pdv-python/pdv/handlers/introspection.py
+++ b/pdv-python/pdv/handlers/introspection.py
@@ -74,20 +74,32 @@ def _resolve_symbol(symbol: str) -> Any:
     else:
         loaded = sys.modules.get(head)
         if loaded is None:
-            raise ModuleNotFoundError(
-                f"Module '{head}' is not loaded; pdv.help does not "
-                f"implicitly import modules"
-            )
-        obj = loaded
-        # Walk the longest already-loaded dotted prefix.
-        while rest:
-            candidate = f"{head}.{rest[0]}"
-            submodule = sys.modules.get(candidate)
-            if submodule is None:
-                break
-            obj = submodule
-            head = candidate
-            rest = rest[1:]
+            # Bare-name fallback: try `<head>` as an attribute of the pdv
+            # package so `pdv.help("PDVScript")` works the same way
+            # `from pdv import PDVScript` would. This is what a user sitting
+            # at the kernel would type, and the original "Module not loaded"
+            # error was actively misleading for it.
+            pdv_module = sys.modules.get("pdv")
+            if pdv_module is not None and hasattr(pdv_module, head):
+                obj = getattr(pdv_module, head)
+            else:
+                raise ModuleNotFoundError(
+                    f"Could not resolve '{symbol}': '{head}' is not loaded "
+                    f"in the kernel. Try the fully qualified name (e.g. "
+                    f"'pdv.{head}') or use a variable from the namespace. "
+                    f"pdv.help does not implicitly import modules."
+                )
+        else:
+            obj = loaded
+            # Walk the longest already-loaded dotted prefix.
+            while rest:
+                candidate = f"{head}.{rest[0]}"
+                submodule = sys.modules.get(candidate)
+                if submodule is None:
+                    break
+                obj = submodule
+                head = candidate
+                rest = rest[1:]
 
     for attr in rest:
         obj = getattr(obj, attr)

--- a/pdv-python/tests/test_introspection_handlers.py
+++ b/pdv-python/tests/test_introspection_handlers.py
@@ -147,6 +147,27 @@ class TestHandleHelp:
         assert response["status"] == "error"
         assert response["payload"]["code"] == "introspection.symbol_not_found"
 
+    def test_resolves_bare_pdv_class_name(self):
+        """pdv.help resolves a bare class name like 'PDVScript' by falling
+        back to looking up attributes of the loaded `pdv` module — the
+        same way `from pdv import PDVScript` works at the kernel."""
+        ip = MagicMock()
+        ip.user_ns = {}
+        mock_comm = _make_mock_comm()
+        msg = _make_msg("pdv.help", {"symbol": "PDVScript"})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_ip", ip),
+        ):
+            handle_help(msg)
+
+        response = mock_comm._sent[0]
+        assert response["type"] == "pdv.help.response"
+        assert response["status"] == "ok"
+        payload = response["payload"]
+        assert payload["symbol"] == "PDVScript"
+        assert payload["kind"] == "class"
+
     def test_does_not_implicitly_import_modules(self):
         """pdv.help refuses to introspect a symbol whose head module is not
         already loaded in sys.modules, instead of triggering an import.


### PR DESCRIPTION
## Summary

Phase 2 of the local MCP server (#180, ARCHITECTURE.md §15), on top of Phase 1's read-only surface. Nine new tools, the renderer plumbing they ride on, and the execution transcript that lets an agent inspect its own runs.

**Tool surface (9 new — 16 total now):**

- **`create_tree_node`** — dispatches by type to \`dict\` / \`script\` / \`note\` / \`lib\`. File-backed types return both the on-disk path and the stub contents inline so the agent doesn't need a second read.
- **`delete_tree_node`** — always raises a native PDV confirmation dialog (60 s timeout, default-cancel) before issuing \`pdv.tree.delete\`. The agent cannot bypass it.
- **`move_tree_node`** — single tool for both rename (same parent) and move (different parent); UUID storage decouples the tree path from disk.
- **`script_run`** / **`pdv_run`** — run code in the live kernel with \`origin: { kind: \"agent\", agentTool: ... }\`. \`pdv_run\` is gated by its own switch.
- **`cell_list`** / **`cell_read`** / **`cell_write`** / **`cell_run`** — main↔renderer round-trip via the new cell-RPC client. \`cell_write\` that appends a new tab auto-activates it.

**Infrastructure:**

- \`KernelExecutionOrigin\` gains an \`agent\` kind + \`agentTool\` field; \`Console\` label and \`kernel-error-parser\` both handle it explicitly.
- \`TranscriptWriter\` (\`electron/main/mcp/transcript.ts\`) appends one §15.7 block per kernel run to \`<workingDir>/execution-transcript.txt\`. \`executeAndTranscribe\` wraps every non-bootstrap \`KernelManager.execute\` call site and accumulates stdout/stderr from streamed chunks so both the transcript and the structured tool summary see the verbatim output.
- \`IPC.push.executeBegin\` / \`executeFinish\` push pair so main-initiated runs seed a renderer Console log entry and finalize it with duration and error — agent runs now appear live in the Console alongside user runs.
- \`CellRpcClient\` (\`electron/main/mcp/cell-rpc.ts\`) — request/response client for renderer-owned cell tabs.
- Mutating-tier register-but-throw gate driven by \`mcp.mutatingToolsEnabled\` and \`mcp.pdvRunEnabled\`; toggles read per-call so a Settings change takes effect without a reconnect.
- Tree-create helpers extracted to \`electron/main/tree-create.ts\` so the IPC handlers and the MCP \`create_tree_node\` share one path.
- Uniform \"read before write if your harness requires it\" hint in every file-backed create response.

## Out of scope (follow-ups)

- Other \`create_tree_node\` types (\`gui\`, \`namelist\`, \`file\`, \`module\`) — incremental adds; lib is the third file-backed shape and proves the pattern.
- Combined \`pdv.tree.get_node\` kernel handler (deferred review item from Phase 1) — latency optimization for the file-backed-node lookup path; still two queries today.
- Playwright E2E for the cell round-trip — covered by the live smoke test.
- Phase 3 (visual coupling, status-bar dot) is its own PR.

## Test plan

- [x] \`cd electron && npm run build:main\` — clean
- [x] \`cd electron && npm run typecheck:renderer\` — clean
- [x] \`cd electron && npm test\` — vitest **453 / 453** (+23 new: 17 transcript + 7 cell-rpc + 1 introspection regression — counting from Phase 1 baseline)
- [x] \`cd pdv-python && pytest tests/ -v\` — green
- [x] **\`pdv-python/scripts/sweep-deps.sh\`** — **all green**
- [x] **Live smoke test** with a real Claude Code agent: three rounds end-to-end, all 16 tools exercised. Confirmed: \`script_run\` / \`cell_run\` / \`pdv_run\` outputs land in the structured summary, in the §15.7 transcript, AND live in the renderer Console with \`Agent · <tool>\` labels; \`cell_write\` swings tab focus to the new cell; \`delete_tree_node\` confirm dialog round-trips; \`pdv.help(\"PDVScript\")\` bare-name fallback works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)