### PR TITLE
Unified editor launcher slot + AI-agent launch button (#289)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -910,7 +910,7 @@ Rules:
 #### External-app launchers (`launchers`)
 
 `preferences.json` carries a `launchers` block for configuring how PDV
-invokes external applications. Today it holds one slot:
+invokes external applications:
 
 - `launchers.terminal` — `{ preset, customTemplate? }`. The `preset` selects
   a terminal emulator (`terminal-app`, `iterm2`, `alacritty`, `kitty`,
@@ -923,8 +923,26 @@ invokes external applications. Today it holds one slot:
   per-platform preset templates and the `{cmd}` / `{cmdstr}` placeholder
   expansion. When `launchers.terminal` is unset, a platform default is used
   (`terminal-app` on macOS, `x-terminal-emulator` on Linux, `wt.exe` on
-  Windows). The `editor` and `agent` launcher slots are reserved for later
-  milestones (see `PLANNED_FEATURES.md`).
+  Windows).
+
+- `launchers.editor` — `{ fileCommand?, dirCommand?, isTuiEditor? }`. The
+  command PDV uses to open a script (`fileCommand`) or a directory
+  (`dirCommand`); `{}` is the path placeholder. `isTuiEditor` forces terminal
+  wrapping on/off; when unset PDV auto-detects from the command basename.
+  This slot supersedes the legacy `pythonEditorCmd` / `juliaEditorCmd` keys —
+  `ConfigStore` migrates a pre-existing `pythonEditorCmd` into
+  `launchers.editor.fileCommand` once, at load, and drops the legacy keys.
+
+- `launchers.agent` — `{ command?, cwd? }`. The AI-agent CLI launched by the
+  activity-bar agent button. The command runs inside the configured terminal
+  preset, in a login shell that has `cd`-ed into the project (`cwd: 'project'`)
+  or session working directory (`cwd: 'working'`). Three placeholders are
+  substituted with quoted absolute paths: `{mcpConfig}`, `{projectRoot}`,
+  `{workingDir}`. Before launch, `mcp/mcp-config-writer.ts` materializes a
+  `.pdv-mcp.json` (mode `0600`) into the kernel working directory so the agent
+  — Claude Code by default — connects back to PDV's MCP server. The working
+  directory is ephemeral, so the embedded bearer token never lands in a
+  user-visible or version-controlled location.
 
 The renderer reads the host platform synchronously via the preload value
 `window.pdv.system.platform` — exposed as a constant rather than an IPC
@@ -1578,6 +1596,7 @@ The API surface:
 - `window.pdv.environment.*` — Python environment management: `list`, `check`, `install`, `refresh`; push: `onInstallOutput(cb) → unsub`
 - `window.pdv.chrome.*` — window chrome controls: `getInfo`, `minimize`, `toggleMaximize`, `close`; push: `onStateChanged(cb) → unsub`
 - `window.pdv.system.*` — constant host facts injected at preload time: `platform` (the main process's `process.platform`). Exposed as a plain value, not a function — it never changes during a session, so it needs no IPC channel
+- `window.pdv.launchers.*` — action-bar external-app launchers: `openAgent` (launch the configured AI agent in a terminal)
 - `window.pdv.progress.*` — operation progress: push only: `onProgress(cb) → unsub`
 - `window.pdv.menu.*` — menu bridge: `updateRecentProjects(paths)`, `onAction(cb) → unsub`
 

--- a/electron/main/agent-launcher.test.ts
+++ b/electron/main/agent-launcher.test.ts
@@ -1,0 +1,117 @@
+/**
+ * agent-launcher.test.ts — Tests for buildAgentInvocation.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildAgentInvocation } from "./agent-launcher";
+
+describe("buildAgentInvocation", () => {
+  it("wraps the default command in sh -lc + the terminal preset (Linux)", () => {
+    expect(
+      buildAgentInvocation({
+        terminal: { preset: "alacritty" },
+        mcpConfigPath: "/wd/.pdv-mcp.json",
+        projectRoot: "/proj",
+        workingDir: "/wd",
+        platform: "linux",
+      }),
+    ).toEqual({
+      file: "alacritty",
+      args: [
+        "-e",
+        "sh",
+        "-lc",
+        "cd '/proj' && exec claude --mcp-config '/wd/.pdv-mcp.json'",
+      ],
+    });
+  });
+
+  it("substitutes {mcpConfig}, {projectRoot} and {workingDir} with quoted paths", () => {
+    const { args } = buildAgentInvocation({
+      agent: { command: "myagent {mcpConfig} {projectRoot} {workingDir}" },
+      terminal: { preset: "alacritty" },
+      mcpConfigPath: "/wd/.pdv-mcp.json",
+      projectRoot: "/proj",
+      workingDir: "/wd",
+      platform: "linux",
+    });
+    expect(args[3]).toBe(
+      "cd '/proj' && exec myagent '/wd/.pdv-mcp.json' '/proj' '/wd'",
+    );
+  });
+
+  it("cd's into the working directory when cwd='working'", () => {
+    const { args } = buildAgentInvocation({
+      agent: { cwd: "working" },
+      terminal: { preset: "alacritty" },
+      mcpConfigPath: "/wd/.pdv-mcp.json",
+      projectRoot: "/proj",
+      workingDir: "/wd",
+      platform: "linux",
+    });
+    expect(args[3]).toBe(
+      "cd '/wd' && exec claude --mcp-config '/wd/.pdv-mcp.json'",
+    );
+  });
+
+  it("falls back to the working directory when cwd='project' but no project is loaded", () => {
+    const { args } = buildAgentInvocation({
+      terminal: { preset: "alacritty" },
+      mcpConfigPath: "/wd/.pdv-mcp.json",
+      projectRoot: null,
+      workingDir: "/wd",
+      platform: "linux",
+    });
+    expect(args[3]).toBe(
+      "cd '/wd' && exec claude --mcp-config '/wd/.pdv-mcp.json'",
+    );
+  });
+
+  it("quotes a project path containing spaces", () => {
+    const { args } = buildAgentInvocation({
+      terminal: { preset: "alacritty" },
+      mcpConfigPath: "/wd/.pdv-mcp.json",
+      projectRoot: "/Users/me/My Project",
+      workingDir: "/wd",
+      platform: "linux",
+    });
+    expect(args[3]).toBe(
+      "cd '/Users/me/My Project' && exec claude --mcp-config '/wd/.pdv-mcp.json'",
+    );
+  });
+
+  it("uses cmd /c on Windows and wraps in Windows Terminal", () => {
+    expect(
+      buildAgentInvocation({
+        mcpConfigPath: "C:\\wd\\.pdv-mcp.json",
+        projectRoot: "C:\\proj",
+        workingDir: "C:\\wd",
+        platform: "win32",
+      }),
+    ).toEqual({
+      file: "wt.exe",
+      args: [
+        "new-tab",
+        "cmd",
+        "/c",
+        `cd /d "C:\\proj" && claude --mcp-config "C:\\wd\\.pdv-mcp.json"`,
+      ],
+    });
+  });
+
+  it("wraps in Terminal.app via osascript on macOS by default", () => {
+    const { file, args } = buildAgentInvocation({
+      mcpConfigPath: "/wd/.pdv-mcp.json",
+      projectRoot: "/proj",
+      workingDir: "/wd",
+      platform: "darwin",
+    });
+    expect(file).toBe("osascript");
+    // The shell line is embedded as an AppleScript string literal; assert the
+    // recognisable, post-escape fragments survive.
+    expect(args[1]).toContain("do script");
+    expect(args[1]).toContain("cd ");
+    expect(args[1]).toContain("claude --mcp-config");
+  });
+});

--- a/electron/main/agent-launcher.test.ts
+++ b/electron/main/agent-launcher.test.ts
@@ -100,6 +100,19 @@ describe("buildAgentInvocation", () => {
     });
   });
 
+  it("double-quotes a Windows path containing a space", () => {
+    const { args } = buildAgentInvocation({
+      mcpConfigPath: "C:\\wd\\.pdv-mcp.json",
+      projectRoot: "C:\\Users\\me\\My Project",
+      workingDir: "C:\\wd",
+      platform: "win32",
+    });
+    // args = ["new-tab", "cmd", "/c", "<line>"]
+    expect(args[3]).toBe(
+      `cd /d "C:\\Users\\me\\My Project" && claude --mcp-config "C:\\wd\\.pdv-mcp.json"`,
+    );
+  });
+
   it("wraps in Terminal.app via osascript on macOS by default", () => {
     const { file, args } = buildAgentInvocation({
       mcpConfigPath: "/wd/.pdv-mcp.json",

--- a/electron/main/agent-launcher.ts
+++ b/electron/main/agent-launcher.ts
@@ -44,12 +44,20 @@ export interface BuildAgentInvocationOptions {
 }
 
 /**
- * Quote a path for a `cmd.exe` command line. Windows paths don't contain
- * the shell metacharacters that would need escaping; wrapping in double
- * quotes covers the realistic case (spaces in the path).
+ * Quote a path for a `cmd.exe` command line.
+ *
+ * Wrapping in double quotes covers spaces and most metacharacters (`&`, `|`,
+ * `^` are inert inside quotes). Embedded `"` is doubled — though NTFS forbids
+ * `"` in path names, so this is purely defensive.
+ *
+ * Known limitation: `cmd.exe` expands `%VAR%` even inside double quotes and
+ * offers no command-line escape for a literal `%`. A directory whose name
+ * contains a `%NAME%` pair matching a real environment variable will be
+ * mis-expanded. This is rare, Windows-only, and the user can work around it
+ * with a custom agent command; a hard failure is not worth the complexity.
  */
 function cmdQuote(arg: string): string {
-  return `"${arg}"`;
+  return `"${arg.replace(/"/g, '""')}"`;
 }
 
 /**

--- a/electron/main/agent-launcher.ts
+++ b/electron/main/agent-launcher.ts
@@ -1,0 +1,99 @@
+/**
+ * agent-launcher.ts — Build the spawn spec for the action-bar AI-agent button.
+ *
+ * Responsibilities:
+ * - Expand the configured agent command's `{mcpConfig}` / `{projectRoot}` /
+ *   `{workingDir}` placeholders.
+ * - Wrap the agent CLI in a shell that `cd`s to the target directory, then
+ *   wrap that in the user's terminal-emulator preset.
+ *
+ * Non-responsibilities:
+ * - Spawning the process (the IPC handler does that).
+ * - Writing the `.pdv-mcp.json` file (see `mcp/mcp-config-writer.ts`).
+ *
+ * Why a `cd … &&` shell wrapper rather than the `spawn` `cwd` option:
+ * argv-style terminals (`alacritty -e …`) inherit the spawn cwd, but the
+ * macOS osascript presets tell Terminal.app/iTerm2 to open a *new* shell
+ * that starts in `$HOME` regardless of the osascript process's cwd. Putting
+ * the `cd` inside the command itself is the one approach that works for
+ * every preset.
+ */
+
+import {
+  DEFAULT_AGENT_COMMAND,
+  posixShellQuote,
+  resolveEditorSpawn,
+  type AgentLauncherConfig,
+  type TerminalLauncherConfig,
+} from "./editor-spawn";
+
+/** Inputs for {@link buildAgentInvocation}. */
+export interface BuildAgentInvocationOptions {
+  /** `launchers.agent` config (command + cwd mode). */
+  agent?: AgentLauncherConfig;
+  /** `launchers.terminal` config (which terminal emulator to wrap in). */
+  terminal?: TerminalLauncherConfig;
+  /** Absolute path of the materialized `.pdv-mcp.json`. */
+  mcpConfigPath: string;
+  /** Active project directory, or `null` when no project is loaded. */
+  projectRoot: string | null;
+  /** Active kernel's session working directory. */
+  workingDir: string;
+  /** Target platform; defaults to `process.platform`. */
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * Quote a path for a `cmd.exe` command line. Windows paths don't contain
+ * the shell metacharacters that would need escaping; wrapping in double
+ * quotes covers the realistic case (spaces in the path).
+ */
+function cmdQuote(arg: string): string {
+  return `"${arg}"`;
+}
+
+/**
+ * Build the spawn spec for launching the configured AI agent.
+ *
+ * The agent CLI is run inside a login shell (`sh -lc` on POSIX, `cmd /c` on
+ * Windows) that first `cd`s into the target directory, and that shell is in
+ * turn wrapped in the user's terminal-emulator preset via
+ * {@link resolveEditorSpawn} (with `wrapInTerminal` forced on — the agent
+ * always needs a terminal window).
+ *
+ * @param opts - See {@link BuildAgentInvocationOptions}.
+ * @returns Spawn-ready `{ file, args }` for `child_process.spawn`.
+ */
+export function buildAgentInvocation(
+  opts: BuildAgentInvocationOptions,
+): { file: string; args: string[] } {
+  const platform = opts.platform ?? process.platform;
+  const isWindows = platform === "win32";
+  const quote = isWindows ? cmdQuote : posixShellQuote;
+
+  const command =
+    (opts.agent?.command ?? DEFAULT_AGENT_COMMAND).trim() || DEFAULT_AGENT_COMMAND;
+  const cwdMode = opts.agent?.cwd ?? "project";
+  // `working` always exists; `project` falls back to the working directory
+  // when no project has been saved yet.
+  const targetDir =
+    cwdMode === "working"
+      ? opts.workingDir
+      : (opts.projectRoot ?? opts.workingDir);
+
+  const expandedCommand = command
+    .replace(/\{mcpConfig\}/g, quote(opts.mcpConfigPath))
+    .replace(/\{projectRoot\}/g, quote(opts.projectRoot ?? opts.workingDir))
+    .replace(/\{workingDir\}/g, quote(opts.workingDir));
+
+  const shellFile = isWindows ? "cmd" : "sh";
+  const shellArgs = isWindows
+    ? ["/c", `cd /d ${quote(targetDir)} && ${expandedCommand}`]
+    : ["-lc", `cd ${quote(targetDir)} && exec ${expandedCommand}`];
+
+  return resolveEditorSpawn(shellFile, shellArgs, {
+    wrapInTerminal: true,
+    terminal: opts.terminal,
+    platform,
+  });
+}

--- a/electron/main/bootstrap.ts
+++ b/electron/main/bootstrap.ts
@@ -47,7 +47,7 @@ import * as path from "path";
 import * as fs from "fs";
 
 import { createWindow, wireAppEvents } from "./app";
-import { getMcpServerHooks } from "./index";
+import { getMcpServerHooks, setMcpServerInstance } from "./index";
 import { CellRpcClient } from "./mcp/cell-rpc";
 import { PdvMcpServer } from "./mcp/mcp-server";
 import { CommRouter } from "./comm-router";
@@ -133,6 +133,9 @@ async function openMainWindow(): Promise<void> {
         });
         try {
           await mcpServer.start();
+          // Publish the live server so the agent-launcher IPC handler can
+          // read its status (port + token) at button-click time.
+          setMcpServerInstance(mcpServer);
         } catch (error) {
           console.error("[PDV] Failed to start MCP server:", error);
         }

--- a/electron/main/config.test.ts
+++ b/electron/main/config.test.ts
@@ -159,6 +159,25 @@ describe("ConfigStore", () => {
     expect(onDisk.launchers.editor.fileCommand).toBe("nvim {}");
   });
 
+  it("migrates juliaEditorCmd when no pythonEditorCmd is present", () => {
+    const appDataDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(appDataDir, "preferences.json"),
+      JSON.stringify({
+        showPrivateVariables: false,
+        showModuleVariables: false,
+        showCallableVariables: false,
+        juliaEditorCmd: "nvim {}",
+      }),
+      "utf8",
+    );
+
+    const store = new ConfigStore(appDataDir);
+    const config = store.getAll();
+    expect(config.launchers?.editor?.fileCommand).toBe("nvim {}");
+    expect(config.juliaEditorCmd).toBeUndefined();
+  });
+
   it("drops legacy editor keys without overwriting an existing launchers.editor.fileCommand", () => {
     const appDataDir = makeTempDir();
     fs.writeFileSync(

--- a/electron/main/config.test.ts
+++ b/electron/main/config.test.ts
@@ -130,6 +130,122 @@ describe("ConfigStore", () => {
     expect(errorSpy).toHaveBeenCalled();
   });
 
+  it("migrates legacy pythonEditorCmd to launchers.editor.fileCommand on load", () => {
+    const appDataDir = makeTempDir();
+    const configPath = path.join(appDataDir, "preferences.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        showPrivateVariables: false,
+        showModuleVariables: false,
+        showCallableVariables: false,
+        pythonEditorCmd: "nvim {}",
+        juliaEditorCmd: "code {}",
+      }),
+      "utf8",
+    );
+
+    const store = new ConfigStore(appDataDir);
+    const config = store.getAll();
+    expect(config.launchers?.editor?.fileCommand).toBe("nvim {}");
+    expect(config.pythonEditorCmd).toBeUndefined();
+    expect(config.juliaEditorCmd).toBeUndefined();
+
+    // The legacy keys are scrubbed from the persisted file, not just the
+    // in-memory view.
+    const onDisk = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(onDisk.pythonEditorCmd).toBeUndefined();
+    expect(onDisk.juliaEditorCmd).toBeUndefined();
+    expect(onDisk.launchers.editor.fileCommand).toBe("nvim {}");
+  });
+
+  it("drops legacy editor keys without overwriting an existing launchers.editor.fileCommand", () => {
+    const appDataDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(appDataDir, "preferences.json"),
+      JSON.stringify({
+        showPrivateVariables: false,
+        showModuleVariables: false,
+        showCallableVariables: false,
+        pythonEditorCmd: "nvim {}",
+        launchers: { editor: { fileCommand: "code {}" } },
+      }),
+      "utf8",
+    );
+
+    const store = new ConfigStore(appDataDir);
+    const config = store.getAll();
+    // The newer launchers.editor value wins; the legacy key is just dropped.
+    expect(config.launchers?.editor?.fileCommand).toBe("code {}");
+    expect(config.pythonEditorCmd).toBeUndefined();
+  });
+
+  it("does not rewrite preferences.json when there is nothing to migrate", () => {
+    const appDataDir = makeTempDir();
+    const configPath = path.join(appDataDir, "preferences.json");
+    const original = JSON.stringify({
+      showPrivateVariables: true,
+      showModuleVariables: false,
+      showCallableVariables: false,
+    });
+    fs.writeFileSync(configPath, original, "utf8");
+    const mtimeBefore = fs.statSync(configPath).mtimeMs;
+
+    new ConfigStore(appDataDir);
+
+    // No legacy keys → migration is a no-op and must not touch the file.
+    expect(fs.readFileSync(configPath, "utf8")).toBe(original);
+    expect(fs.statSync(configPath).mtimeMs).toBe(mtimeBefore);
+  });
+
+  it("loads a full launchers block (terminal, editor, agent)", () => {
+    const appDataDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(appDataDir, "preferences.json"),
+      JSON.stringify({
+        showPrivateVariables: false,
+        showModuleVariables: false,
+        showCallableVariables: false,
+        launchers: {
+          terminal: { preset: "alacritty" },
+          editor: { fileCommand: "nvim {}", isTuiEditor: true },
+          agent: { command: "claude --mcp-config {mcpConfig}", cwd: "working" },
+        },
+      }),
+      "utf8",
+    );
+
+    const store = new ConfigStore(appDataDir);
+    expect(store.getAll().launchers).toEqual({
+      terminal: { preset: "alacritty" },
+      editor: { fileCommand: "nvim {}", isTuiEditor: true },
+      agent: { command: "claude --mcp-config {mcpConfig}", cwd: "working" },
+    });
+  });
+
+  it("rejects an invalid launchers.agent.cwd and backs up the file", () => {
+    const appDataDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(appDataDir, "preferences.json"),
+      JSON.stringify({
+        showPrivateVariables: false,
+        showModuleVariables: false,
+        showCallableVariables: false,
+        launchers: { agent: { cwd: "nonsense" } },
+      }),
+      "utf8",
+    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    // parseConfig throws → loadState backs up the file and falls back to defaults.
+    const store = new ConfigStore(appDataDir);
+    expect(store.getAll().launchers).toBeUndefined();
+    expect(
+      fs.readdirSync(appDataDir).some((n) => n.startsWith("preferences.json.corrupted-")),
+    ).toBe(true);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
   it("treats null optional fields as cleared values", () => {
     const appDataDir = makeTempDir();
     fs.writeFileSync(

--- a/electron/main/config.ts
+++ b/electron/main/config.ts
@@ -486,7 +486,9 @@ export class ConfigStore {
       this.state.juliaEditorCmd !== undefined;
     if (!hasLegacy) return;
 
-    const legacyCmd = this.state.pythonEditorCmd;
+    // Prefer the Python editor command; fall back to the Julia one so a
+    // user who configured only `juliaEditorCmd` doesn't lose it.
+    const legacyCmd = this.state.pythonEditorCmd ?? this.state.juliaEditorCmd;
     const alreadyMigrated =
       this.state.launchers?.editor?.fileCommand !== undefined;
 

--- a/electron/main/config.ts
+++ b/electron/main/config.ts
@@ -19,6 +19,8 @@ import * as path from "path";
 
 import {
   TERMINAL_PRESET_LIST,
+  type AgentLauncherConfig,
+  type EditorLauncherConfig,
   type TerminalLauncherConfig,
   type TerminalPreset,
 } from "./editor-spawn";
@@ -52,15 +54,14 @@ export interface PDVConfig {
   /** UI theme override. Undefined = follow system. */
   theme?: "light" | "dark";
   /**
-   * External editor command for Python scripts.
-   * Use `{}` as the file-path placeholder, e.g. `"code {}"` or `"nvim {}"`.
-   * If `{}` is absent the path is appended as the last argument.
-   * Defaults to `"code {}"`.
+   * @deprecated Superseded by `launchers.editor.fileCommand`. Retained so the
+   * one-shot migration in {@link ConfigStore} can pick up pre-existing values;
+   * no longer written once a user has the `launchers.editor` block.
    */
   pythonEditorCmd?: string;
   /**
-   * External editor command for Julia scripts.
-   * Same `{}` placeholder convention as `pythonEditorCmd`.
+   * @deprecated Superseded by `launchers.editor.fileCommand`. See
+   * {@link PDVConfig.pythonEditorCmd}.
    */
   juliaEditorCmd?: string;
   /**
@@ -102,8 +103,8 @@ export interface PDVConfig {
   };
   /**
    * Configurable external-app launchers — terminal emulator wrap for TUI
-   * editors today, and (in later milestones) editor/IDE and AI-agent slots
-   * that share the same infrastructure. See `editor-spawn.ts` for templates.
+   * editors and the editor/IDE command today, plus (in a later milestone) an
+   * AI-agent slot that shares the same infrastructure. See `editor-spawn.ts`.
    */
   launchers?: {
     /**
@@ -113,6 +114,13 @@ export interface PDVConfig {
      * Windows.
      */
     terminal?: TerminalLauncherConfig;
+    /**
+     * Editor / IDE commands. Supersedes the legacy `pythonEditorCmd` /
+     * `juliaEditorCmd` keys (migrated automatically on first load).
+     */
+    editor?: EditorLauncherConfig;
+    /** AI-agent CLI launched by the action-bar agent button. */
+    agent?: AgentLauncherConfig;
   };
   /** AI agent integration (MCP server) settings. */
   mcp?: {
@@ -376,6 +384,55 @@ function parseLaunchers(
       out.terminal = entry;
     }
   }
+  if ("editor" in obj) {
+    const editor = obj.editor;
+    if (editor !== null && editor !== undefined) {
+      if (typeof editor !== "object" || Array.isArray(editor)) {
+        throw new Error(`Invalid config value for launchers.editor in ${filePath}`);
+      }
+      const e = editor as Record<string, unknown>;
+      const entry: EditorLauncherConfig = {};
+      for (const key of ["fileCommand", "dirCommand"] as const) {
+        const val = e[key];
+        if (val !== undefined && val !== null) {
+          if (typeof val !== "string") {
+            throw new Error(`Invalid config value for launchers.editor.${key} in ${filePath}`);
+          }
+          entry[key] = val;
+        }
+      }
+      if (e.isTuiEditor !== undefined && e.isTuiEditor !== null) {
+        if (typeof e.isTuiEditor !== "boolean") {
+          throw new Error(`Invalid config value for launchers.editor.isTuiEditor in ${filePath}`);
+        }
+        entry.isTuiEditor = e.isTuiEditor;
+      }
+      if (Object.keys(entry).length > 0) out.editor = entry;
+    }
+  }
+  if ("agent" in obj) {
+    const agent = obj.agent;
+    if (agent !== null && agent !== undefined) {
+      if (typeof agent !== "object" || Array.isArray(agent)) {
+        throw new Error(`Invalid config value for launchers.agent in ${filePath}`);
+      }
+      const a = agent as Record<string, unknown>;
+      const entry: AgentLauncherConfig = {};
+      if (a.command !== undefined && a.command !== null) {
+        if (typeof a.command !== "string") {
+          throw new Error(`Invalid config value for launchers.agent.command in ${filePath}`);
+        }
+        entry.command = a.command;
+      }
+      if (a.cwd !== undefined && a.cwd !== null) {
+        if (a.cwd !== "project" && a.cwd !== "working") {
+          throw new Error(`Invalid config value for launchers.agent.cwd in ${filePath}`);
+        }
+        entry.cwd = a.cwd;
+      }
+      if (Object.keys(entry).length > 0) out.agent = entry;
+    }
+  }
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
@@ -406,6 +463,44 @@ export class ConfigStore {
     fs.mkdirSync(this.appDataDir, { recursive: true });
     this.configPath = path.join(this.appDataDir, "preferences.json");
     this.state = this.loadState();
+    this.migrateLegacyEditorCmd();
+  }
+
+  /**
+   * One-shot migration from the legacy per-language editor keys
+   * (`pythonEditorCmd` / `juliaEditorCmd`) to the unified
+   * `launchers.editor.fileCommand` slot.
+   *
+   * Runs once at load: if a legacy key is present, its value seeds
+   * `launchers.editor.fileCommand` (unless that is already set — the newer
+   * value wins) and both legacy keys are dropped from the persisted file.
+   * After it has run the config no longer carries the legacy keys, so on
+   * every subsequent launch this is a cheap no-op with no disk write.
+   *
+   * @returns Nothing.
+   * @throws {Error} When the rewritten config cannot be persisted.
+   */
+  private migrateLegacyEditorCmd(): void {
+    const hasLegacy =
+      this.state.pythonEditorCmd !== undefined ||
+      this.state.juliaEditorCmd !== undefined;
+    if (!hasLegacy) return;
+
+    const legacyCmd = this.state.pythonEditorCmd;
+    const alreadyMigrated =
+      this.state.launchers?.editor?.fileCommand !== undefined;
+
+    const next: Partial<PDVConfig> = { ...this.state };
+    delete next.pythonEditorCmd;
+    delete next.juliaEditorCmd;
+    if (!alreadyMigrated && typeof legacyCmd === "string") {
+      next.launchers = {
+        ...next.launchers,
+        editor: { ...next.launchers?.editor, fileCommand: legacyCmd },
+      };
+    }
+    this.state = next;
+    this.persist();
   }
 
   /**

--- a/electron/main/editor-spawn.test.ts
+++ b/electron/main/editor-spawn.test.ts
@@ -220,11 +220,37 @@ describe("resolveEditorSpawn", () => {
     warnSpy.mockRestore();
   });
 
-  it("returns the spec unchanged for a GUI editor", () => {
+  it("returns the spec unchanged for a GUI editor (auto-detect)", () => {
     expect(resolveEditorSpawn("code", ["/tmp/foo.py"])).toEqual({
       file: "code",
       args: ["/tmp/foo.py"],
     });
+  });
+
+  it("wraps a GUI-named editor when wrapInTerminal is forced true", () => {
+    // The override path: a TUI editor PDV's allowlist doesn't recognise.
+    const { file } = resolveEditorSpawn("my-tui-editor", ["/tmp/foo.py"], {
+      wrapInTerminal: true,
+      terminal: { preset: "alacritty" },
+      platform: "linux",
+    });
+    expect(file).toBe("alacritty");
+  });
+
+  it("does not wrap a TUI editor when wrapInTerminal is forced false", () => {
+    // The opt-out path: a GUI variant whose basename matches the allowlist.
+    expect(
+      resolveEditorSpawn("vim", ["/tmp/foo.py"], { wrapInTerminal: false }),
+    ).toEqual({ file: "vim", args: ["/tmp/foo.py"] });
+  });
+
+  it("auto-detects wrapping when wrapInTerminal is omitted", () => {
+    expect(
+      resolveEditorSpawn("vim", ["/tmp/foo.py"], {
+        terminal: { preset: "alacritty" },
+        platform: "linux",
+      }).file,
+    ).toBe("alacritty");
   });
 
   it("does not wrap when preset='none', even for a TUI editor (logs warning)", () => {

--- a/electron/main/editor-spawn.ts
+++ b/electron/main/editor-spawn.ts
@@ -70,6 +70,53 @@ export interface TerminalLauncherConfig {
 }
 
 /**
+ * User-configured editor / IDE launcher. Persisted under
+ * `PDVConfig.launchers.editor`. Supersedes the legacy per-language
+ * `pythonEditorCmd` / `juliaEditorCmd` config keys.
+ */
+export interface EditorLauncherConfig {
+  /**
+   * Command used to open a single file (e.g. `"code {}"`, `"nvim {}"`).
+   * `{}` is the file-path placeholder; if absent the path is appended.
+   */
+  fileCommand?: string;
+  /**
+   * Command used to open a directory (e.g. the per-kernel working
+   * directory). Same `{}` placeholder convention. Consumed by the
+   * "open working directory" action — see PLANNED_FEATURES.md.
+   */
+  dirCommand?: string;
+  /**
+   * Whether `fileCommand` is a TUI editor that must be wrapped in a
+   * terminal. When unset, PDV auto-detects from the command's basename
+   * (see {@link isTerminalEditorCommand}).
+   */
+  isTuiEditor?: boolean;
+}
+
+/**
+ * User-configured AI-agent launcher. Persisted under
+ * `PDVConfig.launchers.agent`. The agent CLI runs inside the configured
+ * terminal preset, in a shell that has `cd`-ed to {@link cwd}.
+ */
+export interface AgentLauncherConfig {
+  /**
+   * Agent CLI command. Three placeholders are substituted with
+   * shell-quoted absolute paths before launch:
+   * - `{mcpConfig}` — the materialized `.pdv-mcp.json` (point the agent at
+   *   PDV's MCP server, e.g. `claude --mcp-config {mcpConfig}`).
+   * - `{projectRoot}` — the active project directory.
+   * - `{workingDir}` — the active kernel's session working directory.
+   */
+  command?: string;
+  /** Which directory the agent shell starts in. Defaults to `'project'`. */
+  cwd?: "project" | "working";
+}
+
+/** Default agent command when `launchers.agent.command` is unset. */
+export const DEFAULT_AGENT_COMMAND = "claude --mcp-config {mcpConfig}";
+
+/**
  * Templates for each preset. Two placeholders are recognised:
  *
  * - `{cmd}` — splices the editor argv in as multiple argv tokens. Used by
@@ -197,7 +244,7 @@ export function isTerminalEditorCommand(command: string): boolean {
  * @param arg - Argv element to quote.
  * @returns Single-quoted form safe to embed in a shell command line.
  */
-function posixShellQuote(arg: string): string {
+export function posixShellQuote(arg: string): string {
   if (arg.length === 0) return "''";
   return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
@@ -397,9 +444,12 @@ export function buildEditorSpawn(
 /**
  * Resolve platform-specific spawn command/args for launching an editor.
  *
- * For non-TUI editors (`code`, `subl`, …) the spec passes through unchanged.
- * For TUI editors (`vim`, `nvim`, …) the spec is wrapped in the configured
- * terminal preset so a terminal window actually opens.
+ * Whether to wrap the command in a terminal is governed by
+ * `opts.wrapInTerminal`. The caller passes the user's
+ * `launchers.editor.isTuiEditor` flag straight through: when it is `true`
+ * the spec is wrapped, when `false` it is left bare, and when `undefined`
+ * (the user has expressed no preference) PDV auto-detects from the
+ * command's basename via {@link isTerminalEditorCommand}.
  *
  * When `opts.terminal` is unset, the platform-default preset is used (see
  * {@link defaultTerminalPreset}) — preserves PDV's prior macOS-Terminal.app
@@ -408,24 +458,32 @@ export function buildEditorSpawn(
  * at all.
  *
  * `preset: 'none'` is a deliberate opt-out: it returns the spec unwrapped
- * even for TUI editors. Spawning `vim` without a TTY won't open a usable
+ * even for a TUI editor. Spawning `vim` without a TTY won't open a usable
  * window — the setting is intended for GUI editors that PDV's allowlist
  * misclassifies (e.g. `nvim-qt`, custom shims). A warning is logged when
  * this combination is hit.
  *
  * @param command - Editor executable.
  * @param args - Editor arguments.
- * @param opts - Optional terminal-launcher configuration. `platform` defaults
- *   to `process.platform` and exists primarily so tests can exercise
- *   platform-specific templates without monkey-patching globals.
+ * @param opts - Optional launcher configuration:
+ *   - `wrapInTerminal` — force terminal wrapping on/off; auto-detected when
+ *     omitted.
+ *   - `terminal` — terminal-emulator preset selection.
+ *   - `platform` — defaults to `process.platform`; lets tests exercise
+ *     platform-specific templates without monkey-patching globals.
  * @returns Spawn-ready executable and argument list.
  */
 export function resolveEditorSpawn(
   command: string,
   args: string[],
-  opts?: { terminal?: TerminalLauncherConfig; platform?: NodeJS.Platform },
+  opts?: {
+    wrapInTerminal?: boolean;
+    terminal?: TerminalLauncherConfig;
+    platform?: NodeJS.Platform;
+  },
 ): { file: string; args: string[] } {
-  if (!isTerminalEditorCommand(command)) {
+  const wrapInTerminal = opts?.wrapInTerminal ?? isTerminalEditorCommand(command);
+  if (!wrapInTerminal) {
     return { file: command, args };
   }
 

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -588,7 +588,7 @@ describe("Step 5 IPC handlers", () => {
         showPrivateVariables: false,
         showModuleVariables: false,
         showCallableVariables: false,
-        pythonEditorCmd: "nvim {}",
+        launchers: { editor: { fileCommand: "nvim {}" } },
       });
       (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
         { payload: { path: "/tmp/script.py", file_path: "/tmp/script.py" } }
@@ -621,8 +621,10 @@ describe("Step 5 IPC handlers", () => {
         showPrivateVariables: false,
         showModuleVariables: false,
         showCallableVariables: false,
-        pythonEditorCmd: "nvim {}",
-        launchers: { terminal: { preset: "iterm2" } },
+        launchers: {
+          editor: { fileCommand: "nvim {}" },
+          terminal: { preset: "iterm2" },
+        },
       });
       (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
         { payload: { path: "/tmp/script.py", file_path: "/tmp/script.py" } }
@@ -648,8 +650,10 @@ describe("Step 5 IPC handlers", () => {
         showPrivateVariables: false,
         showModuleVariables: false,
         showCallableVariables: false,
-        pythonEditorCmd: "nvim {}",
-        launchers: { terminal: { preset: "x-terminal-emulator" } },
+        launchers: {
+          editor: { fileCommand: "nvim {}" },
+          terminal: { preset: "x-terminal-emulator" },
+        },
       });
       (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
         { payload: { path: "/tmp/script.py", file_path: "/tmp/script.py" } }
@@ -674,8 +678,10 @@ describe("Step 5 IPC handlers", () => {
         showPrivateVariables: false,
         showModuleVariables: false,
         showCallableVariables: false,
-        pythonEditorCmd: "nvim {}",
-        launchers: { terminal: { preset: "none" } },
+        launchers: {
+          editor: { fileCommand: "nvim {}" },
+          terminal: { preset: "none" },
+        },
       });
       (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
         { payload: { path: "/tmp/script.py", file_path: "/tmp/script.py" } }
@@ -695,6 +701,29 @@ describe("Step 5 IPC handlers", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it("script:edit honours an explicit launchers.editor.isTuiEditor=false override", async () => {
+    const { configStore, commRouter } = setup();
+    (configStore.getAll as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      showPrivateVariables: false,
+      showModuleVariables: false,
+      showCallableVariables: false,
+      // `nvim` would normally auto-wrap; the explicit flag opts out.
+      launchers: { editor: { fileCommand: "nvim {}", isTuiEditor: false } },
+    });
+    (commRouter.request as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      { payload: { path: "/tmp/script.py", file_path: "/tmp/script.py" } }
+    );
+
+    const edit = getHandler(IPC.script.edit);
+    await edit({}, "kernel-1", "/tmp/script.py");
+
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      "nvim",
+      ["/tmp/script.py"],
+      expect.objectContaining({ detached: true, stdio: "ignore" }),
+    );
   });
 
   it("config:get returns current config object", async () => {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -57,8 +57,10 @@ import {
   NamespaceQueryOptions,
   PDVConfig,
   type CodeCellData,
+  type McpStatus,
 } from "./ipc";
 import { PDVMessage, PDVMessageType, setAppVersion } from "./pdv-protocol";
+import { registerLaunchersIpcHandlers } from "./ipc-register-launchers";
 import type { McpServerHooks } from "./mcp/mcp-context";
 import {
   allocateAndRegisterLib,
@@ -617,6 +619,14 @@ export function registerIpcHandlers(
     resolveEditorSpawn,
   });
 
+  registerLaunchersIpcHandlers({
+    kernelWorkingDirs,
+    getActiveKernelId: () => activeKernelId,
+    getActiveProjectDir: () => activeProjectDir,
+    getConfig: () => readConfig(configStore),
+    getMcpStatus: () => mcpServerInstance?.status ?? null,
+  });
+
   registerModulesIpcHandlers({
     win,
     kernelManager,
@@ -1019,6 +1029,27 @@ let mcpServerHooks: McpServerHooks | null = null;
  */
 export function getMcpServerHooks(): McpServerHooks | null {
   return mcpServerHooks;
+}
+
+/**
+ * Live MCP server reference, set by `bootstrap.ts` once the server has
+ * started. The agent-launcher IPC handler reads `.status` from it at
+ * click time. `null` before the server starts (and in tests).
+ *
+ * Typed structurally so this module does not import the `PdvMcpServer`
+ * class (which would pull MCP-server transitive deps into every importer).
+ */
+let mcpServerInstance: { status: McpStatus } | null = null;
+
+/**
+ * Register (or clear) the live MCP server reference.
+ *
+ * @param server - The running MCP server, or `null` to clear.
+ */
+export function setMcpServerInstance(
+  server: { status: McpStatus } | null,
+): void {
+  mcpServerInstance = server;
 }
 
 /**

--- a/electron/main/ipc-register-app-state.test.ts
+++ b/electron/main/ipc-register-app-state.test.ts
@@ -204,6 +204,26 @@ describe("config:get / config:set", () => {
       mutatingToolsEnabled: true,
     });
   });
+
+  it("config:set deep-merges the `launchers` subtree to preserve sibling slots", async () => {
+    // A partial `launchers` update (just the agent slot) must not wipe the
+    // previously-saved `terminal` / `editor` slots.
+    const { config } = setup();
+    (config.state as unknown as Record<string, unknown>).launchers = {
+      terminal: { preset: "alacritty" },
+      editor: { fileCommand: "nvim {}" },
+    };
+
+    await getHandler(IPC.config.set)({}, {
+      launchers: { agent: { command: "claude" } },
+    } as Partial<PDVConfig>);
+
+    expect((config.state as unknown as Record<string, unknown>).launchers).toMatchObject({
+      terminal: { preset: "alacritty" },
+      editor: { fileCommand: "nvim {}" },
+      agent: { command: "claude" },
+    });
+  });
 });
 
 describe("themes:get / themes:save / themes:openDir", () => {

--- a/electron/main/ipc-register-app-state.ts
+++ b/electron/main/ipc-register-app-state.ts
@@ -166,13 +166,19 @@ export function registerAppStateIpcHandlers(
     for (const key of Object.keys(updates) as Array<keyof PDVConfig>) {
       const value = updates[key];
       if (value === undefined) continue;
-      if (key === "mcp" && value !== null && typeof value === "object") {
-        // The renderer's `Config['mcp']` type intentionally omits main-only
-        // fields (e.g. `authToken`). A full replace would silently drop the
-        // persisted bearer token and break every connected agent on the
-        // next toggle, so merge into the existing `mcp` subtree instead.
-        const existing = (configStore.get("mcp") ?? {}) as NonNullable<PDVConfig["mcp"]>;
-        configStore.set("mcp", { ...existing, ...(value as PDVConfig["mcp"]) });
+      if ((key === "mcp" || key === "launchers") && value !== null && typeof value === "object") {
+        // Shallow-merge these nested subtrees rather than full-replacing them:
+        // - `mcp`: the renderer's `Config['mcp']` type omits main-only fields
+        //   (e.g. `authToken`); a full replace would drop the persisted bearer
+        //   token and break every connected agent on the next toggle.
+        // - `launchers`: a caller may send a partial update (just `terminal`,
+        //   say); a full replace would silently drop the sibling `editor` /
+        //   `agent` slots.
+        const existing = (configStore.get(key) ?? {}) as Record<string, unknown>;
+        configStore.set(key, {
+          ...existing,
+          ...(value as Record<string, unknown>),
+        } as PDVConfig[typeof key]);
       } else {
         configStore.set(key, value);
       }

--- a/electron/main/ipc-register-coverage.test.ts
+++ b/electron/main/ipc-register-coverage.test.ts
@@ -118,6 +118,7 @@ import { registerProjectIpcHandlers } from "./ipc-register-project";
 import { registerAppStateIpcHandlers } from "./ipc-register-app-state";
 import { registerModuleWindowIpcHandlers } from "./ipc-register-module-windows";
 import { registerGuiEditorIpcHandlers } from "./ipc-register-gui-editor";
+import { registerLaunchersIpcHandlers } from "./ipc-register-launchers";
 import {
   createBrowserWindowMock,
   createCommRouterMock,
@@ -262,6 +263,13 @@ function setupAll(): void {
     guiEditorWindowManager: createGuiEditorWindowManagerMock(),
     guiViewerWindowManager: createGuiViewerWindowManagerMock(),
     commRouter: commRouter.router,
+  });
+  registerLaunchersIpcHandlers({
+    kernelWorkingDirs,
+    getActiveKernelId: () => null,
+    getActiveProjectDir: () => null,
+    getConfig: () => config.store.getAll() as PDVConfig,
+    getMcpStatus: () => null,
   });
 }
 

--- a/electron/main/ipc-register-launchers.ts
+++ b/electron/main/ipc-register-launchers.ts
@@ -1,0 +1,104 @@
+/**
+ * ipc-register-launchers.ts — IPC handlers for the action-bar launcher buttons.
+ *
+ * Currently registers `launchers.openAgent`, which launches the configured AI
+ * agent CLI in a terminal window pointed at PDV's MCP server.
+ *
+ * Non-responsibilities:
+ * - Building the spawn spec (see `agent-launcher.ts`).
+ * - Writing the MCP config file (see `mcp/mcp-config-writer.ts`).
+ */
+
+import { spawn } from "child_process";
+
+import { ipcMain } from "electron";
+
+import { buildAgentInvocation } from "./agent-launcher";
+import type { PDVConfig } from "./config";
+import { IPC, type McpStatus, type ScriptOperationResult } from "./ipc";
+import { writeMcpConfigFile } from "./mcp/mcp-config-writer";
+
+/** Dependency bag for {@link registerLaunchersIpcHandlers}. */
+export interface RegisterLaunchersIpcHandlersOptions {
+  /** Per-kernel working-directory map (kernel id → absolute path). */
+  kernelWorkingDirs: Map<string, string>;
+  /** Accessor for the active kernel id. */
+  getActiveKernelId: () => string | null;
+  /** Accessor for the active project directory (`null` when unsaved). */
+  getActiveProjectDir: () => string | null;
+  /** Accessor for the current merged config snapshot. */
+  getConfig: () => PDVConfig;
+  /** Accessor for the live MCP server status (`null` before the server starts). */
+  getMcpStatus: () => McpStatus | null;
+}
+
+/**
+ * Register the `launchers.*` IPC handlers.
+ *
+ * @param options - Dependency bag; see {@link RegisterLaunchersIpcHandlersOptions}.
+ * @returns Nothing.
+ */
+export function registerLaunchersIpcHandlers(
+  options: RegisterLaunchersIpcHandlersOptions,
+): void {
+  const {
+    kernelWorkingDirs,
+    getActiveKernelId,
+    getActiveProjectDir,
+    getConfig,
+    getMcpStatus,
+  } = options;
+
+  ipcMain.handle(
+    IPC.launchers.openAgent,
+    async (): Promise<ScriptOperationResult> => {
+      // Under E2E we never spawn an external terminal — the spawn is detached
+      // and would outlive the Electron app being torn down by the test.
+      if (process.env.PDV_E2E === "1") {
+        return { success: true };
+      }
+
+      const kernelId = getActiveKernelId();
+      if (!kernelId) {
+        return { success: false, error: "No active kernel; start one first." };
+      }
+      const workingDir = kernelWorkingDirs.get(kernelId);
+      if (!workingDir) {
+        return { success: false, error: "No working directory for the active kernel." };
+      }
+      const mcpStatus = getMcpStatus();
+      if (!mcpStatus || !mcpStatus.running) {
+        return { success: false, error: "The MCP server is not running." };
+      }
+
+      try {
+        const mcpConfigPath = await writeMcpConfigFile(workingDir, mcpStatus);
+        const config = getConfig();
+        const spawnSpec = buildAgentInvocation({
+          agent: config.launchers?.agent,
+          terminal: config.launchers?.terminal,
+          mcpConfigPath,
+          projectRoot: getActiveProjectDir(),
+          workingDir,
+        });
+        const child = spawn(spawnSpec.file, spawnSpec.args, {
+          detached: true,
+          stdio: "ignore",
+        });
+        child.on("error", (err) => {
+          const msg =
+            err && (err as NodeJS.ErrnoException).code === "ENOENT"
+              ? `Agent launch failed: "${spawnSpec.file}" not found.`
+              : `Agent launch failed: ${err.message}`;
+          console.error("[pdv] agent spawn error:", msg);
+        });
+        child.unref();
+        return { success: true };
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        console.error("[pdv] launchers.openAgent failed:", error);
+        return { success: false, error: `Failed to launch agent: ${error}` };
+      }
+    },
+  );
+}

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -68,7 +68,10 @@ interface RegisterTreeNamespaceScriptIpcHandlersOptions {
   resolveEditorSpawn: (
     command: string,
     args: string[],
-    opts?: { terminal?: import("./editor-spawn").TerminalLauncherConfig },
+    opts?: {
+      wrapInTerminal?: boolean;
+      terminal?: import("./editor-spawn").TerminalLauncherConfig;
+    },
   ) => { file: string; args: string[] };
 }
 
@@ -599,10 +602,12 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
     const resolvedPath = filePath;
 
-    const isJulia = resolvedPath.endsWith(".jl");
-    const cmdString = isJulia ? config.juliaEditorCmd : config.pythonEditorCmd;
-    const { file, args } = buildEditorSpawn(cmdString, resolvedPath);
+    const { file, args } = buildEditorSpawn(
+      config.launchers?.editor?.fileCommand,
+      resolvedPath,
+    );
     const spawnSpec = resolveEditorSpawn(file, args, {
+      wrapInTerminal: config.launchers?.editor?.isTuiEditor,
       terminal: config.launchers?.terminal,
     });
     try {

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -45,11 +45,16 @@ import type {
 
 export type { PDVConfig } from "./config";
 /**
- * Re-export the terminal-launcher types so renderer-facing type files can
- * consume them via `types/pdv.d.ts` without importing across the
- * main↔renderer process boundary.
+ * Re-export the launcher types so renderer-facing type files can consume
+ * them via `types/pdv.d.ts` without importing across the main↔renderer
+ * process boundary.
  */
-export type { TerminalPreset, TerminalLauncherConfig } from "./editor-spawn";
+export type {
+  TerminalPreset,
+  TerminalLauncherConfig,
+  EditorLauncherConfig,
+  AgentLauncherConfig,
+} from "./editor-spawn";
 import type { UpdateStatus } from "./auto-updater";
 export type { UpdateStatus } from "./auto-updater";
 export type { EnvironmentInfo, EnvironmentInstallResult, InstallOutputChunk } from "./environment-detector";
@@ -109,6 +114,10 @@ export const IPC = {
     edit: "script:edit",
     run: "script:run",
     getParams: "script:getParams",
+  },
+  /** External-app launcher channels (action-bar buttons). */
+  launchers: {
+    openAgent: "launchers:openAgent",
   },
   /** Markdown note channels. */
   note: {
@@ -2607,6 +2616,19 @@ export interface PDVApi {
      * action-bar buttons) can branch on platform without an async call.
      */
     platform: NodeJS.Platform;
+  };
+
+  /** External-app launchers driven by the action bar. */
+  launchers: {
+    /**
+     * Launch the configured AI agent (Claude Code by default) in a terminal
+     * window, `cd`-ed to the active project (or working) directory, with a
+     * freshly-written `.pdv-mcp.json` pointing it at PDV's MCP server.
+     *
+     * @returns `{ success: true }`, or `{ success: false, error }` when no
+     *   kernel is active, the MCP server is down, or the spawn fails.
+     */
+    openAgent(): Promise<ScriptOperationResult>;
   };
 
   /** Window chrome integration and title-bar controls. */

--- a/electron/main/mcp/mcp-config-writer.test.ts
+++ b/electron/main/mcp/mcp-config-writer.test.ts
@@ -1,0 +1,85 @@
+/**
+ * mcp-config-writer.test.ts — Tests for writeMcpConfigFile.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { McpStatus } from "../ipc";
+import { MCP_CONFIG_FILENAME, writeMcpConfigFile } from "./mcp-config-writer";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pdv-mcpcfg-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+const RUNNING_STATUS: McpStatus = {
+  running: true,
+  host: "127.0.0.1",
+  port: 7391,
+  token: "secret-token",
+  url: "http://127.0.0.1:7391/mcp",
+  generation: 0,
+  clientCount: 0,
+};
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("writeMcpConfigFile", () => {
+  it("writes a Claude-Code-shaped mcpServers config", async () => {
+    const dir = makeTempDir();
+    const configPath = await writeMcpConfigFile(dir, RUNNING_STATUS);
+
+    expect(configPath).toBe(path.join(dir, MCP_CONFIG_FILENAME));
+    const parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(parsed).toEqual({
+      mcpServers: {
+        pdv: {
+          type: "http",
+          url: "http://127.0.0.1:7391/mcp",
+          headers: { Authorization: "Bearer secret-token" },
+        },
+      },
+    });
+  });
+
+  it("creates the file mode 0600 so the bearer token is not world-readable", () => {
+    if (process.platform === "win32") return; // mode bits are a no-op on Windows
+    return writeMcpConfigFile(makeTempDir(), RUNNING_STATUS).then((configPath) => {
+      const mode = fs.statSync(configPath).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+  });
+
+  it("overwrites a stale config on a second write", async () => {
+    const dir = makeTempDir();
+    await writeMcpConfigFile(dir, { ...RUNNING_STATUS, port: 1111, url: "http://127.0.0.1:1111/mcp" });
+    const configPath = await writeMcpConfigFile(dir, RUNNING_STATUS);
+    const parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(parsed.mcpServers.pdv.url).toBe("http://127.0.0.1:7391/mcp");
+  });
+
+  it("throws when the MCP server is not running", async () => {
+    const dir = makeTempDir();
+    await expect(
+      writeMcpConfigFile(dir, {
+        running: false,
+        host: "127.0.0.1",
+        port: null,
+        token: null,
+        url: null,
+        generation: 0,
+        clientCount: 0,
+      }),
+    ).rejects.toThrow(/not running/);
+  });
+});

--- a/electron/main/mcp/mcp-config-writer.ts
+++ b/electron/main/mcp/mcp-config-writer.ts
@@ -19,6 +19,7 @@
  *   the protection boundary there.
  */
 
+import { randomBytes } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
@@ -63,8 +64,9 @@ export async function writeMcpConfigFile(
   // Atomic temp-then-rename, with the temp file created mode 0600 so the
   // bearer token is never briefly world-readable. `fs.writeFile`'s `mode`
   // only applies when the file is created; `chmod` defensively covers a
-  // pre-existing temp file left by a crashed write.
-  const tmp = `${configPath}.tmp`;
+  // pre-existing temp file left by a crashed write. The temp name carries a
+  // random suffix so two concurrent writes can't clobber each other's temp.
+  const tmp = `${configPath}.${randomBytes(6).toString("hex")}.tmp`;
   try {
     await fs.writeFile(tmp, body, { encoding: "utf8", mode: 0o600 });
     await fs.chmod(tmp, 0o600);

--- a/electron/main/mcp/mcp-config-writer.ts
+++ b/electron/main/mcp/mcp-config-writer.ts
@@ -1,0 +1,77 @@
+/**
+ * mcp-config-writer.ts — Materialize a `.pdv-mcp.json` for external agents.
+ *
+ * The action-bar agent button launches an external agent CLI (Claude Code by
+ * default) and points it at PDV's loopback MCP server via a config file. This
+ * module writes that file.
+ *
+ * Why the per-kernel working directory (not the project directory):
+ * - The file embeds the MCP bearer token. The working directory lives under
+ *   `~/.PDV/working/pdv-<random>/`, is owned by the current user, and is
+ *   deleted on kernel teardown — so the secret is ephemeral and never lands
+ *   in a directory the user might commit to version control.
+ * - It is written fresh immediately before each agent launch, so it always
+ *   reflects the MCP server's current port and token.
+ *
+ * Security:
+ * - The file is written with mode `0600` (owner read/write only) on POSIX.
+ *   On Windows the mode bit is a no-op; the user-owned working directory is
+ *   the protection boundary there.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import type { McpStatus } from "../ipc";
+
+/** Filename written into the working directory. */
+export const MCP_CONFIG_FILENAME = ".pdv-mcp.json";
+
+/**
+ * Write `.pdv-mcp.json` into `workingDir`, describing PDV's MCP server in the
+ * `mcpServers` shape that Claude Code's `--mcp-config` flag consumes.
+ *
+ * @param workingDir - Absolute path of the active kernel's working directory.
+ * @param status - Live MCP server status; must be `running` with a non-null
+ *   `url` and `token`.
+ * @returns Absolute path of the written config file.
+ * @throws {Error} When the server is not running, or the file cannot be
+ *   written. A stale temp file is removed before the error propagates.
+ */
+export async function writeMcpConfigFile(
+  workingDir: string,
+  status: McpStatus,
+): Promise<string> {
+  if (!status.running || !status.url || !status.token) {
+    throw new Error("MCP server is not running; cannot write agent config.");
+  }
+  const configPath = path.join(workingDir, MCP_CONFIG_FILENAME);
+  const body = JSON.stringify(
+    {
+      mcpServers: {
+        pdv: {
+          type: "http",
+          url: status.url,
+          headers: { Authorization: `Bearer ${status.token}` },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+  // Atomic temp-then-rename, with the temp file created mode 0600 so the
+  // bearer token is never briefly world-readable. `fs.writeFile`'s `mode`
+  // only applies when the file is created; `chmod` defensively covers a
+  // pre-existing temp file left by a crashed write.
+  const tmp = `${configPath}.tmp`;
+  try {
+    await fs.writeFile(tmp, body, { encoding: "utf8", mode: 0o600 });
+    await fs.chmod(tmp, 0o600);
+    await fs.rename(tmp, configPath);
+  } catch (err) {
+    await fs.rm(tmp, { force: true }).catch(() => {});
+    throw err;
+  }
+  return configPath;
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -239,6 +239,9 @@ const api: PDVApi = {
     // IPC channel — renderers read this synchronously from `window.pdv`.
     platform: process.platform,
   },
+  launchers: {
+    openAgent: () => ipcRenderer.invoke(IPC.launchers.openAgent),
+  },
   chrome: {
     getInfo: () => ipcRenderer.invoke(IPC.chrome.getInfo),
     minimize: () => ipcRenderer.invoke(IPC.chrome.minimize),

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -401,6 +401,25 @@ const App: React.FC = () => {
   const currentKernelIdRef = useRef(currentKernelId);
   currentKernelIdRef.current = currentKernelId;
 
+  // Guards re-entrant agent-button clicks so a rapid double-click doesn't
+  // spawn two terminals. Set true for the duration of the openAgent call.
+  const agentLaunchingRef = useRef(false);
+  const handleOpenAgent = useCallback(() => {
+    if (agentLaunchingRef.current) return;
+    agentLaunchingRef.current = true;
+    void window.pdv.launchers
+      .openAgent()
+      .then((result) => {
+        if (!result.success) {
+          console.error('[pdv] failed to launch agent:', result.error);
+          window.alert(result.error ?? 'Failed to launch the AI agent.');
+        }
+      })
+      .finally(() => {
+        agentLaunchingRef.current = false;
+      });
+  }, []);
+
   const handleKernelCrash = useCallback((crashedKernelId: string) => {
     if (crashedKernelId === currentKernelIdRef.current) {
       setKernelStatus('error');
@@ -1421,14 +1440,7 @@ const App: React.FC = () => {
           leftPanel={leftPanel}
           onActivityBarClick={handleActivityBarClick}
           onSettingsClick={() => { setSettingsInitialTab('general'); setShowSettings(true); }}
-          onAgentClick={() => {
-            void window.pdv.launchers.openAgent().then((result) => {
-              if (!result.success) {
-                console.error('[pdv] failed to launch agent:', result.error);
-                window.alert(result.error ?? 'Failed to launch the AI agent.');
-              }
-            });
-          }}
+          onAgentClick={handleOpenAgent}
           guiModules={importedGuiModules}
           kernelId={currentKernelId}
         />

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -1421,6 +1421,14 @@ const App: React.FC = () => {
           leftPanel={leftPanel}
           onActivityBarClick={handleActivityBarClick}
           onSettingsClick={() => { setSettingsInitialTab('general'); setShowSettings(true); }}
+          onAgentClick={() => {
+            void window.pdv.launchers.openAgent().then((result) => {
+              if (!result.success) {
+                console.error('[pdv] failed to launch agent:', result.error);
+                window.alert(result.error ?? 'Failed to launch the AI agent.');
+              }
+            });
+          }}
           guiModules={importedGuiModules}
           kernelId={currentKernelId}
         />

--- a/electron/renderer/src/components/ActivityBar/index.tsx
+++ b/electron/renderer/src/components/ActivityBar/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { TreeIcon, NamespaceIcon, SettingsIcon } from '../Icons';
+import { TreeIcon, NamespaceIcon, SettingsIcon, AgentIcon } from '../Icons';
 
 type LeftPanel = 'tree' | 'namespace';
 
@@ -15,6 +15,7 @@ interface ActivityBarProps {
   leftPanel: LeftPanel;
   onActivityBarClick: (panel: LeftPanel) => void;
   onSettingsClick: () => void;
+  onAgentClick: () => void;
   guiModules?: { alias: string; name: string }[];
   kernelId: string | null;
 }
@@ -25,6 +26,7 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
   leftPanel,
   onActivityBarClick,
   onSettingsClick,
+  onAgentClick,
   guiModules = [],
   kernelId,
 }) => (
@@ -66,6 +68,14 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
       )}
     </div>
     <div className="activity-bar-bottom">
+      <button
+        className="activity-btn"
+        onClick={onAgentClick}
+        disabled={!kernelId}
+        title={kernelId ? 'Open AI agent in terminal' : 'Start a kernel to launch an AI agent'}
+      >
+        <AgentIcon />
+      </button>
       <button
         className="activity-btn"
         onClick={onSettingsClick}

--- a/electron/renderer/src/components/Icons.tsx
+++ b/electron/renderer/src/components/Icons.tsx
@@ -68,3 +68,14 @@ export const SettingsIcon: React.FC<IconProps> = (props) => (
     </g>
   </svg>
 );
+
+/** Robot-head icon for the AI-agent launcher button. */
+export const AgentIcon: React.FC<IconProps> = (props) => (
+  <svg {...defaults} {...props}>
+    <rect x="4" y="7.5" width="12" height="8.5" rx="2" />
+    <line x1="10" y1="4" x2="10" y2="7.5" />
+    <circle cx="10" cy="3.3" r="1.1" fill="currentColor" stroke="none" />
+    <circle cx="8" cy="11.5" r="1.1" fill="currentColor" stroke="none" />
+    <circle cx="12" cy="11.5" r="1.1" fill="currentColor" stroke="none" />
+  </svg>
+);

--- a/electron/renderer/src/components/SettingsDialog/index.tsx
+++ b/electron/renderer/src/components/SettingsDialog/index.tsx
@@ -22,6 +22,7 @@ import {
   TERMINAL_PRESET_LABELS,
   defaultTerminalPresetForPlatform,
   getTerminalPresetsForPlatform,
+  isLikelyTuiEditor,
   normalizeShortcut,
 } from './utils';
 import { ShortcutCapture } from './ShortcutCapture';
@@ -32,6 +33,8 @@ import { DEFAULT_AUTOSAVE_INTERVAL_S } from '../../app/constants';
 type SettingsTab = 'general' | 'shortcuts' | 'appearance' | 'agents' | 'runtime' | 'about';
 
 const DEFAULT_FILE_MANAGER = IS_MAC ? 'open {}' : 'xdg-open {}';
+/** Mirrors `DEFAULT_AGENT_COMMAND` in `main/editor-spawn.ts`. */
+const DEFAULT_AGENT_COMMAND = 'claude --mcp-config {mcpConfig}';
 const DEFAULT_VSCODE_PAIR = THEME_PAIRS.find((pair) => pair.name === 'VSCode');
 
 /**
@@ -91,11 +94,13 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
   );
 
   // General settings state
-  const [pythonEditorCmd, setPythonEditorCmd] = useState('code {}');
-  const [juliaEditorCmd, setJuliaEditorCmd] = useState('code {}');
+  const [editorFileCommand, setEditorFileCommand] = useState('code {}');
+  const [editorIsTuiEditor, setEditorIsTuiEditor] = useState(false);
   const [fileManagerCmd, setFileManagerCmd] = useState(DEFAULT_FILE_MANAGER);
   const [terminalPreset, setTerminalPreset] = useState<TerminalPreset>(DEFAULT_TERMINAL_PRESET);
   const [terminalCustomTemplate, setTerminalCustomTemplate] = useState('');
+  const [agentCommand, setAgentCommand] = useState(DEFAULT_AGENT_COMMAND);
+  const [agentCwd, setAgentCwd] = useState<'project' | 'working'>('project');
   const [defaultSaveLocation, setDefaultSaveLocation] = useState('');
   const [workingDirBase, setWorkingDirBase] = useState('');
   const [autoSaveInterval, setAutoSaveInterval] = useState(DEFAULT_AUTOSAVE_INTERVAL_S);
@@ -126,8 +131,12 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     if (!isOpen) return;
     /* eslint-disable react-hooks/set-state-in-effect -- intentional sync from props on dialog open */
     setEditedShortcuts(shortcuts);
-    setPythonEditorCmd(config?.pythonEditorCmd ?? 'code {}');
-    setJuliaEditorCmd(config?.juliaEditorCmd ?? 'code {}');
+    const editorCfg = config?.launchers?.editor;
+    const fileCmd = editorCfg?.fileCommand ?? 'code {}';
+    setEditorFileCommand(fileCmd);
+    // The checkbox shows the *effective* wrap decision: an explicit saved
+    // override, or PDV's basename auto-detection when the user has none.
+    setEditorIsTuiEditor(editorCfg?.isTuiEditor ?? isLikelyTuiEditor(fileCmd));
     setFileManagerCmd(config?.fileManagerCmd ?? DEFAULT_FILE_MANAGER);
     const savedPreset = config?.launchers?.terminal?.preset;
     setTerminalPreset(
@@ -136,6 +145,8 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
         : DEFAULT_TERMINAL_PRESET,
     );
     setTerminalCustomTemplate(config?.launchers?.terminal?.customTemplate ?? '');
+    setAgentCommand(config?.launchers?.agent?.command ?? DEFAULT_AGENT_COMMAND);
+    setAgentCwd(config?.launchers?.agent?.cwd ?? 'project');
     setDefaultSaveLocation(config?.defaultSaveLocation ?? '');
     setWorkingDirBase(config?.workingDirBase ?? '');
     setAutoSaveInterval(config?.autoSaveIntervalSeconds ?? DEFAULT_AUTOSAVE_INTERVAL_S);
@@ -335,11 +346,23 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
         ? { preset: terminalPreset, customTemplate: trimmedCustom || undefined }
         : { preset: terminalPreset };
 
+    const fileCommand = editorFileCommand.trim() || 'code {}';
+    // Persist `isTuiEditor` only when it overrides PDV's auto-detection — that
+    // keeps the main-process auto-detect live for the common case (a saved
+    // explicit `false` for, say, `vim` would silently break terminal wrapping).
+    const isTuiEditor =
+      editorIsTuiEditor === isLikelyTuiEditor(fileCommand) ? undefined : editorIsTuiEditor;
+
     await onSave({
-      pythonEditorCmd: pythonEditorCmd.trim() || 'code {}',
-      juliaEditorCmd:  juliaEditorCmd.trim()  || 'code {}',
       fileManagerCmd:  fileManagerCmd.trim()  || DEFAULT_FILE_MANAGER,
-      launchers: { terminal: terminalLauncher },
+      launchers: {
+        terminal: terminalLauncher,
+        editor: { fileCommand, isTuiEditor },
+        agent: {
+          command: agentCommand.trim() || DEFAULT_AGENT_COMMAND,
+          cwd: agentCwd,
+        },
+      },
       defaultSaveLocation: defaultSaveLocation.trim() || undefined,
       workingDirBase: workingDirBase.trim() || undefined,
       autoSaveIntervalSeconds: Math.max(30, autoSaveInterval),
@@ -396,24 +419,42 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                 If omitted, the path is appended automatically.
               </p>
               <div className="settings-general-grid">
-                <label htmlFor="sg-python-editor">Python editor</label>
+                <label htmlFor="sg-editor-file">Editor / IDE</label>
                 <input
-                  id="sg-python-editor"
+                  id="sg-editor-file"
                   type="text"
-                  value={pythonEditorCmd}
-                  onChange={(e) => setPythonEditorCmd(e.target.value)}
+                  value={editorFileCommand}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    setEditorFileCommand(value);
+                    // Re-derive the wrap checkbox as the command changes so a
+                    // user switching to vim/nvim gets terminal wrapping without
+                    // having to discover the checkbox. A deliberate override is
+                    // re-applied by toggling the checkbox after editing.
+                    setEditorIsTuiEditor(isLikelyTuiEditor(value));
+                  }}
                   placeholder="code {}"
                   spellCheck={false}
                 />
                 <div className="settings-general-desc">
-                  Used when opening Python scripts from the Tree (e.g. <code>code {'{}' }</code>, <code>nvim {'{}' }</code>).
+                  Used when opening a script from the Tree (e.g. <code>code {'{}' }</code>, <code>nvim {'{}' }</code>).
                 </div>
 
-                {/* Julia editor field hidden alongside the welcome-screen
-                    Julia button while the Julia workflow is still
-                    experimental. The juliaEditorCmd state and persistence
-                    paths are intact so re-enabling is just unhiding this
-                    block. */}
+                <label htmlFor="sg-editor-tui">Run in terminal</label>
+                <div className="settings-general-check">
+                  <input
+                    id="sg-editor-tui"
+                    type="checkbox"
+                    checked={editorIsTuiEditor}
+                    onChange={(e) => setEditorIsTuiEditor(e.target.checked)}
+                  />
+                </div>
+                <div className="settings-general-desc">
+                  Wrap the editor in a terminal window — required for TUI editors
+                  like <code>vim</code>, <code>nvim</code>, <code>nano</code>.
+                  Auto-detected from the command; toggle to override (e.g. for GUI
+                  variants such as <code>nvim-qt</code>).
+                </div>
 
                 <label htmlFor="sg-file-manager">File manager</label>
                 <input
@@ -470,6 +511,38 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                     </div>
                   </>
                 )}
+              </div>
+
+              <h4 className="settings-general-section">AI agent</h4>
+              <div className="settings-general-grid">
+                <label htmlFor="sg-agent-command">Command</label>
+                <input
+                  id="sg-agent-command"
+                  type="text"
+                  value={agentCommand}
+                  onChange={(e) => setAgentCommand(e.target.value)}
+                  placeholder={DEFAULT_AGENT_COMMAND}
+                  spellCheck={false}
+                />
+                <div className="settings-general-desc">
+                  Run by the agent button in the activity bar, inside the configured terminal.
+                  Placeholders: <code>{'{mcpConfig}'}</code> (PDV's MCP config file),{' '}
+                  <code>{'{projectRoot}'}</code>, <code>{'{workingDir}'}</code> — each substituted
+                  with a quoted absolute path.
+                </div>
+
+                <label htmlFor="sg-agent-cwd">Start in</label>
+                <select
+                  id="sg-agent-cwd"
+                  value={agentCwd}
+                  onChange={(e) => setAgentCwd(e.target.value as 'project' | 'working')}
+                >
+                  <option value="project">Project directory</option>
+                  <option value="working">Session working directory</option>
+                </select>
+                <div className="settings-general-desc">
+                  Which directory the agent shell <code>cd</code>s into before launching.
+                </div>
               </div>
 
               <h4 className="settings-general-section">Directories</h4>

--- a/electron/renderer/src/components/SettingsDialog/utils.ts
+++ b/electron/renderer/src/components/SettingsDialog/utils.ts
@@ -72,6 +72,30 @@ export function defaultTerminalPresetForPlatform(platform: NodeJS.Platform): Ter
   return 'x-terminal-emulator';
 }
 
+/**
+ * TUI editor basenames PDV auto-wraps in a terminal. Mirrors `TERMINAL_EDITORS`
+ * in `main/editor-spawn.ts` — kept in sync manually (the list is small and
+ * stable, and the runtime value can't cross the process boundary).
+ */
+const TUI_EDITOR_BASENAMES = new Set([
+  'vi', 'vim', 'nvim', 'nano', 'pico', 'emacs', 'kak', 'hx', 'helix',
+]);
+
+/**
+ * Whether an editor command's executable looks like a TUI editor. Used to
+ * pre-derive the "Run in terminal" checkbox so vim/nvim work without the
+ * user having to discover the setting. Mirrors `isTerminalEditorCommand`
+ * in `main/editor-spawn.ts`.
+ *
+ * @param command - Editor command template, e.g. `"nvim {}"` or `"code {}"`.
+ * @returns True when the first token's basename is a known TUI editor.
+ */
+export function isLikelyTuiEditor(command: string): boolean {
+  const firstToken = command.trim().split(/\s+/)[0] ?? '';
+  const base = (firstToken.split(/[/\\]/).pop() ?? '').toLowerCase().replace(/\.exe$/, '');
+  return TUI_EDITOR_BASENAMES.has(base);
+}
+
 /** Convert a stored shortcut token to a human-readable key badge label. */
 export function tokenToLabel(token: string): string {
   switch (token.toLowerCase()) {

--- a/electron/renderer/src/styles/dialogs.css
+++ b/electron/renderer/src/styles/dialogs.css
@@ -239,6 +239,14 @@
   margin-bottom: 4px;
 }
 
+/* Checkbox cell in the settings grid — vertically centre the control so it
+   lines up with its right-aligned label. */
+.settings-general-check {
+  display: flex;
+  align-items: center;
+  min-height: 26px;
+}
+
 .settings-general-desc code {
   font-family: var(--font-mono);
   background: var(--bg-tertiary);

--- a/electron/renderer/src/test-fixtures/pdv-mock.ts
+++ b/electron/renderer/src/test-fixtures/pdv-mock.ts
@@ -214,6 +214,9 @@ function buildBase() {
       // sensitive renderer code under test sees the same value as in prod.
       platform: process.platform,
     },
+    launchers: {
+      openAgent: stub<PDVApi["launchers"]["openAgent"]>(async () => ({ success: true })),
+    },
     chrome: {
       getInfo: stub<PDVApi["chrome"]["getInfo"]>(),
       minimize: stub<PDVApi["chrome"]["minimize"]>(async () => true),

--- a/electron/renderer/src/types/index.ts
+++ b/electron/renderer/src/types/index.ts
@@ -6,7 +6,9 @@
  */
 
 import type {
+  AgentLauncherConfig,
   Config,
+  EditorLauncherConfig,
   EnvironmentInfo,
   InstallOutputChunk,
   KernelExecutionError,
@@ -48,7 +50,9 @@ import type {
 
 /** Re-export core preload API contract types for renderer imports. */
 export type {
+  AgentLauncherConfig,
   Config,
+  EditorLauncherConfig,
   EnvironmentInfo,
   InstallOutputChunk,
   KernelExecutionError,

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -40,6 +40,12 @@ export type { TerminalPreset } from '../../../main/ipc';
 /** Persisted terminal-launcher selection (`launchers.terminal`). */
 export type { TerminalLauncherConfig } from '../../../main/ipc';
 
+/** Persisted editor / IDE launcher config (`launchers.editor`). */
+export type { EditorLauncherConfig } from '../../../main/ipc';
+
+/** Persisted AI-agent launcher config (`launchers.agent`). */
+export type { AgentLauncherConfig } from '../../../main/ipc';
+
 /** Runtime kernel descriptor returned by `kernels.start/list/restart`. */
 export interface KernelInfo {
   /** Opaque kernel id used in subsequent API calls. */
@@ -280,9 +286,9 @@ export interface Config {
   autoRefreshNamespace?: boolean;
   /** Coarse light/dark mode override. */
   theme?: "light" | "dark";
-  /** External editor command for Python scripts. Uses `{}` as file-path placeholder. */
+  /** @deprecated Superseded by `launchers.editor.fileCommand` (migrated on load). */
   pythonEditorCmd?: string;
-  /** External editor command for Julia scripts. Uses `{}` as file-path placeholder. */
+  /** @deprecated Superseded by `launchers.editor.fileCommand` (migrated on load). */
   juliaEditorCmd?: string;
   /** File-manager command to reveal a file/folder. Uses `{}` as placeholder. */
   fileManagerCmd?: string;
@@ -305,6 +311,10 @@ export interface Config {
   launchers?: {
     /** Terminal emulator used to wrap TUI editors (vim, nvim, …). */
     terminal?: TerminalLauncherConfig;
+    /** Editor / IDE commands (supersedes `pythonEditorCmd`/`juliaEditorCmd`). */
+    editor?: EditorLauncherConfig;
+    /** AI-agent CLI launched by the action-bar agent button. */
+    agent?: AgentLauncherConfig;
   };
   settings?: {
     /** Keyboard shortcut overrides. */
@@ -1055,6 +1065,11 @@ export interface PDVApi {
   system: {
     /** Node.js platform identifier of the main process. */
     platform: NodeJS.Platform;
+  };
+  /** External-app launchers driven by the action bar. */
+  launchers: {
+    /** Launch the configured AI agent in a terminal pointed at PDV's MCP server. */
+    openAgent(): Promise<{ success: boolean; error?: string }>;
   };
   chrome: {
     getInfo(): Promise<WindowChromeInfo>;


### PR DESCRIPTION
## Summary

Two follow-on launcher slots after the terminal-launcher PR (#294), bundled into one branch at the author's request.

**Unified editor slot**
- New `launchers.editor` config (`fileCommand`, `dirCommand`, `isTuiEditor`) replacing the per-language `pythonEditorCmd` / `juliaEditorCmd` keys.
- `ConfigStore` runs a one-shot, load-time migration: a pre-existing `pythonEditorCmd` becomes `launchers.editor.fileCommand` and the legacy keys are scrubbed from disk. No-op (no write) when there's nothing to migrate.
- `resolveEditorSpawn` now takes an explicit `wrapInTerminal` flag (auto-detects when omitted). The Settings → General "Editor / IDE" section has a command field + a "Run in terminal" checkbox that auto-derives from the command and is persisted only when it *overrides* auto-detection.

**AI-agent launch button**
- New activity-bar button launches the configured agent CLI (Claude Code by default) inside the terminal preset, in a shell that `cd`s to the project (or working) directory.
- `mcp-config-writer.ts` materializes a `.pdv-mcp.json` (mode `0600`) into the ephemeral kernel working directory so the agent connects back to PDV's MCP server — the bearer token never lands anywhere version-controlled.
- `agent-launcher.ts` expands `{mcpConfig}` / `{projectRoot}` / `{workingDir}` and builds a `sh -lc "cd … && exec …"` wrapper (`cmd /c` on Windows) so cwd is correct across both argv-style terminals and osascript/Terminal.app.
- New `launchers.openAgent` IPC channel + `launchers.agent` config + Settings "AI agent" section.

## Design notes (diverged from the original 4-PR plan)

- MCP config is materialized **lazily at agent-launch**, not hooked into MCP-server start — the port is stable for the session, so no `mcp-server.ts` changes were needed.
- cwd is handled by a `cd … && exec` **shell wrapper**, because `spawn` cwd does not cross the osascript → Terminal.app boundary.
- The env-var fallback (`PDV_MCP_TOKEN` etc.) was **dropped** — env doesn't survive that boundary either, so it would be a false reassurance; `{mcpConfig}` substitution is the real mechanism.
- The `editor-spawn.ts` → `external-launcher.ts` rename is **deferred** to a separate mechanical PR.

## Test plan

- [x] `npm test` — 551/551 passing (new `agent-launcher.test.ts`, `mcp-config-writer.test.ts`, editor-migration + launchers-parse cases).
- [x] `npm run typecheck` — clean (main + renderer).
- [x] `npm run build` — renderer + main build clean.
- [x] Lint clean on all touched files (pre-existing `react-hooks/refs` errors in `app/index.tsx` are unrelated).
- [ ] Manual: agent button — needs `claude` installed + an active kernel; not yet smoke-tested.
- [ ] Windows `cmd /c` agent path is best-effort and untested.
- n/a — does not touch `pdv-python/`, so the dependency sweep does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)