### PR TITLE
Open-working-directory action button + iTerm2 launch fix (#289)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1596,7 +1596,7 @@ The API surface:
 - `window.pdv.environment.*` — Python environment management: `list`, `check`, `install`, `refresh`; push: `onInstallOutput(cb) → unsub`
 - `window.pdv.chrome.*` — window chrome controls: `getInfo`, `minimize`, `toggleMaximize`, `close`; push: `onStateChanged(cb) → unsub`
 - `window.pdv.system.*` — constant host facts injected at preload time: `platform` (the main process's `process.platform`). Exposed as a plain value, not a function — it never changes during a session, so it needs no IPC channel
-- `window.pdv.launchers.*` — action-bar external-app launchers: `openAgent` (launch the configured AI agent in a terminal)
+- `window.pdv.launchers.*` — action-bar external-app launchers: `openAgent` (launch the configured AI agent in a terminal), `openWorkingDir` (open the active kernel's working directory in the configured editor/IDE)
 - `window.pdv.progress.*` — operation progress: push only: `onProgress(cb) → unsub`
 - `window.pdv.menu.*` — menu bridge: `updateRecentProjects(paths)`, `onAction(cb) → unsub`
 

--- a/electron/main/editor-spawn.test.ts
+++ b/electron/main/editor-spawn.test.ts
@@ -416,7 +416,7 @@ describe("resolveEditorSpawn", () => {
     ]);
   });
 
-  it("wraps with iterm2 via osascript and appends `; exit`", () => {
+  it("wraps with iterm2 via osascript using `write text` and appends `; exit`", () => {
     const { file, args } = resolveEditorSpawn("vim", ["/tmp/foo.py"], {
       terminal: { preset: "iterm2" },
       platform: "darwin",
@@ -424,7 +424,7 @@ describe("resolveEditorSpawn", () => {
     expect(file).toBe("osascript");
     expect(args).toEqual([
       "-e",
-      `tell application "iTerm" to create window with default profile command "'vim' '/tmp/foo.py'" & "; exit"`,
+      `tell application "iTerm" to tell current session of (create window with default profile) to write text "'vim' '/tmp/foo.py'" & "; exit"`,
     ]);
   });
 

--- a/electron/main/editor-spawn.ts
+++ b/electron/main/editor-spawn.ts
@@ -158,8 +158,13 @@ const TERMINAL_PRESET_TEMPLATES: Record<
       `osascript -e 'tell application "Terminal" to do script {cmdstr} & "; exit"'`,
   },
   "iterm2": {
+    // `create window … command "…"` is unreliable across iTerm2 versions and
+    // can fail/crash on a complex command string. The documented-robust
+    // pattern is to open a window with the default profile and `write text`
+    // the command into its session — exactly how Terminal.app's `do script`
+    // behaves, so the same quoting that works there works here.
     darwin:
-      `osascript -e 'tell application "iTerm" to create window with default profile command {cmdstr} & "; exit"'`,
+      `osascript -e 'tell application "iTerm" to tell current session of (create window with default profile) to write text {cmdstr} & "; exit"'`,
   },
   "ghostty": {
     darwin: `open -na Ghostty --args -e {cmd}`,

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -636,7 +636,7 @@ describe("Step 5 IPC handlers", () => {
       expect(mocks.spawn).toHaveBeenCalledWith(
         "osascript",
         expect.arrayContaining([
-          expect.stringContaining(`tell application "iTerm" to create window`),
+          expect.stringContaining(`tell application "iTerm" to tell current session of (create window with default profile) to write text`),
         ]),
         expect.any(Object),
       );

--- a/electron/main/ipc-register-launchers.test.ts
+++ b/electron/main/ipc-register-launchers.test.ts
@@ -1,0 +1,125 @@
+/**
+ * ipc-register-launchers.test.ts — Unit tests for the launcher IPC handlers.
+ *
+ * Focuses on `launchers.openWorkingDir` (the kernel guard + the
+ * dirCommand → spawn path). The agent-launch spec building is covered by
+ * `agent-launcher.test.ts`; channel registration is covered by
+ * `ipc-register-coverage.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ipcRegistry = vi.hoisted(() => {
+  const handlers = new Map<string, (event: unknown, ...args: unknown[]) => unknown>();
+  const ipcHandle = vi.fn(
+    (channel: string, handler: (event: unknown, ...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    },
+  );
+  return { handlers, ipcHandle };
+});
+
+const childProcessMocks = vi.hoisted(() => ({
+  spawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: ipcRegistry.ipcHandle, removeHandler: vi.fn() },
+}));
+vi.mock("child_process", () => childProcessMocks);
+
+import type { PDVConfig } from "./config";
+import { IPC } from "./ipc";
+import { registerLaunchersIpcHandlers } from "./ipc-register-launchers";
+
+function getHandler(channel: string): (event: unknown, ...args: unknown[]) => unknown {
+  const handler = ipcRegistry.handlers.get(channel);
+  if (!handler) throw new Error(`no handler for ${channel}`);
+  return handler;
+}
+
+interface SetupOverrides {
+  config?: Partial<PDVConfig>;
+  activeKernelId?: string | null;
+  workingDirs?: [string, string][];
+}
+
+function setup(overrides: SetupOverrides = {}): void {
+  const activeKernelId =
+    "activeKernelId" in overrides ? (overrides.activeKernelId ?? null) : "k1";
+  registerLaunchersIpcHandlers({
+    kernelWorkingDirs: new Map(overrides.workingDirs ?? [["k1", "/tmp/wd"]]),
+    getActiveKernelId: () => activeKernelId,
+    getActiveProjectDir: () => null,
+    getConfig: () =>
+      ({
+        showPrivateVariables: false,
+        showModuleVariables: false,
+        showCallableVariables: false,
+        autoRefreshNamespace: false,
+        ...overrides.config,
+      }) as PDVConfig,
+    getMcpStatus: () => null,
+  });
+}
+
+beforeEach(() => {
+  ipcRegistry.handlers.clear();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("launchers.openWorkingDir", () => {
+  it("opens the working dir with the configured dirCommand (no terminal wrap)", async () => {
+    setup({ config: { launchers: { editor: { dirCommand: "code {}" } } } });
+    const result = await getHandler(IPC.launchers.openWorkingDir)({});
+    expect(result).toEqual({ success: true });
+    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
+      "code",
+      ["/tmp/wd"],
+      expect.objectContaining({ detached: true, stdio: "ignore" }),
+    );
+  });
+
+  it("defaults to `code {}` when no dirCommand is configured", async () => {
+    setup();
+    await getHandler(IPC.launchers.openWorkingDir)({});
+    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
+      "code",
+      ["/tmp/wd"],
+      expect.any(Object),
+    );
+  });
+
+  it("does not wrap a TUI-named dir command in a terminal", async () => {
+    // `wrapInTerminal: false` is forced for directory opens, so even a
+    // vim-like command spawns directly rather than via a terminal preset.
+    setup({ config: { launchers: { editor: { dirCommand: "vim {}" } } } });
+    await getHandler(IPC.launchers.openWorkingDir)({});
+    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
+      "vim",
+      ["/tmp/wd"],
+      expect.any(Object),
+    );
+  });
+
+  it("returns an error when no kernel is active", async () => {
+    setup({ activeKernelId: null });
+    const result = await getHandler(IPC.launchers.openWorkingDir)({});
+    expect(result).toEqual({ success: false, error: expect.stringContaining("No active kernel") });
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the active kernel has no working dir", async () => {
+    setup({ activeKernelId: "ghost", workingDirs: [["k1", "/tmp/wd"]] });
+    const result = await getHandler(IPC.launchers.openWorkingDir)({});
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("No working directory"),
+    });
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
+  });
+});

--- a/electron/main/ipc-register-launchers.ts
+++ b/electron/main/ipc-register-launchers.ts
@@ -1,11 +1,14 @@
 /**
  * ipc-register-launchers.ts — IPC handlers for the action-bar launcher buttons.
  *
- * Currently registers `launchers.openAgent`, which launches the configured AI
- * agent CLI in a terminal window pointed at PDV's MCP server.
+ * Registers:
+ * - `launchers.openAgent` — launch the configured AI agent CLI in a terminal
+ *   pointed at PDV's MCP server.
+ * - `launchers.openWorkingDir` — open the active kernel's working directory in
+ *   the configured editor/IDE.
  *
  * Non-responsibilities:
- * - Building the spawn spec (see `agent-launcher.ts`).
+ * - Building the agent spawn spec (see `agent-launcher.ts`).
  * - Writing the MCP config file (see `mcp/mcp-config-writer.ts`).
  */
 
@@ -15,8 +18,29 @@ import { ipcMain } from "electron";
 
 import { buildAgentInvocation } from "./agent-launcher";
 import type { PDVConfig } from "./config";
+import { buildEditorSpawn, resolveEditorSpawn } from "./editor-spawn";
 import { IPC, type McpStatus, type ScriptOperationResult } from "./ipc";
 import { writeMcpConfigFile } from "./mcp/mcp-config-writer";
+
+/**
+ * Spawn a detached launcher process and never block on it. Errors are logged
+ * (the child outlives this process), so callers treat a successful spawn as
+ * success.
+ *
+ * @param spec - Executable and arguments to spawn.
+ * @param label - Short label used in error logs (e.g. `"agent"`).
+ */
+function spawnDetached(spec: { file: string; args: string[] }, label: string): void {
+  const child = spawn(spec.file, spec.args, { detached: true, stdio: "ignore" });
+  child.on("error", (err) => {
+    const msg =
+      err && (err as NodeJS.ErrnoException).code === "ENOENT"
+        ? `${label} launch failed: "${spec.file}" not found.`
+        : `${label} launch failed: ${err.message}`;
+    console.error(`[pdv] ${label} spawn error:`, msg);
+  });
+  child.unref();
+}
 
 /** Dependency bag for {@link registerLaunchersIpcHandlers}. */
 export interface RegisterLaunchersIpcHandlersOptions {
@@ -81,23 +105,46 @@ export function registerLaunchersIpcHandlers(
           projectRoot: getActiveProjectDir(),
           workingDir,
         });
-        const child = spawn(spawnSpec.file, spawnSpec.args, {
-          detached: true,
-          stdio: "ignore",
-        });
-        child.on("error", (err) => {
-          const msg =
-            err && (err as NodeJS.ErrnoException).code === "ENOENT"
-              ? `Agent launch failed: "${spawnSpec.file}" not found.`
-              : `Agent launch failed: ${err.message}`;
-          console.error("[pdv] agent spawn error:", msg);
-        });
-        child.unref();
+        spawnDetached(spawnSpec, "agent");
         return { success: true };
       } catch (err) {
         const error = err instanceof Error ? err.message : String(err);
         console.error("[pdv] launchers.openAgent failed:", error);
         return { success: false, error: `Failed to launch agent: ${error}` };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IPC.launchers.openWorkingDir,
+    async (): Promise<ScriptOperationResult> => {
+      if (process.env.PDV_E2E === "1") {
+        return { success: true };
+      }
+
+      const kernelId = getActiveKernelId();
+      if (!kernelId) {
+        return { success: false, error: "No active kernel; start one first." };
+      }
+      const workingDir = kernelWorkingDirs.get(kernelId);
+      if (!workingDir) {
+        return { success: false, error: "No working directory for the active kernel." };
+      }
+
+      try {
+        const config = getConfig();
+        const { file, args } = buildEditorSpawn(
+          config.launchers?.editor?.dirCommand,
+          workingDir,
+        );
+        // Opening a directory in a GUI editor/IDE never needs a terminal wrap.
+        const spawnSpec = resolveEditorSpawn(file, args, { wrapInTerminal: false });
+        spawnDetached(spawnSpec, "editor");
+        return { success: true };
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        console.error("[pdv] launchers.openWorkingDir failed:", error);
+        return { success: false, error: `Failed to open working directory: ${error}` };
       }
     },
   );

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -118,6 +118,7 @@ export const IPC = {
   /** External-app launcher channels (action-bar buttons). */
   launchers: {
     openAgent: "launchers:openAgent",
+    openWorkingDir: "launchers:openWorkingDir",
   },
   /** Markdown note channels. */
   note: {
@@ -2629,6 +2630,14 @@ export interface PDVApi {
      *   kernel is active, the MCP server is down, or the spawn fails.
      */
     openAgent(): Promise<ScriptOperationResult>;
+    /**
+     * Open the active kernel's session working directory in the configured
+     * editor/IDE (`launchers.editor.dirCommand`, default `code {}`).
+     *
+     * @returns `{ success: true }`, or `{ success: false, error }` when no
+     *   kernel is active or the spawn fails.
+     */
+    openWorkingDir(): Promise<ScriptOperationResult>;
   };
 
   /** Window chrome integration and title-bar controls. */

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -241,6 +241,7 @@ const api: PDVApi = {
   },
   launchers: {
     openAgent: () => ipcRenderer.invoke(IPC.launchers.openAgent),
+    openWorkingDir: () => ipcRenderer.invoke(IPC.launchers.openWorkingDir),
   },
   chrome: {
     getInfo: () => ipcRenderer.invoke(IPC.chrome.getInfo),

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -420,6 +420,15 @@ const App: React.FC = () => {
       });
   }, []);
 
+  const handleOpenWorkingDir = useCallback(() => {
+    void window.pdv.launchers.openWorkingDir().then((result) => {
+      if (!result.success) {
+        console.error('[pdv] failed to open working directory:', result.error);
+        window.alert(result.error ?? 'Failed to open the working directory.');
+      }
+    });
+  }, []);
+
   const handleKernelCrash = useCallback((crashedKernelId: string) => {
     if (crashedKernelId === currentKernelIdRef.current) {
       setKernelStatus('error');
@@ -1441,6 +1450,7 @@ const App: React.FC = () => {
           onActivityBarClick={handleActivityBarClick}
           onSettingsClick={() => { setSettingsInitialTab('general'); setShowSettings(true); }}
           onAgentClick={handleOpenAgent}
+          onOpenWorkingDir={handleOpenWorkingDir}
           guiModules={importedGuiModules}
           kernelId={currentKernelId}
         />

--- a/electron/renderer/src/components/ActivityBar/index.tsx
+++ b/electron/renderer/src/components/ActivityBar/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { TreeIcon, NamespaceIcon, SettingsIcon, AgentIcon } from '../Icons';
+import { TreeIcon, NamespaceIcon, SettingsIcon, AgentIcon, FolderCodeIcon } from '../Icons';
 
 type LeftPanel = 'tree' | 'namespace';
 
@@ -16,6 +16,7 @@ interface ActivityBarProps {
   onActivityBarClick: (panel: LeftPanel) => void;
   onSettingsClick: () => void;
   onAgentClick: () => void;
+  onOpenWorkingDir: () => void;
   guiModules?: { alias: string; name: string }[];
   kernelId: string | null;
 }
@@ -27,6 +28,7 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
   onActivityBarClick,
   onSettingsClick,
   onAgentClick,
+  onOpenWorkingDir,
   guiModules = [],
   kernelId,
 }) => (
@@ -68,6 +70,14 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
       )}
     </div>
     <div className="activity-bar-bottom">
+      <button
+        className="activity-btn"
+        onClick={onOpenWorkingDir}
+        disabled={!kernelId}
+        title={kernelId ? 'Open working directory in editor' : 'Start a kernel to open its working directory'}
+      >
+        <FolderCodeIcon />
+      </button>
       <button
         className="activity-btn"
         onClick={onAgentClick}

--- a/electron/renderer/src/components/Icons.tsx
+++ b/electron/renderer/src/components/Icons.tsx
@@ -79,3 +79,12 @@ export const AgentIcon: React.FC<IconProps> = (props) => (
     <circle cx="12" cy="11.5" r="1.1" fill="currentColor" stroke="none" />
   </svg>
 );
+
+/** Folder-with-code-caret icon for the "open working directory" button. */
+export const FolderCodeIcon: React.FC<IconProps> = (props) => (
+  <svg {...defaults} {...props}>
+    <path d="M3 6a1 1 0 0 1 1-1h3.5l1.5 2H16a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1z" />
+    <polyline points="8.5,10 7,11.5 8.5,13" />
+    <polyline points="11.5,10 13,11.5 11.5,13" />
+  </svg>
+);

--- a/electron/renderer/src/components/SettingsDialog/index.tsx
+++ b/electron/renderer/src/components/SettingsDialog/index.tsx
@@ -95,6 +95,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
 
   // General settings state
   const [editorFileCommand, setEditorFileCommand] = useState('code {}');
+  const [editorDirCommand, setEditorDirCommand] = useState('code {}');
   const [editorIsTuiEditor, setEditorIsTuiEditor] = useState(false);
   const [fileManagerCmd, setFileManagerCmd] = useState(DEFAULT_FILE_MANAGER);
   const [terminalPreset, setTerminalPreset] = useState<TerminalPreset>(DEFAULT_TERMINAL_PRESET);
@@ -134,6 +135,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     const editorCfg = config?.launchers?.editor;
     const fileCmd = editorCfg?.fileCommand ?? 'code {}';
     setEditorFileCommand(fileCmd);
+    setEditorDirCommand(editorCfg?.dirCommand ?? 'code {}');
     // The checkbox shows the *effective* wrap decision: an explicit saved
     // override, or PDV's basename auto-detection when the user has none.
     setEditorIsTuiEditor(editorCfg?.isTuiEditor ?? isLikelyTuiEditor(fileCmd));
@@ -347,6 +349,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
         : { preset: terminalPreset };
 
     const fileCommand = editorFileCommand.trim() || 'code {}';
+    const dirCommand = editorDirCommand.trim() || 'code {}';
     // Persist `isTuiEditor` only when it overrides PDV's auto-detection — that
     // keeps the main-process auto-detect live for the common case (a saved
     // explicit `false` for, say, `vim` would silently break terminal wrapping).
@@ -357,7 +360,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
       fileManagerCmd:  fileManagerCmd.trim()  || DEFAULT_FILE_MANAGER,
       launchers: {
         terminal: terminalLauncher,
-        editor: { fileCommand, isTuiEditor },
+        editor: { fileCommand, dirCommand, isTuiEditor },
         agent: {
           command: agentCommand.trim() || DEFAULT_AGENT_COMMAND,
           cwd: agentCwd,
@@ -454,6 +457,20 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                   like <code>vim</code>, <code>nvim</code>, <code>nano</code>.
                   Auto-detected from the command; toggle to override (e.g. for GUI
                   variants such as <code>nvim-qt</code>).
+                </div>
+
+                <label htmlFor="sg-editor-dir">Open folder command</label>
+                <input
+                  id="sg-editor-dir"
+                  type="text"
+                  value={editorDirCommand}
+                  onChange={(e) => setEditorDirCommand(e.target.value)}
+                  placeholder="code {}"
+                  spellCheck={false}
+                />
+                <div className="settings-general-desc">
+                  Used by the activity-bar button that opens the session working
+                  directory in your editor/IDE (e.g. <code>code {'{}' }</code>).
                 </div>
 
                 <label htmlFor="sg-file-manager">File manager</label>

--- a/electron/renderer/src/test-fixtures/pdv-mock.ts
+++ b/electron/renderer/src/test-fixtures/pdv-mock.ts
@@ -216,6 +216,7 @@ function buildBase() {
     },
     launchers: {
       openAgent: stub<PDVApi["launchers"]["openAgent"]>(async () => ({ success: true })),
+      openWorkingDir: stub<PDVApi["launchers"]["openWorkingDir"]>(async () => ({ success: true })),
     },
     chrome: {
       getInfo: stub<PDVApi["chrome"]["getInfo"]>(),

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -1070,6 +1070,8 @@ export interface PDVApi {
   launchers: {
     /** Launch the configured AI agent in a terminal pointed at PDV's MCP server. */
     openAgent(): Promise<{ success: boolean; error?: string }>;
+    /** Open the active kernel's working directory in the configured editor/IDE. */
+    openWorkingDir(): Promise<{ success: boolean; error?: string }>;
   };
   chrome: {
     getInfo(): Promise<WindowChromeInfo>;


### PR DESCRIPTION
## Summary

The final launcher slot (PR 4 of 4 after #294 / #295), plus a fix for an iTerm2 launch crash surfaced during smoke testing.

**Open-working-directory button**
- New `launchers.openWorkingDir` IPC channel + handler — opens the active kernel's **session working directory** in the configured editor/IDE (`launchers.editor.dirCommand`, default `code {}`), spawned with `wrapInTerminal: false` (a folder open never needs a terminal).
- Activity-bar button (folder-with-code icon), disabled when no kernel is active.
- Surfaces the `dirCommand` field as "Open folder command" in Settings → General → Editor / IDE. The config field + parser already existed (laid down in #295); this PR adds the UI and the consumer.
- Refactored the agent/editor spawn into a shared `spawnDetached` helper in `ipc-register-launchers.ts`.

**iTerm2 launch fix**
- The `iterm2` terminal preset used `create window with default profile command "…"`, which is unreliable across iTerm2 versions and crashes on a complex command string (hit when launching the agent or a TUI editor in iTerm2).
- Switched to `tell current session of (create window with default profile) to write text …` — the documented-robust pattern that types the command into the new session's shell, exactly like Terminal.app's `do script`. The same quoting that already works for Terminal.app now works for iTerm2.

## Test plan

- [x] `npm test` — 569/569 passing (new `ipc-register-launchers.test.ts` covers the dirCommand→spawn path, the `code {}` default, `wrapInTerminal:false`, and both kernel guards; iterm2 preset assertions updated).
- [x] `npm run typecheck` — clean (main + renderer).
- [x] Lint clean on touched files.
- [x] Manual smoke test (macOS): open-working-dir button opens the kernel working dir in the configured editor; Settings round-trips `dirCommand`; iTerm2 launch no longer crashes.
- n/a — does not touch `pdv-python/`, so the dependency sweep does not apply.

## Note

`title`-attribute tooltip on the new button was reported as inconsistent during testing; markup is identical to the sibling agent button (native `title`, no tooltip component) — being confirmed against dev-HMR staleness. If it persists, a follow-up will swap the activity-bar tooltips to an explicit element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)