### PR TITLE
fix: stop forcing MCP reconnect on save + add cell_write read-before-write guard

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -566,8 +566,9 @@ export function registerIpcHandlers(
       // sessions — but the initial null -> id assignment at window startup
       // is not a switch (the agent hasn't seen this kernel yet) and bumping
       // there would surface a misleading "PDV's project or kernel has
-      // changed" error on an eager agent's first call.
-      if (prevId !== null) {
+      // changed" error on an eager agent's first call. Likewise, re-asserting
+      // the same id is not a switch.
+      if (prevId !== null && prevId !== id) {
         bumpGeneration();
       }
       if (id) {
@@ -650,9 +651,11 @@ export function registerIpcHandlers(
     setActiveProjectDir: (dir) => {
       const prevDir = activeProjectDir;
       activeProjectDir = dir;
-      // Only a *change* invalidates connected MCP sessions; the initial
-      // null -> dir assignment at window startup is not a project switch.
-      if (prevDir !== null) {
+      // Only a *change* invalidates connected MCP sessions. The initial
+      // null -> dir assignment at window startup is not a project switch,
+      // and `project:save` re-asserts the same dir on every save — bumping
+      // there would force the agent to reconnect after each save.
+      if (prevDir !== null && prevDir !== dir) {
         bumpGeneration();
       }
     },

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -28,6 +28,7 @@ import { buildEditorSpawn, resolveEditorSpawn } from "./editor-spawn";
 import { registerKernelIpcHandlers } from "./ipc-register-kernels";
 import { registerModulesIpcHandlers } from "./ipc-register-modules";
 import { registerProjectIpcHandlers } from "./ipc-register-project";
+import { shouldBumpOnSwap } from "./mcp/generation-guard";
 import { mirrorAutosaveSidecars, autosaveDirFor } from "./autosave-sidecars";
 import { KernelManager } from "./kernel-manager";
 import { ModuleManager } from "./module-manager";
@@ -563,12 +564,9 @@ export function registerIpcHandlers(
       const prevId = activeKernelId;
       activeKernelId = id;
       // A kernel switch (restart, language change) invalidates connected MCP
-      // sessions — but the initial null -> id assignment at window startup
-      // is not a switch (the agent hasn't seen this kernel yet) and bumping
-      // there would surface a misleading "PDV's project or kernel has
-      // changed" error on an eager agent's first call. Likewise, re-asserting
-      // the same id is not a switch.
-      if (prevId !== null && prevId !== id) {
+      // sessions. See `shouldBumpOnSwap` for the no-bump cases (initial set,
+      // re-assertion of the same id).
+      if (shouldBumpOnSwap(prevId, id)) {
         bumpGeneration();
       }
       if (id) {
@@ -651,11 +649,10 @@ export function registerIpcHandlers(
     setActiveProjectDir: (dir) => {
       const prevDir = activeProjectDir;
       activeProjectDir = dir;
-      // Only a *change* invalidates connected MCP sessions. The initial
-      // null -> dir assignment at window startup is not a project switch,
-      // and `project:save` re-asserts the same dir on every save — bumping
-      // there would force the agent to reconnect after each save.
-      if (prevDir !== null && prevDir !== dir) {
+      // Only a real switch invalidates connected MCP sessions. See
+      // `shouldBumpOnSwap` for the no-bump cases (initial set; re-assertion
+      // of the same dir, which `project:save` does on every save).
+      if (shouldBumpOnSwap(prevDir, dir)) {
         bumpGeneration();
       }
     },

--- a/electron/main/mcp/generation-guard.test.ts
+++ b/electron/main/mcp/generation-guard.test.ts
@@ -1,0 +1,36 @@
+/**
+ * generation-guard.test.ts — Unit tests for the MCP generation-bump predicate.
+ *
+ * Locks in the contract that:
+ *  - first set (null -> X) does not bump (the agent has not seen anything yet)
+ *  - re-assertion (X -> X) does not bump (e.g. `project:save` re-asserting
+ *    the same `saveDir` after every save) — this is the regression PR #291
+ *    was opened to fix
+ *  - real change (X -> Y, X -> null) bumps
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { shouldBumpOnSwap } from "./generation-guard";
+
+describe("shouldBumpOnSwap", () => {
+  it("does not bump on the initial null -> X assignment", () => {
+    expect(shouldBumpOnSwap(null, "/proj/a")).toBe(false);
+    expect(shouldBumpOnSwap(null, null)).toBe(false);
+  });
+
+  it("does not bump when re-asserting the same value (project:save pattern)", () => {
+    expect(shouldBumpOnSwap("/proj/a", "/proj/a")).toBe(false);
+    expect(shouldBumpOnSwap("kernel-1", "kernel-1")).toBe(false);
+  });
+
+  it("bumps when the value actually changes between two set values", () => {
+    expect(shouldBumpOnSwap("/proj/a", "/proj/b")).toBe(true);
+    expect(shouldBumpOnSwap("kernel-1", "kernel-2")).toBe(true);
+  });
+
+  it("bumps when transitioning from a set value to null (project close)", () => {
+    expect(shouldBumpOnSwap("/proj/a", null)).toBe(true);
+    expect(shouldBumpOnSwap("kernel-1", null)).toBe(true);
+  });
+});

--- a/electron/main/mcp/generation-guard.ts
+++ b/electron/main/mcp/generation-guard.ts
@@ -1,0 +1,37 @@
+/**
+ * generation-guard.ts — Predicate for bumping the MCP project/kernel
+ * generation counter (ARCHITECTURE.md §15.3).
+ *
+ * The counter must bump only when the active project dir or kernel id
+ * actually *changes from one set value to another or to null* — i.e. a real
+ * project/kernel switch. The two cases that look like a "set" but aren't a
+ * switch:
+ *
+ *   - initial `null -> X` at window startup (no agent has seen any state yet)
+ *   - re-asserting the same value (`X -> X`), as `project:save` does on every
+ *     save when it calls `setActiveProjectDir(saveDir)`
+ *
+ * Both must NOT bump, or any connected MCP agent will see a misleading
+ * "PDV's project or kernel has changed since this MCP session connected.
+ * Reconnect the MCP client to continue." error.
+ *
+ * This file holds the predicate as a pure function so it can be unit-tested
+ * independent of the IPC closure that owns the mutable `activeProjectDir` /
+ * `activeKernelId` state.
+ */
+
+/**
+ * Returns true when transitioning `prev -> next` is a real switch that
+ * should bump the MCP generation counter.
+ *
+ * A real switch requires `prev` to have been set (non-null) AND the new
+ * value to differ from the old. `null -> X` (first set) and `X -> X`
+ * (re-assertion, e.g. project:save) are both no-ops.
+ *
+ * @param prev - The previous value (`null` when never set in this session).
+ * @param next - The value being assigned.
+ * @returns Whether to call `bumpGeneration()`.
+ */
+export function shouldBumpOnSwap<T>(prev: T | null, next: T | null): boolean {
+  return prev !== null && prev !== next;
+}

--- a/electron/main/mcp/mcp-context.ts
+++ b/electron/main/mcp/mcp-context.ts
@@ -121,4 +121,33 @@ export interface McpToolContext {
    * @returns The connect-time generation, or `undefined`.
    */
   getSessionGeneration(sessionId: string | undefined): number | undefined;
+  /**
+   * Record that the calling MCP session has just read a code-cell tab, along
+   * with a hash of the source that was returned. Used by the `cell_write`
+   * read-before-write guard to detect concurrent edits by the user or
+   * another agent.
+   *
+   * @param sessionId - The MCP session id (or `undefined` for an unknown
+   *   session — recorded but never matched).
+   * @param tabId - The cell tab id.
+   * @param code - The cell source the session just observed.
+   */
+  recordCellRead(
+    sessionId: string | undefined,
+    tabId: number,
+    code: string,
+  ): void;
+  /**
+   * Hash of the cell source the given session most recently observed for the
+   * given tab, or `undefined` when the session has not read that tab in this
+   * connection.
+   *
+   * @param sessionId - The MCP session id, or `undefined`.
+   * @param tabId - The cell tab id.
+   * @returns The recorded hash, or `undefined`.
+   */
+  getCellReadHash(
+    sessionId: string | undefined,
+    tabId: number,
+  ): string | undefined;
 }

--- a/electron/main/mcp/mcp-instructions.ts
+++ b/electron/main/mcp/mcp-instructions.ts
@@ -30,4 +30,9 @@ cells) and run through PDV so results integrate into the project Tree. Do not
 run ad-hoc analysis or produce plots outside PDV.
 
 Use the pdv_help tool to introspect the pdv library API and any project symbol.
+
+Code cells: call cell_read before cell_write on an existing tab — the
+read-before-write guard rejects an overwrite when the session hasn't read the
+tab, or when the cell changed since the last read (a user or another agent
+edited it). To create a new tab, call cell_write without tab_id.
 `;

--- a/electron/main/mcp/mcp-instructions.ts
+++ b/electron/main/mcp/mcp-instructions.ts
@@ -31,8 +31,9 @@ run ad-hoc analysis or produce plots outside PDV.
 
 Use the pdv_help tool to introspect the pdv library API and any project symbol.
 
-Code cells: call cell_read before cell_write on an existing tab — the
-read-before-write guard rejects an overwrite when the session hasn't read the
-tab, or when the cell changed since the last read (a user or another agent
-edited it). To create a new tab, call cell_write without tab_id.
+Code cells: cell_write with a tab_id requires (a) the tab_id to refer to an
+existing tab and (b) you to have called cell_read on it in this session,
+and (c) the cell to be unchanged since that read. To create a new tab, call
+cell_write WITHOUT tab_id. The guard prevents clobbering edits the user or
+another agent made while you were reasoning.
 `;

--- a/electron/main/mcp/mcp-server.test.ts
+++ b/electron/main/mcp/mcp-server.test.ts
@@ -199,6 +199,8 @@ describe("assertCurrentGeneration", () => {
       cellRpc: {} as McpToolContext["cellRpc"],
       getRendererWindow: () => null,
       getSessionGeneration: () => sessionGen,
+      recordCellRead: () => undefined,
+      getCellReadHash: () => undefined,
     };
   }
   const extra = { sessionId: "s1" } as ToolExtra;

--- a/electron/main/mcp/mcp-server.ts
+++ b/electron/main/mcp/mcp-server.ts
@@ -43,6 +43,7 @@ import { generateBearerToken, requestHasValidToken } from "./mcp-auth";
 import type { McpServerHooks, McpToolContext } from "./mcp-context";
 import { MCP_INSTRUCTIONS } from "./mcp-instructions";
 import { registerAllTools } from "./tools";
+import { hashCellCode } from "./tools/_helpers";
 
 /** Loopback host the MCP server always binds to. */
 const HOST = "127.0.0.1";
@@ -80,6 +81,13 @@ interface McpSession {
   server: McpServer;
   /** Project/kernel generation the session connected at (ARCHITECTURE.md §15.3). */
   generation: number;
+  /**
+   * Per-tab SHA-256 of the cell source this session last observed via
+   * `cell_read` (or last successfully wrote). Drives the `cell_write`
+   * read-before-write guard: a session must read a cell before overwriting
+   * it, and the cell must not have changed in between.
+   */
+  readCells: Map<number, string>;
 }
 
 /**
@@ -114,6 +122,16 @@ export class PdvMcpServer {
       getRendererWindow: deps.getRendererWindow,
       getSessionGeneration: (sessionId) =>
         sessionId ? this.sessions.get(sessionId)?.generation : undefined,
+      recordCellRead: (sessionId, tabId, code) => {
+        if (!sessionId) return;
+        const session = this.sessions.get(sessionId);
+        if (!session) return;
+        session.readCells.set(tabId, hashCellCode(code));
+      },
+      getCellReadHash: (sessionId, tabId) => {
+        if (!sessionId) return undefined;
+        return this.sessions.get(sessionId)?.readCells.get(tabId);
+      },
     };
   }
 
@@ -244,6 +262,7 @@ export class PdvMcpServer {
           transport,
           server: mcpServer,
           generation: this.deps.hooks.getGeneration(),
+          readCells: new Map(),
         });
         this.pushClientStatus();
       },

--- a/electron/main/mcp/tools/_helpers.test.ts
+++ b/electron/main/mcp/tools/_helpers.test.ts
@@ -7,9 +7,12 @@
 import { describe, expect, it } from "vitest";
 
 import type { McpToolContext } from "../mcp-context";
+import type { ToolExtra } from "./_helpers";
 import {
+  assertCellReadFresh,
   assertMutatingToolsEnabled,
   assertPdvRunEnabled,
+  hashCellCode,
 } from "./_helpers";
 
 /** Minimal context exposing only the configStore needed by the gate helpers. */
@@ -66,6 +69,36 @@ describe("assertPdvRunEnabled", () => {
       assertPdvRunEnabled(
         makeCtx({ pdvRunEnabled: true, mutatingToolsEnabled: false }),
       ),
+    ).not.toThrow();
+  });
+});
+
+describe("assertCellReadFresh (read-before-write guard)", () => {
+  /** Build a ctx whose `getCellReadHash` returns a fixed recorded hash. */
+  function ctxWithRecordedHash(recorded: string | undefined): McpToolContext {
+    return {
+      getCellReadHash: () => recorded,
+    } as unknown as McpToolContext;
+  }
+  const extra = { sessionId: "s1" } as ToolExtra;
+
+  it("throws when the session never read this tab", () => {
+    expect(() =>
+      assertCellReadFresh(ctxWithRecordedHash(undefined), extra, 7, "x = 1"),
+    ).toThrow(/must call cell_read/);
+  });
+
+  it("throws when the cell changed since the session's last read", () => {
+    const staleHash = hashCellCode("x = 1");
+    expect(() =>
+      assertCellReadFresh(ctxWithRecordedHash(staleHash), extra, 7, "x = 2"),
+    ).toThrow(/changed since you last/);
+  });
+
+  it("passes when the recorded hash matches the current source", () => {
+    const liveHash = hashCellCode("x = 1");
+    expect(() =>
+      assertCellReadFresh(ctxWithRecordedHash(liveHash), extra, 7, "x = 1"),
     ).not.toThrow();
   });
 });

--- a/electron/main/mcp/tools/_helpers.ts
+++ b/electron/main/mcp/tools/_helpers.ts
@@ -17,6 +17,8 @@ import type {
   ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 
+import { createHash } from "node:crypto";
+
 import type { PDVMessage } from "../../pdv-protocol";
 import type { McpToolContext } from "../mcp-context";
 
@@ -126,6 +128,57 @@ export function assertPdvRunEnabled(ctx: McpToolContext): void {
     throw new Error(
       "The pdv_run tool is disabled. Enable it in PDV under " +
         "Settings → Agents → Allow pdv_run (arbitrary kernel code).",
+    );
+  }
+}
+
+/**
+ * Hash a code-cell source the same way `mcp-server.ts` does for its
+ * per-session read cache. Kept in sync via {@link hashCellCode}'s usage in
+ * both files — SHA-256 of the UTF-8 source, hex-encoded.
+ *
+ * @param code - The cell source to fingerprint.
+ * @returns Hex SHA-256 digest of `code`.
+ */
+export function hashCellCode(code: string): string {
+  return createHash("sha256").update(code).digest("hex");
+}
+
+/**
+ * Read-before-write guard for `cell_write`. Mirrors Claude Code's Read/Edit
+ * mechanic: a session must have called `cell_read` for the tab in this
+ * connection, and the cell source must not have changed in between. This
+ * prevents the agent from clobbering edits the user (or another agent) made
+ * after the agent last looked.
+ *
+ * @param ctx - The MCP tool context.
+ * @param extra - The SDK tool-callback `extra` (carries the session id).
+ * @param tabId - The cell tab id about to be overwritten.
+ * @param currentCode - The cell's source as it exists right now.
+ * @throws {Error} When the session has not read the tab, or the cell has
+ *   changed since the last read.
+ */
+export function assertCellReadFresh(
+  ctx: McpToolContext,
+  extra: ToolExtra,
+  tabId: number,
+  currentCode: string,
+): void {
+  const recorded = ctx.getCellReadHash(extra.sessionId, tabId);
+  if (recorded === undefined) {
+    throw new Error(
+      `cell_write refused: you must call cell_read on tab ${tabId} ` +
+        "before overwriting it. Reading first lets the guard detect " +
+        "concurrent edits by the user or another agent. To create a new " +
+        "tab, call cell_write without `tab_id`.",
+    );
+  }
+  const current = hashCellCode(currentCode);
+  if (current !== recorded) {
+    throw new Error(
+      `cell_write refused: cell ${tabId} has changed since you last ` +
+        "read it (likely a user or another agent edited it). Call " +
+        "cell_read again to see the current source before overwriting.",
     );
   }
 }

--- a/electron/main/mcp/tools/execution.test.ts
+++ b/electron/main/mcp/tools/execution.test.ts
@@ -16,7 +16,7 @@ vi.mock("electron", () => ({
 }));
 
 import type { McpToolContext } from "../mcp-context";
-import type { ToolExtra } from "./_helpers";
+import { hashCellCode, type ToolExtra } from "./_helpers";
 import { registerExecutionTools } from "./execution";
 
 type ToolCallback = (
@@ -37,6 +37,14 @@ function captureTools(): { server: McpServer; tools: Map<string, ToolCallback> }
 interface CtxOpts {
   mutatingEnabled?: boolean;
   pdvRunEnabled?: boolean;
+  /** When set, `cellRpc.read` rejects with this error message. */
+  cellReadError?: string;
+  /** When set, used as the response from `cellRpc.read`. */
+  cellReadResult?: { id: number; name?: string; code: string };
+  /** Captures cell_write fire-and-forget pushes for assertions. */
+  cellWriteSpy?: ReturnType<typeof vi.fn>;
+  /** Hash recorded for the read-before-write guard, keyed by tab id. */
+  cellReadHashes?: Map<number, string>;
 }
 
 function makeCtx(opts: CtxOpts = {}): McpToolContext {
@@ -73,11 +81,23 @@ function makeCtx(opts: CtxOpts = {}): McpToolContext {
       },
     } as unknown as McpToolContext["hooks"],
     appVersion: "0.0.0-test",
-    cellRpc: {} as McpToolContext["cellRpc"],
+    cellRpc: {
+      read: vi.fn(async (_tabId: number) => {
+        if (opts.cellReadError) {
+          throw new Error(opts.cellReadError);
+        }
+        return opts.cellReadResult ?? { id: 1, code: "" };
+      }),
+      write: opts.cellWriteSpy ?? vi.fn(),
+      list: vi.fn(),
+    } as unknown as McpToolContext["cellRpc"],
     getRendererWindow: () => null,
     getSessionGeneration: () => 0,
-    recordCellRead: () => undefined,
-    getCellReadHash: () => undefined,
+    recordCellRead: vi.fn((_sessionId, tabId, code) => {
+      opts.cellReadHashes?.set(tabId, hashCellCode(code));
+    }),
+    getCellReadHash: (_sessionId, tabId) =>
+      opts.cellReadHashes?.get(tabId),
   };
 }
 
@@ -125,5 +145,74 @@ describe("pdv_run gating", () => {
         extra,
       ),
     ).resolves.toBeDefined();
+  });
+});
+
+describe("cell_write tab_id contract", () => {
+  it("rejects with a clean error when tab_id refers to no existing tab", async () => {
+    // The renderer rejects unknown ids with `No cell tab with id N`. The
+    // tool layer must convert that into a tool-level error that explains
+    // the contract (use cell_list to find ids, omit tab_id to append) —
+    // not surface the bare RPC failure.
+    const { server, tools } = captureTools();
+    const cellWriteSpy = vi.fn();
+    registerExecutionTools(
+      server,
+      makeCtx({
+        mutatingEnabled: true,
+        cellReadError: "No cell tab with id 99",
+        cellWriteSpy,
+      }),
+    );
+    await expect(
+      tools.get("cell_write")!(
+        { tab_id: 99, code: "x = 1" },
+        extra,
+      ),
+    ).rejects.toThrow(/no cell tab with id 99.*omit tab_id to append/i);
+    // The fire-and-forget write must NOT have been issued — the previous
+    // behavior was an accidental append on a typo'd tab_id.
+    expect(cellWriteSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-throws unrelated RPC failures untouched", async () => {
+    // Renderer-unreachable / timeout errors should bubble up as-is so the
+    // agent can distinguish "you typed the wrong id" from "PDV is gone."
+    const { server, tools } = captureTools();
+    registerExecutionTools(
+      server,
+      makeCtx({
+        mutatingEnabled: true,
+        cellReadError: "Cell read failed: no renderer window",
+      }),
+    );
+    await expect(
+      tools.get("cell_write")!(
+        { tab_id: 1, code: "x = 1" },
+        extra,
+      ),
+    ).rejects.toThrow(/no renderer window/);
+  });
+
+  it("appends without any prior read when tab_id is omitted", async () => {
+    // The guard only fires on overwrites of an existing tab_id. An append
+    // is safe by definition — there's nothing to clobber.
+    const { server, tools } = captureTools();
+    const cellWriteSpy = vi.fn();
+    registerExecutionTools(
+      server,
+      makeCtx({
+        mutatingEnabled: true,
+        cellWriteSpy,
+      }),
+    );
+    await expect(
+      tools.get("cell_write")!({ code: "x = 1" }, extra),
+    ).resolves.toBeDefined();
+    expect(cellWriteSpy).toHaveBeenCalledWith({
+      tabId: undefined,
+      code: "x = 1",
+      name: undefined,
+    });
   });
 });

--- a/electron/main/mcp/tools/execution.test.ts
+++ b/electron/main/mcp/tools/execution.test.ts
@@ -76,6 +76,8 @@ function makeCtx(opts: CtxOpts = {}): McpToolContext {
     cellRpc: {} as McpToolContext["cellRpc"],
     getRendererWindow: () => null,
     getSessionGeneration: () => 0,
+    recordCellRead: () => undefined,
+    getCellReadHash: () => undefined,
   };
 }
 

--- a/electron/main/mcp/tools/execution.ts
+++ b/electron/main/mcp/tools/execution.ts
@@ -199,12 +199,13 @@ export function registerExecutionTools(server: McpServer, ctx: McpToolContext): 
     {
       title: "Write a PDV code cell",
       description:
-        "Overwrite a cell tab's source, or append a new tab when `tab_id` " +
-        "is omitted or matches no existing tab. The renderer updates its " +
-        "live tab state on receipt. When `tab_id` is provided, you must " +
-        "call `cell_read` on that tab first, and the cell must not have " +
-        "changed since — this prevents clobbering edits the user or another " +
-        "agent made while you were reasoning.",
+        "Overwrite a cell tab's source, or — when `tab_id` is omitted — " +
+        "append a new tab. The renderer updates its live tab state on " +
+        "receipt. When `tab_id` is provided it MUST refer to an existing " +
+        "tab (use `cell_list` to discover ids); you must also have called " +
+        "`cell_read` on that tab first, and the cell must not have changed " +
+        "since — this prevents clobbering edits the user or another agent " +
+        "made while you were reasoning. To create a new tab, omit `tab_id`.",
       inputSchema: {
         tab_id: z
           .number()
@@ -222,10 +223,33 @@ export function registerExecutionTools(server: McpServer, ctx: McpToolContext): 
         // Read-before-write: fetch the current source and compare it to the
         // hash the session captured at cell_read time. Throws if the
         // session never read this tab, or if the cell changed since.
-        const current = await ctx.cellRpc.read(tab_id);
+        // Convert the renderer's "no tab matches" error into an actionable
+        // tool error so the agent doesn't see a bare RPC failure.
+        let current;
+        try {
+          current = await ctx.cellRpc.read(tab_id);
+        } catch (err) {
+          if (err instanceof Error && /No cell tab with id/.test(err.message)) {
+            throw new Error(
+              `cell_write refused: no cell tab with id ${tab_id}. ` +
+                "Call cell_list to discover existing tab ids, or omit " +
+                "tab_id to append a new tab.",
+            );
+          }
+          throw err;
+        }
+        // Key the guard on `current.id` (the renderer's canonical id) — the
+        // same key cell_read used to arm it. This stays correct even when
+        // the renderer canonicalizes a caller-supplied id (e.g. -1 → active
+        // tab), because the canonicalized id flows back through `current`.
         assertCellReadFresh(ctx, extra, current.id, current.code);
         // Promote the write to the new "last seen" state so the session can
         // immediately follow up with another cell_write without re-reading.
+        // Note: cell_rpc.write is fire-and-forget (see cell-rpc.ts), so the
+        // promoted hash is the agent's *intended* code, not whatever the
+        // renderer ultimately applied. That's good enough — the guard's
+        // scope is the "agent thought for 30s then clobbered" window, not
+        // the millisecond race against a concurrent user edit.
         ctx.recordCellRead(extra.sessionId, current.id, code);
       }
       ctx.cellRpc.write({ tabId: tab_id, code, name });

--- a/electron/main/mcp/tools/execution.ts
+++ b/electron/main/mcp/tools/execution.ts
@@ -37,6 +37,7 @@ import { PDVMessageType } from "../../pdv-protocol";
 import type { McpToolContext } from "../mcp-context";
 import { executeAndTranscribe, TranscriptWriter } from "../transcript";
 import {
+  assertCellReadFresh,
   assertCurrentGeneration,
   assertMutatingToolsEnabled,
   assertPdvRunEnabled,
@@ -182,6 +183,11 @@ export function registerExecutionTools(server: McpServer, ctx: McpToolContext): 
     async ({ tab_id }, extra) => {
       assertCurrentGeneration(ctx, extra);
       const cell = await ctx.cellRpc.read(tab_id);
+      // Record this read for the cell_write read-before-write guard. We key
+      // on `cell.id` (the renderer's canonical id) rather than the request
+      // arg so an arg of e.g. `-1` mapping to an active tab still arms the
+      // guard for the right tab.
+      ctx.recordCellRead(extra.sessionId, cell.id, cell.code);
       const header =
         `cell id: ${cell.id}` + (cell.name ? `  (${cell.name})` : "");
       return textResult(`${header}\n\n${cell.code}`);
@@ -195,7 +201,10 @@ export function registerExecutionTools(server: McpServer, ctx: McpToolContext): 
       description:
         "Overwrite a cell tab's source, or append a new tab when `tab_id` " +
         "is omitted or matches no existing tab. The renderer updates its " +
-        "live tab state on receipt.",
+        "live tab state on receipt. When `tab_id` is provided, you must " +
+        "call `cell_read` on that tab first, and the cell must not have " +
+        "changed since — this prevents clobbering edits the user or another " +
+        "agent made while you were reasoning.",
       inputSchema: {
         tab_id: z
           .number()
@@ -209,6 +218,16 @@ export function registerExecutionTools(server: McpServer, ctx: McpToolContext): 
     async ({ tab_id, code, name }, extra) => {
       assertCurrentGeneration(ctx, extra);
       assertMutatingToolsEnabled(ctx);
+      if (tab_id !== undefined) {
+        // Read-before-write: fetch the current source and compare it to the
+        // hash the session captured at cell_read time. Throws if the
+        // session never read this tab, or if the cell changed since.
+        const current = await ctx.cellRpc.read(tab_id);
+        assertCellReadFresh(ctx, extra, current.id, current.code);
+        // Promote the write to the new "last seen" state so the session can
+        // immediately follow up with another cell_write without re-reading.
+        ctx.recordCellRead(extra.sessionId, current.id, code);
+      }
       ctx.cellRpc.write({ tabId: tab_id, code, name });
       return textResult(
         tab_id !== undefined

--- a/electron/main/mcp/tools/tree-mutate.test.ts
+++ b/electron/main/mcp/tools/tree-mutate.test.ts
@@ -137,6 +137,8 @@ function makeCtx(opts: CtxOpts = {}): {
     cellRpc: {} as McpToolContext["cellRpc"],
     getRendererWindow: () => null,
     getSessionGeneration: () => 0,
+    recordCellRead: () => undefined,
+    getCellReadHash: () => undefined,
   };
   return { ctx, commRequest };
 }

--- a/electron/main/mcp/tools/tree-read.test.ts
+++ b/electron/main/mcp/tools/tree-read.test.ts
@@ -76,6 +76,8 @@ function makeCtx(query: QueryFn, kernelRunning = true): McpToolContext {
     cellRpc: {} as McpToolContext["cellRpc"],
     getRendererWindow: () => null,
     getSessionGeneration: () => 0,
+    recordCellRead: () => undefined,
+    getCellReadHash: () => undefined,
   };
 }
 


### PR DESCRIPTION
Closes #293.

## Summary

Two MCP server fixes:

- **No more reconnect on every save** (issue #293). `setActiveProjectDir` and `setActiveKernelId` only bump the project/kernel generation when the value actually *changes*. Previously the guard was `prev !== null`, so `project:save` — which re-asserts the same `saveDir` on every save — was treated as a project switch and forced any connected MCP agent (Claude Code, Cursor, …) to reconnect. The check is extracted as `shouldBumpOnSwap` in `main/mcp/generation-guard.ts` so the contract is unit-testable.
- **`cell_write` now enforces read-before-write.** The session must have called `cell_read` on the target tab first, and the cell's source must not have changed since (SHA-256 of the source observed at read time is compared to the source at write time). Mirrors Claude Code's own Read/Edit guard so the agent can't clobber edits the user (or another agent) made while it was reasoning. `tab_id` must refer to an existing tab — unknown ids are rejected with an actionable error (the old "matches no existing tab → silent append" fallback was a footgun for typo'd ids). Appends (omit `tab_id`) are unaffected; a successful write promotes the session's "last seen" hash so consecutive writes don't need a re-read.

## Test plan

- [x] `npm test -- --run` — 493/493 pass. New tests: 4 for `shouldBumpOnSwap`, 3 for `assertCellReadFresh`, 3 for `cell_write` `tab_id` contract (unknown id rejected with no fire-and-forget write; unrelated RPC errors pass through; append still works without a prior read).
- [x] `npx tsc --noEmit` and `npx tsc --noEmit -p tsconfig.test.json` — both clean.
- [x] Live MCP smoke test against a running PDV from a fresh Claude Code session — all 12 scripted checks pass:
    - Patch 1: `tree_list` still works after explicit saves; no "reconnect" error.
    - Patch 2: `cell_write` without a prior read is rejected with the "must call cell_read" error; write after `cell_read` succeeds; consecutive write without re-read succeeds (promoted hash); write after a user edits the cell in the UI is rejected with the "changed since you last read it" error; re-read + write succeeds; append (no `tab_id`) succeeds without any read.
- [ ] `pdv-python/scripts/sweep-deps.sh` — **not run**: the PR touches only `electron/main/mcp/` and `electron/main/index.ts`; no changes under `pdv-python/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)