### PR TITLE
Data-integrity batch 1: tree copy/pickle, NaN serialization, resilient load, namespace protection + renderer fixes

### DIFF
--- a/electron/renderer/src/app/useCodeCellsPersistence.test.ts
+++ b/electron/renderer/src/app/useCodeCellsPersistence.test.ts
@@ -4,9 +4,11 @@
  * useCodeCellsPersistence.test.ts — Unit tests for the debounced code-cell
  * autosave hook.
  *
- * Covers: debounce coalescing of rapid changes, no-op when kernel is null,
- * cleanup-on-unmount only flushes when the kernel was alive at unmount, and
- * cleanup is a no-op if the kernel was already null at unmount.
+ * Covers: debounce coalescing of rapid changes (regression: the effect
+ * cleanup used to fire an immediate save on every dep change, i.e. an IPC
+ * + disk write per keystroke), no-op when kernel is null, flush-on-unmount
+ * when the kernel is alive with a pending edit, and no flush when the
+ * kernel was already null at unmount.
  */
 
 import { act } from "@testing-library/react";
@@ -51,12 +53,11 @@ describe("useCodeCellsPersistence", () => {
     expect(pdv.codeCells.save).not.toHaveBeenCalled();
   });
 
-  it("flushes intermediate saves on each change and a final save after the debounce window", async () => {
-    // Note: this hook intentionally flushes on every rerender (effect cleanup
-    // cancels the pending timeout AND fires an immediate save) plus a final
-    // settle save when the timeout elapses. So rapid changes don't *coalesce*
-    // — they each get persisted right away. The debounce only matters as the
-    // tail timer for the last change.
+  it("coalesces rapid changes into a single save with the latest content", async () => {
+    // Regression: the cleanup used to fire an immediate save on every dep
+    // change, so typing produced one IPC + disk write per keystroke with
+    // one-keystroke-stale content. Rapid edits must coalesce into exactly
+    // one save after the debounce window, carrying the newest tabs.
     const { rerender, pdv } = renderHookWithPdv<void, Props>(
       (p) => useCodeCellsPersistence(p),
       {
@@ -79,23 +80,27 @@ describe("useCodeCellsPersistence", () => {
       currentKernelId: "k1",
     });
 
-    // Each rerender triggers cleanup-then-effect, and cleanup flushes when
-    // the kernel is still alive. So we already have ≥1 save by here.
-    const callsBeforeAdvance = (pdv.codeCells.save as ReturnType<typeof vi.fn>).mock
-      .calls.length;
-    expect(callsBeforeAdvance).toBeGreaterThan(0);
+    // Nothing has been written yet — the debounce is still pending.
+    expect(pdv.codeCells.save).not.toHaveBeenCalled();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(CODE_CELL_SAVE_DEBOUNCE_MS);
     });
 
-    // The final settle save fires with the latest tabs.
+    // Exactly one save, with the latest tabs.
+    expect(pdv.codeCells.save).toHaveBeenCalledTimes(1);
     expect(pdv.codeCells.save).toHaveBeenLastCalledWith(
       expect.objectContaining({
         tabs: [{ id: 1, code: "print(3)" }],
         activeTabId: 1,
       }),
     );
+
+    // And the debounce stays quiet afterwards — no trailing writes.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CODE_CELL_SAVE_DEBOUNCE_MS * 3);
+    });
+    expect(pdv.codeCells.save).toHaveBeenCalledTimes(1);
   });
 
   it("on unmount, flushes the pending save when the kernel is still alive", () => {

--- a/electron/renderer/src/app/useCodeCellsPersistence.ts
+++ b/electron/renderer/src/app/useCodeCellsPersistence.ts
@@ -26,11 +26,19 @@ export function useCodeCellsPersistence({
   currentKernelId,
 }: UseCodeCellsPersistenceOptions): void {
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const hasKernelRef = useRef(currentKernelId);
+  // True while an edit is scheduled but not yet written. Lets the
+  // kernel-change/unmount flush below know whether there is anything to
+  // persist without re-running on every keystroke.
+  const pendingRef = useRef(false);
+  const latestRef = useRef({ cellTabs, activeCellTab });
   useEffect(() => {
-    hasKernelRef.current = currentKernelId;
+    latestRef.current = { cellTabs, activeCellTab };
   });
 
+  // Debounced save. The cleanup ONLY cancels the pending timer — it must
+  // not write. `cellTabs` changes on every keystroke, so a cleanup that
+  // saves (as this hook once did) degrades into an IPC + disk write per
+  // keystroke with one-keystroke-stale content.
   useEffect(() => {
     if (!window.pdv?.codeCells || !currentKernelId) {
       return;
@@ -38,8 +46,10 @@ export function useCodeCellsPersistence({
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
     }
-
+    pendingRef.current = true;
     saveTimeoutRef.current = setTimeout(async () => {
+      saveTimeoutRef.current = null;
+      pendingRef.current = false;
       try {
         await window.pdv.codeCells.save({
           tabs: cellTabs,
@@ -53,13 +63,28 @@ export function useCodeCellsPersistence({
     return () => {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
-        if (hasKernelRef.current) {
-          void window.pdv.codeCells.save({
-            tabs: cellTabs,
-            activeTabId: activeCellTab,
-          });
-        }
+        saveTimeoutRef.current = null;
       }
     };
   }, [activeCellTab, cellTabs, currentKernelId]);
+
+  // Flush on true unmount or kernel change only. Keyed on the kernel id
+  // alone, so it does NOT re-run per edit; it reads the newest tab state
+  // from `latestRef`. This cleanup runs after the debounce cleanup above
+  // (declaration order), which has already cancelled the timer but left
+  // `pendingRef` set.
+  useEffect(() => {
+    if (!window.pdv?.codeCells || !currentKernelId) {
+      return;
+    }
+    return () => {
+      if (pendingRef.current) {
+        pendingRef.current = false;
+        void window.pdv.codeCells.save({
+          tabs: latestRef.current.cellTabs,
+          activeTabId: latestRef.current.activeCellTab,
+        });
+      }
+    };
+  }, [currentKernelId]);
 }

--- a/electron/renderer/src/components/ModuleGui/NamelistEditor.tsx
+++ b/electron/renderer/src/components/ModuleGui/NamelistEditor.tsx
@@ -216,7 +216,7 @@ interface NamelistFieldProps {
   onChange: (value: unknown) => void;
 }
 
-const NamelistField: React.FC<NamelistFieldProps> = ({
+export const NamelistField: React.FC<NamelistFieldProps> = ({
   value,
   typeHint,
   onChange,
@@ -256,25 +256,7 @@ const NamelistField: React.FC<NamelistFieldProps> = ({
   }
 
   if (typeHint === "array") {
-    const arr = Array.isArray(value) ? value : [];
-    const text = arr.join(", ");
-    return (
-      <input
-        type="text"
-        value={text}
-        onChange={(e) => {
-          const parts = e.target.value
-            .split(",")
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0)
-            .map((s) => {
-              const n = Number(s);
-              return Number.isNaN(n) ? s : n;
-            });
-          onChange(parts);
-        }}
-      />
-    );
+    return <NamelistArrayField value={value} onChange={onChange} />;
   }
 
   // Default: string
@@ -283,6 +265,46 @@ const NamelistField: React.FC<NamelistFieldProps> = ({
       type="text"
       value={value === null || value === undefined ? "" : String(value)}
       onChange={(e) => onChange(e.target.value)}
+    />
+  );
+};
+
+/**
+ * Array field with a local draft while editing.
+ *
+ * The displayed text must NOT be re-derived from the parsed array on
+ * every keystroke — parse-and-rejoin consumes the comma the user just
+ * typed (and any partial entry), making arrays effectively uneditable.
+ * Instead the raw string is held in local state while the field is being
+ * edited and parsed once on blur, mirroring the numeric branch above.
+ */
+const NamelistArrayField: React.FC<{
+  value: unknown;
+  onChange: (value: unknown) => void;
+}> = ({ value, onChange }) => {
+  const arr = Array.isArray(value) ? value : [];
+  const joined = arr.join(", ");
+  // null = not editing; display follows the committed value.
+  const [draft, setDraft] = useState<string | null>(null);
+
+  return (
+    <input
+      type="text"
+      value={draft ?? joined}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => {
+        if (draft === null) return;
+        const parts = draft
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+          .map((s) => {
+            const n = Number(s);
+            return Number.isNaN(n) ? s : n;
+          });
+        onChange(parts);
+        setDraft(null);
+      }}
     />
   );
 };

--- a/electron/renderer/src/components/ModuleGui/NamelistField.test.tsx
+++ b/electron/renderer/src/components/ModuleGui/NamelistField.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+/**
+ * NamelistField.test.tsx — Renderer tests for the typed namelist fields.
+ *
+ * Regression coverage for the array field: the displayed text used to be
+ * re-derived from the parsed array on every keystroke (split → trim →
+ * rejoin), which consumed the comma the user just typed and made arrays
+ * effectively uneditable. The field must hold a raw draft while focused
+ * and commit the parsed array on blur — like the numeric field already
+ * does.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NamelistField } from "./NamelistEditor";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("NamelistField (array)", () => {
+  it("keeps typed commas and partial entries while editing (regression)", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<NamelistField value={[]} typeHint="array" onChange={onChange} />);
+    const input = screen.getByRole<HTMLInputElement>("textbox");
+
+    await user.click(input);
+    await user.keyboard("1, 2,");
+    // The raw text — including the trailing comma — must survive.
+    expect(input.value).toBe("1, 2,");
+    // Nothing committed yet.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("commits the parsed array on blur (numbers stay numeric)", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<NamelistField value={[]} typeHint="array" onChange={onChange} />);
+    const input = screen.getByRole<HTMLInputElement>("textbox");
+
+    await user.click(input);
+    await user.keyboard("1, 2.5, abc");
+    fireEvent.blur(input);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith([1, 2.5, "abc"]);
+  });
+
+  it("displays the committed value when not editing", () => {
+    render(
+      <NamelistField value={[1, 2, 3]} typeHint="array" onChange={vi.fn()} />
+    );
+    const input = screen.getByRole<HTMLInputElement>("textbox");
+    expect(input.value).toBe("1, 2, 3");
+  });
+
+  it("blur without edits does not fire onChange", () => {
+    const onChange = vi.fn();
+    render(
+      <NamelistField value={[1, 2]} typeHint="array" onChange={onChange} />
+    );
+    fireEvent.blur(screen.getByRole("textbox"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/electron/renderer/src/gui-editor/LayoutCanvas.tsx
+++ b/electron/renderer/src/gui-editor/LayoutCanvas.tsx
@@ -152,6 +152,9 @@ function CanvasNode({ node, path, onDrop }: CanvasNodeProps) {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // The root container is not deletable — same rule as the delete
+    // button, which is hidden for the root row.
+    if (isRoot) return;
     if (e.key === "Delete" || e.key === "Backspace") {
       e.preventDefault();
       dispatch({ type: "DELETE_NODE", path });

--- a/electron/renderer/src/gui-editor/editor-state.test.ts
+++ b/electron/renderer/src/gui-editor/editor-state.test.ts
@@ -1,0 +1,150 @@
+/**
+ * editor-state.test.ts — Unit tests for the GUI editor reducer.
+ *
+ * Regression coverage for two data-loss bugs:
+ *
+ * - DELETE_NODE with the root path ("") used to strip every input/action
+ *   descriptor from the manifest while leaving the layout untouched — a
+ *   one-keypress corruption (the root row's keyhandler dispatched it).
+ * - MOVE_NODE had no "target inside the dragged subtree" guard, so
+ *   dropping a container into its own descendant threw inside the
+ *   reducer or corrupted the layout.
+ */
+
+import { describe, it, expect } from "vitest";
+import { editorReducer, getNodeAtPath, type EditorState } from "./editor-state";
+import type {
+  GuiManifestV1,
+  LayoutContainer,
+} from "../types/pdv.d";
+
+/**
+ * Build a small but realistic editor state:
+ *
+ * root (column)
+ * ├── 0: group "A"
+ * │   ├── 0.0: input ref "x"
+ * │   └── 0.1: group "B" (empty)
+ * └── 1: action ref "go"
+ */
+function makeState(): EditorState {
+  const layout: LayoutContainer = {
+    type: "column",
+    children: [
+      {
+        type: "group",
+        label: "A",
+        children: [
+          { type: "input", id: "x" } as never,
+          { type: "group", label: "B", children: [] },
+        ],
+      },
+      { type: "action", id: "go" } as never,
+    ],
+  };
+  const manifest: GuiManifestV1 = {
+    has_gui: true,
+    gui: { layout },
+    inputs: [{ id: "x", label: "X value" }],
+    actions: [{ id: "go", label: "Run", script_path: "scripts.run" }],
+  };
+  return {
+    manifest,
+    selectedNodePath: null,
+    dirty: false,
+    treePath: "mod.gui",
+    kernelId: "k1",
+  };
+}
+
+describe("DELETE_NODE", () => {
+  it("root path is a no-op (regression: used to strip all inputs/actions)", () => {
+    const state = makeState();
+    const next = editorReducer(state, { type: "DELETE_NODE", path: "" });
+    expect(next.manifest.inputs).toHaveLength(1);
+    expect(next.manifest.actions).toHaveLength(1);
+    expect(next.manifest.gui?.layout.children).toHaveLength(2);
+    expect(next.dirty).toBe(false);
+  });
+
+  it("deleting a subtree removes its descriptors and layout node", () => {
+    const state = makeState();
+    const next = editorReducer(state, { type: "DELETE_NODE", path: "0" });
+    // Group "A" and the input inside it are gone; the action survives.
+    expect(next.manifest.gui?.layout.children).toHaveLength(1);
+    expect(next.manifest.inputs).toHaveLength(0);
+    expect(next.manifest.actions).toHaveLength(1);
+    expect(next.dirty).toBe(true);
+  });
+});
+
+describe("MOVE_NODE", () => {
+  it("rejects moving a container into its own descendant (regression)", () => {
+    const state = makeState();
+    // Drag group "A" (path 0) into its own child group "B" (path 0.1).
+    const next = editorReducer(state, {
+      type: "MOVE_NODE",
+      fromPath: "0",
+      toParentPath: "0.1",
+      toIndex: 0,
+    });
+    // Must be rejected outright: layout unchanged, nothing lost.
+    expect(next.manifest.gui?.layout.children).toHaveLength(2);
+    expect(getNodeAtPath(next.manifest.gui!.layout, "0.0")).toMatchObject({
+      type: "input",
+      id: "x",
+    });
+    expect(getNodeAtPath(next.manifest.gui!.layout, "0.1")).toMatchObject({
+      type: "group",
+      label: "B",
+    });
+    expect(next.dirty).toBe(false);
+  });
+
+  it("rejects moving a container onto itself", () => {
+    const state = makeState();
+    const next = editorReducer(state, {
+      type: "MOVE_NODE",
+      fromPath: "0",
+      toParentPath: "0",
+      toIndex: 0,
+    });
+    expect(next.manifest.gui?.layout.children).toHaveLength(2);
+    expect(getNodeAtPath(next.manifest.gui!.layout, "0.1")).toMatchObject({
+      type: "group",
+      label: "B",
+    });
+  });
+
+  it("does not confuse sibling prefixes (moving node 0 into node 0.1 vs 0.10)", () => {
+    // Guard must compare path segments, not string prefixes: "0" is an
+    // ancestor of "0.1" but NOT of "01"/"1".
+    const state = makeState();
+    // Legit move: group "A" (0) into root at index 2 (after the action).
+    const next = editorReducer(state, {
+      type: "MOVE_NODE",
+      fromPath: "0",
+      toParentPath: "",
+      toIndex: 2,
+    });
+    const children = next.manifest.gui!.layout.children;
+    expect(children).toHaveLength(2);
+    expect(children[0]).toMatchObject({ type: "action", id: "go" });
+    expect(children[1]).toMatchObject({ type: "group", label: "A" });
+    expect(next.dirty).toBe(true);
+  });
+
+  it("still allows moving a leaf out of a container", () => {
+    const state = makeState();
+    // Move input "x" (0.0) to the root at index 0.
+    const next = editorReducer(state, {
+      type: "MOVE_NODE",
+      fromPath: "0.0",
+      toParentPath: "",
+      toIndex: 0,
+    });
+    const children = next.manifest.gui!.layout.children;
+    expect(children).toHaveLength(3);
+    expect(children[0]).toMatchObject({ type: "input", id: "x" });
+  });
+});

--- a/electron/renderer/src/gui-editor/editor-state.ts
+++ b/electron/renderer/src/gui-editor/editor-state.ts
@@ -249,6 +249,18 @@ export function editorReducer(state: EditorState, action: EditorAction): EditorS
     case "MOVE_NODE": {
       const layout = state.manifest.gui?.layout;
       if (!layout) return state;
+      // Reject moves into the dragged subtree (or onto the node itself):
+      // removing the source first would also remove the destination, so
+      // the insert either throws or silently drops the whole subtree.
+      // Compare parsed index segments, not string prefixes.
+      const fromIndices = parsePath(action.fromPath);
+      const toParentIndices = parsePath(action.toParentPath);
+      if (
+        fromIndices.length <= toParentIndices.length &&
+        fromIndices.every((v, i) => v === toParentIndices[i])
+      ) {
+        return state;
+      }
       const [afterRemove, removed] = removeNode(layout, action.fromPath);
       if (!removed) return state;
       const adjusted = adjustPathAfterRemoval(action.toParentPath, action.toIndex, action.fromPath);
@@ -264,6 +276,10 @@ export function editorReducer(state: EditorState, action: EditorAction): EditorS
     case "DELETE_NODE": {
       const layout = state.manifest.gui?.layout;
       if (!layout) return state;
+      // The root container is not deletable. Without this guard, the
+      // empty path collects every input/action ID from the root (wiping
+      // all descriptors) while removeNode leaves the layout untouched.
+      if (!action.path) return state;
 
       // Collect all input/action IDs in the subtree before removing
       const nodeToDelete = getNodeAtPath(layout, action.path);

--- a/electron/renderer/src/module-window/ModuleWindowRoot.tsx
+++ b/electron/renderer/src/module-window/ModuleWindowRoot.tsx
@@ -51,7 +51,10 @@ export const ModuleWindowRoot: React.FC = () => {
       try {
         const ctx = await window.pdv.moduleWindows.context();
         if (cancelled || !ctx) {
-          if (!cancelled) setError("No module context available.");
+          if (!cancelled) {
+            setError("No module context available.");
+            setLoading(false);
+          }
           return;
         }
         setContext(ctx);
@@ -59,7 +62,10 @@ export const ModuleWindowRoot: React.FC = () => {
         const importedModules = await window.pdv.modules.listImported();
         const mod = importedModules.find((m) => m.alias === ctx.alias);
         if (!mod) {
-          setError(`Module not found: ${ctx.alias}`);
+          if (!cancelled) {
+            setError(`Module not found: ${ctx.alias}`);
+            setLoading(false);
+          }
           return;
         }
 
@@ -348,18 +354,20 @@ export const ModuleWindowRoot: React.FC = () => {
 
   const handleSetError = useCallback((msg: string) => setError(msg), []);
 
-  if (loading) {
-    return (
-      <div className="module-window-root" style={{ padding: 16 }}>
-        <div style={{ color: "var(--text-secondary)" }}>Loading module...</div>
-      </div>
-    );
-  }
-
+  // Error wins over the loading placeholder: an early failure that never
+  // cleared `loading` must show the message, not spin forever.
   if (error && !descriptor) {
     return (
       <div className="module-window-root" style={{ padding: 16 }}>
         <div style={{ color: "var(--error)" }}>{error}</div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="module-window-root" style={{ padding: 16 }}>
+        <div style={{ color: "var(--text-secondary)" }}>Loading module...</div>
       </div>
     );
   }

--- a/pdv-python/pdv/handlers/project.py
+++ b/pdv-python/pdv/handlers/project.py
@@ -633,6 +633,7 @@ def handle_project_load(msg: dict) -> None:
     """
     import json
     import os
+    import sys
 
     from pdv.comms import get_pdv_tree, send_error, send_message  # noqa: PLC0415
 
@@ -719,7 +720,7 @@ def handle_project_load(msg: dict) -> None:
         before Pass 2 deserializes data nodes."""
         _early_module_setup(nodes, save_dir, working_dir)
 
-    load_tree_index(
+    skipped_nodes = load_tree_index(
         tree,
         nodes,
         on_progress=_emit_load_progress,
@@ -727,6 +728,13 @@ def handle_project_load(msg: dict) -> None:
         working_dir=working_dir,
         between_passes=_setup_modules_before_leaves,
     )
+    if skipped_nodes:
+        print(
+            f"[pdv] project load: skipped {len(skipped_nodes)} unloadable "
+            f"node(s): "
+            + ", ".join(f"{s['path']} ({s['error']})" for s in skipped_nodes),
+            file=sys.stderr,
+        )
 
     os.chdir(os.path.expanduser("~"))
     node_count = len(nodes)
@@ -737,7 +745,11 @@ def handle_project_load(msg: dict) -> None:
 
     send_message(
         "pdv.project.load.response",
-        {"node_count": node_count, "post_load_checksum": post_load_checksum},
+        {
+            "node_count": node_count,
+            "post_load_checksum": post_load_checksum,
+            "skipped_nodes": skipped_nodes,
+        },
         in_reply_to=msg_id,
     )
     # Send pdv.project.loaded push notification (no in_reply_to)
@@ -822,7 +834,10 @@ def serialize_tree_to_dir(
             "autosave_cache_hits": autosave_hits[0],
         }
 
-    index_data = json.dumps(nodes, indent=2, default=str)
+    # allow_nan=False: a bare NaN/Infinity token would be invalid JSON and
+    # make the app's JSON.parse reject the whole index at load time —
+    # better to fail the save loudly than write a corrupt file.
+    index_data = json.dumps(nodes, indent=2, default=str, allow_nan=False)
     index_path = os.path.join(save_dir, "tree-index.json")
     tmp_path = index_path + ".tmp"
     with open(tmp_path, "w", encoding="utf-8") as fh:

--- a/pdv-python/pdv/namespace.py
+++ b/pdv-python/pdv/namespace.py
@@ -78,6 +78,79 @@ class PDVNamespace(dict):
             )
         super().__delitem__(key)
 
+    def update(self, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
+        """Merge key/value pairs, blocking reassignment of protected names.
+
+        Raises
+        ------
+        PDVProtectedNameError
+            If any incoming key is in :data:`_PROTECTED_NAMES`. No keys are
+            merged in that case (all-or-nothing).
+        """
+        incoming = dict(*args, **kwargs)
+        for key in incoming:
+            if key in _PROTECTED_NAMES:
+                raise PDVProtectedNameError(
+                    f"'{key}' is a protected PDV object and cannot be reassigned. "
+                    "Use pdv_tree['key'] = value to store data in the tree."
+                )
+        super().update(incoming)
+
+    def pop(self, key: str, *args: Any) -> Any:
+        """Remove and return *key*, blocking removal of protected names.
+
+        Raises
+        ------
+        PDVProtectedNameError
+            If ``key`` is in :data:`_PROTECTED_NAMES`.
+        """
+        if key in _PROTECTED_NAMES:
+            raise PDVProtectedNameError(
+                f"'{key}' is a protected PDV object and cannot be removed."
+            )
+        return super().pop(key, *args)
+
+    def popitem(self) -> tuple[str, Any]:
+        """Remove and return an arbitrary item, never a protected one.
+
+        Raises
+        ------
+        KeyError
+            If no non-protected items remain.
+        """
+        for key in reversed(list(self.keys())):
+            if key not in _PROTECTED_NAMES:
+                return key, super().pop(key)
+        raise KeyError("popitem(): no removable (non-protected) items")
+
+    def setdefault(self, key: str, default: Any = None) -> Any:
+        """Get *key* if present, otherwise set it to *default*.
+
+        Raises
+        ------
+        PDVProtectedNameError
+            If ``key`` is a protected name that is not already present
+            (assigning it is not allowed). Reading an existing protected
+            name is fine.
+        """
+        if key in _PROTECTED_NAMES and key not in self:
+            raise PDVProtectedNameError(
+                f"'{key}' is a protected PDV object and cannot be assigned."
+            )
+        return super().setdefault(key, default)
+
+    def clear(self) -> None:
+        """Remove all names EXCEPT protected ones.
+
+        IPython's ``%reset`` calls ``user_ns.clear()`` — without this
+        override it would silently wipe ``pdv_tree`` out of the namespace.
+        Preserving (rather than raising) keeps ``%reset`` working for
+        everything else.
+        """
+        preserved = {k: self[k] for k in self if k in _PROTECTED_NAMES}
+        super().clear()
+        super().update(preserved)
+
 
 def pdv_namespace(
     ns: dict,

--- a/pdv-python/pdv/serialization.py
+++ b/pdv-python/pdv/serialization.py
@@ -33,6 +33,7 @@ ARCHITECTURE.md §7.2 (node types), §7.3 (node descriptor)
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from pdv.errors import PDVSerializationError
@@ -94,8 +95,13 @@ def _can_inline_json(value: Any) -> bool:
     """
     if value is None or isinstance(value, (str, bool)):
         return True
-    if isinstance(value, (int, float)) and not isinstance(value, complex):
+    if isinstance(value, int):
         return True
+    if isinstance(value, float):
+        # NaN/inf serialize as bare ``NaN``/``Infinity`` tokens, which are
+        # invalid JSON — JSON.parse on the app side would reject the whole
+        # tree-index.json. Route non-finite floats to the pickle path.
+        return math.isfinite(value)
     if isinstance(value, list):
         return all(_can_inline_json(v) for v in value)
     if isinstance(value, dict):
@@ -710,9 +716,14 @@ def serialize_node(
         return descriptor
 
     if kind == KIND_SCALAR:
-        if isinstance(value, complex):
+        if isinstance(value, complex) or (
+            isinstance(value, float) and not math.isfinite(value)
+        ):
             # complex isn't JSON-native, so the inline path can't store it.
-            # Pickle it like other non-JSON-native values.
+            # NaN/inf floats are JSON-native to json.dumps but serialize as
+            # bare NaN/Infinity tokens — invalid JSON that the app's
+            # JSON.parse rejects, corrupting tree-index.json.
+            # Pickle both like other non-JSON-native values.
             node_uuid = generate_node_uuid()
             filename = key + ".pickle"
             file_path = uuid_tree_path(working_dir, node_uuid, filename)

--- a/pdv-python/pdv/tree.py
+++ b/pdv-python/pdv/tree.py
@@ -855,7 +855,7 @@ class PDVTree(dict):
     _global_lock: threading.Lock = threading.Lock()
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__()
         self._working_dir: str | None = None
         self._save_dir: str | None = None
         # Absolute path to the uv binary, provided by the app at pdv.init for
@@ -865,6 +865,17 @@ class PDVTree(dict):
         self._pending_changes: list[tuple[str, str]] = []
         self._debounce_timer: threading.Timer | None = None
         self._debounce_lock = threading.Lock()
+        # Route initial data through set_quiet so dotted keys expand into
+        # nested nodes and non-string keys are rejected — otherwise
+        # ``PDVTree({'a.b': 1})`` would store a literal ``'a.b'`` key that
+        # ``__getitem__('a.b')`` can never retrieve.
+        if args or kwargs:
+            for key, value in dict(*args, **kwargs).items():
+                if not isinstance(key, str):
+                    raise PDVPathError(
+                        f"Tree keys must be strings, got {type(key).__name__}: {key!r}"
+                    )
+                self.set_quiet(key, value)
 
     # ------------------------------------------------------------------
     # Internal state management (not user-facing)
@@ -1024,6 +1035,37 @@ class PDVTree(dict):
     # dict overrides
     # ------------------------------------------------------------------
 
+    def __getstate__(self) -> dict:
+        """Return picklable instance state, dropping runtime-only attributes.
+
+        The debounce lock/timer and the comm send-fn are not picklable and
+        are rebuilt on unpickle (see :meth:`__setstate__`). Because
+        ``copy.deepcopy`` uses the same ``__reduce_ex__`` machinery, this
+        also makes deepcopy work — without it, both raise
+        ``TypeError: cannot pickle '_thread.lock' object``. Subclass
+        attributes (``PDVModule._module_id``, etc.) survive because they
+        live in ``__dict__``.
+        """
+        state = self.__dict__.copy()
+        state.pop("_debounce_lock", None)
+        state.pop("_debounce_timer", None)
+        state.pop("_send_fn", None)
+        state["_pending_changes"] = []
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore instance state, rebuilding runtime-only attributes.
+
+        The restored tree is intentionally *detached*: ``_send_fn`` is None,
+        so it emits no notifications until inserted into the root tree.
+        """
+        self.__dict__.update(state)
+        self._debounce_lock = threading.Lock()
+        self._debounce_timer = None
+        self._send_fn = None
+        if "_pending_changes" not in self.__dict__:
+            self._pending_changes = []
+
     def __getitem__(self, key: str) -> Any:
         """Get a value by key or dot-separated path.
 
@@ -1055,6 +1097,35 @@ class PDVTree(dict):
             return _resolve_nested(self, parts)
         except KeyError:
             raise PDVKeyError(key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get a value by key or dot-path, returning *default* if absent.
+
+        Unlike ``dict.get``, this resolves dot-separated paths the same way
+        ``__getitem__``/``__contains__`` do, so ``tree.get('a.b')`` and
+        ``tree['a.b']`` agree instead of ``get`` silently returning the
+        default for any dotted path.
+        """
+        try:
+            return self[key]
+        except PDVKeyError:
+            return default
+
+    def copy(self) -> "PDVTree":
+        """Return a shallow copy that preserves the node's actual type.
+
+        Unlike ``dict.copy`` (which returns a plain ``dict``, silently
+        dropping the PDVTree type, working/save dirs, and any subclass
+        attributes), this rebuilds the same class with the same instance
+        state. The copy is *detached* — no comm attached — so mutating it
+        emits no notifications until it is inserted into the root tree.
+        Values are shared (shallow), matching ``dict.copy`` semantics.
+        """
+        new = type(self).__new__(type(self))
+        new.__setstate__(self.__getstate__())
+        for k in dict.keys(self):
+            dict.__setitem__(new, k, dict.__getitem__(self, k))
+        return new
 
     def set_quiet(self, key: str, value: Any) -> None:
         """Set a value at a dot-path without emitting notifications.

--- a/pdv-python/pdv/tree_loader.py
+++ b/pdv-python/pdv/tree_loader.py
@@ -67,8 +67,13 @@ def load_tree_index(
     module_id_default: str = "",
     working_dir: str = "",
     between_passes: Callable[[], None] | None = None,
-) -> None:
+) -> list[dict]:
     """Mount a tree-index node list into ``tree`` using the two-pass algorithm.
+
+    A node that fails to mount (missing/corrupt backing file, bad
+    metadata) is skipped and reported rather than aborting the whole
+    load — mirroring save's "never fail on a single node" policy. All
+    other nodes still load.
 
     Parameters
     ----------
@@ -105,6 +110,13 @@ def load_tree_index(
         (leaves) begins. Used by project load to import module entry
         points — which may register custom serializers — so that
         custom-format data nodes can be deserialized in Pass 2.
+
+    Returns
+    -------
+    list[dict]
+        One ``{"path": <full tree path>, "error": <repr of the failure>}``
+        entry per node that could not be mounted. Empty when every node
+        loaded cleanly.
     """
     # Local imports to avoid circular dependencies — tree.py imports nothing
     # from this module, so importing tree.py here is safe.
@@ -132,6 +144,8 @@ def load_tree_index(
         except (KeyError, TypeError):
             return False, None
 
+    skipped: list[dict] = []
+
     # ── Pass 1: containers ───────────────────────────────────────────────
     for node in nodes:
         node_path_rel = node.get("path", "")
@@ -146,31 +160,34 @@ def load_tree_index(
             if exists:
                 continue
 
-        if node_type == "folder":
-            folder = PDVTree()
-            folder._working_dir = tree._working_dir
-            folder._save_dir = tree._save_dir
-            tree.set_quiet(full_path, folder)
-        elif node_type == "mapping" and meta.get("composite"):
-            # Composite mapping: the user assigned a plain dict containing
-            # non-JSON-native leaves (e.g. ndarrays). Reconstruct as a plain
-            # dict — NOT a PDVTree — so type(value) is dict on load, matching
-            # what the user originally stored. Children are populated in
-            # Pass 2 via set_quiet, which traverses through plain dicts.
-            tree.set_quiet(full_path, {})
-        elif node_type == "module":
-            storage = node.get("storage", {})
-            old_meta = storage.get("value", {})
-            mod = PDVModule(
-                module_id=meta.get(
-                    "module_id", old_meta.get("module_id", module_id_default)
-                ),
-                name=meta.get("name", old_meta.get("name", "")),
-                version=meta.get("version", old_meta.get("version", "")),
-            )
-            mod._working_dir = tree._working_dir
-            mod._save_dir = tree._save_dir
-            tree.set_quiet(full_path, mod)
+        try:
+            if node_type == "folder":
+                folder = PDVTree()
+                folder._working_dir = tree._working_dir
+                folder._save_dir = tree._save_dir
+                tree.set_quiet(full_path, folder)
+            elif node_type == "mapping" and meta.get("composite"):
+                # Composite mapping: the user assigned a plain dict containing
+                # non-JSON-native leaves (e.g. ndarrays). Reconstruct as a plain
+                # dict — NOT a PDVTree — so type(value) is dict on load, matching
+                # what the user originally stored. Children are populated in
+                # Pass 2 via set_quiet, which traverses through plain dicts.
+                tree.set_quiet(full_path, {})
+            elif node_type == "module":
+                storage = node.get("storage", {})
+                old_meta = storage.get("value", {})
+                mod = PDVModule(
+                    module_id=meta.get(
+                        "module_id", old_meta.get("module_id", module_id_default)
+                    ),
+                    name=meta.get("name", old_meta.get("name", "")),
+                    version=meta.get("version", old_meta.get("version", "")),
+                )
+                mod._working_dir = tree._working_dir
+                mod._save_dir = tree._save_dir
+                tree.set_quiet(full_path, mod)
+        except Exception as exc:  # noqa: BLE001 — one bad container must not abort the load
+            skipped.append({"path": full_path, "error": repr(exc)})
 
     if between_passes is not None:
         between_passes()
@@ -220,6 +237,9 @@ def load_tree_index(
                 f"Skipping node '{node_path_rel}' with unsafe UUID: {node_uuid!r}",
                 stacklevel=2,
             )
+            skipped.append(
+                {"path": full_path, "error": f"unsafe UUID: {node_uuid!r}"}
+            )
             if on_progress is not None:
                 on_progress(index, total)
             continue
@@ -229,95 +249,106 @@ def load_tree_index(
         # save/load cycles. See ARCHITECTURE.md §5.13.
         src_rel = node.get("source_rel_path")
 
-        if node_type == "script":
-            language = meta.get("language", node.get("language", "python"))
-            doc = meta.get("doc")
-            mod_id = meta.get("module_id", module_id_default)
-            tree.set_quiet(
-                full_path,
-                PDVScript(
-                    uuid=node_uuid,
-                    filename=node_filename,
-                    language=language,
-                    doc=doc,
-                    module_id=mod_id,
-                    source_rel_path=src_rel,
-                ),
-            )
-        elif node_type == "markdown":
-            title = meta.get("title")
-            tree.set_quiet(
-                full_path,
-                PDVNote(
-                    uuid=node_uuid,
-                    filename=node_filename,
-                    title=title,
-                ),
-            )
-        elif node_type == "gui":
-            mod_id = meta.get("module_id", node.get("module_id", module_id_default))
-            gui_node = PDVGui(
-                uuid=node_uuid,
-                filename=node_filename,
-                module_id=mod_id,
-                source_rel_path=src_rel,
-            )
-            tree.set_quiet(full_path, gui_node)
-            # Attach gui reference to parent PDVModule if applicable.
-            parts = full_path.split(".")
-            if len(parts) > 1:
-                parent_path = ".".join(parts[:-1])
-                try:
-                    parent = tree[parent_path]
-                    if isinstance(parent, PDVModule):
-                        parent.gui = gui_node
-                except (KeyError, AttributeError):
-                    pass
-        elif node_type == "namelist":
-            mod_id = meta.get("module_id", node.get("module_id", module_id_default))
-            namelist_format = meta.get(
-                "namelist_format", node.get("namelist_format", "auto")
-            )
-            tree.set_quiet(
-                full_path,
-                PDVNamelist(
-                    uuid=node_uuid,
-                    filename=node_filename,
-                    format=namelist_format,
-                    module_id=mod_id,
-                    source_rel_path=src_rel,
-                ),
-            )
-        elif node_type == "lib":
-            mod_id = meta.get("module_id", node.get("module_id", module_id_default))
-            tree.set_quiet(
-                full_path,
-                PDVLib(
+        try:
+            if node_type == "script":
+                language = meta.get("language", node.get("language", "python"))
+                doc = meta.get("doc")
+                mod_id = meta.get("module_id", module_id_default)
+                tree.set_quiet(
+                    full_path,
+                    PDVScript(
+                        uuid=node_uuid,
+                        filename=node_filename,
+                        language=language,
+                        doc=doc,
+                        module_id=mod_id,
+                        source_rel_path=src_rel,
+                    ),
+                )
+            elif node_type == "markdown":
+                title = meta.get("title")
+                tree.set_quiet(
+                    full_path,
+                    PDVNote(
+                        uuid=node_uuid,
+                        filename=node_filename,
+                        title=title,
+                    ),
+                )
+            elif node_type == "gui":
+                mod_id = meta.get(
+                    "module_id", node.get("module_id", module_id_default)
+                )
+                gui_node = PDVGui(
                     uuid=node_uuid,
                     filename=node_filename,
                     module_id=mod_id,
                     source_rel_path=src_rel,
-                ),
-            )
-        elif node_type == "file":
-            tree.set_quiet(
-                full_path,
-                PDVFile(
-                    uuid=node_uuid,
-                    filename=node_filename,
-                    source_rel_path=src_rel,
-                ),
-            )
-        elif backend == "inline":
-            tree.set_quiet(full_path, storage.get("value"))
-        elif backend == "local_file":
-            value = deserialize_node(
-                storage,
-                working_dir,
-                trusted=True,
-                python_type=meta.get("python_type", ""),
-            )
-            tree.set_quiet(full_path, value)
+                )
+                tree.set_quiet(full_path, gui_node)
+                # Attach gui reference to parent PDVModule if applicable.
+                parts = full_path.split(".")
+                if len(parts) > 1:
+                    parent_path = ".".join(parts[:-1])
+                    try:
+                        parent = tree[parent_path]
+                        if isinstance(parent, PDVModule):
+                            parent.gui = gui_node
+                    except (KeyError, AttributeError):
+                        pass
+            elif node_type == "namelist":
+                mod_id = meta.get(
+                    "module_id", node.get("module_id", module_id_default)
+                )
+                namelist_format = meta.get(
+                    "namelist_format", node.get("namelist_format", "auto")
+                )
+                tree.set_quiet(
+                    full_path,
+                    PDVNamelist(
+                        uuid=node_uuid,
+                        filename=node_filename,
+                        format=namelist_format,
+                        module_id=mod_id,
+                        source_rel_path=src_rel,
+                    ),
+                )
+            elif node_type == "lib":
+                mod_id = meta.get(
+                    "module_id", node.get("module_id", module_id_default)
+                )
+                tree.set_quiet(
+                    full_path,
+                    PDVLib(
+                        uuid=node_uuid,
+                        filename=node_filename,
+                        module_id=mod_id,
+                        source_rel_path=src_rel,
+                    ),
+                )
+            elif node_type == "file":
+                tree.set_quiet(
+                    full_path,
+                    PDVFile(
+                        uuid=node_uuid,
+                        filename=node_filename,
+                        source_rel_path=src_rel,
+                    ),
+                )
+            elif backend == "inline":
+                tree.set_quiet(full_path, storage.get("value"))
+            elif backend == "local_file":
+                value = deserialize_node(
+                    storage,
+                    working_dir,
+                    trusted=True,
+                    python_type=meta.get("python_type", ""),
+                )
+                tree.set_quiet(full_path, value)
+        except Exception as exc:  # noqa: BLE001 — one bad leaf must not abort the load
+            skipped.append({"path": full_path, "error": repr(exc)})
 
         if on_progress is not None:
             on_progress(index, total)
+
+    return skipped

--- a/pdv-python/tests/test_handlers_project.py
+++ b/pdv-python/tests/test_handlers_project.py
@@ -115,6 +115,89 @@ class TestHandleProjectLoad:
             handle_project_load(msg)
         assert numpy.array_equal(dict.__getitem__(tree_with_comm, "arr"), arr)
 
+    def test_corrupt_node_skipped_rest_of_project_loads(
+        self, tree_with_comm, tmp_save_dir
+    ):
+        """One unloadable node must not abort the load (regression).
+
+        A leaf whose backing file is missing used to raise out of
+        handle_project_load, leaving the tree half-populated with no
+        pdv.project.loaded push. Now it is skipped and reported in the
+        response's skipped_nodes, and every other node still loads.
+        """
+        nodes = [
+            {
+                "path": "good_before",
+                "type": "scalar",
+                "storage": {"backend": "inline", "format": "inline", "value": 1},
+                "metadata": {},
+            },
+            {
+                "path": "broken",
+                "type": "ndarray",
+                "storage": {
+                    "backend": "local_file",
+                    "uuid": "missing_uuid",
+                    "filename": "gone.npy",
+                    "format": "npy",
+                },
+                "metadata": {},
+            },
+            {
+                "path": "good_after",
+                "type": "scalar",
+                "storage": {"backend": "inline", "format": "inline", "value": 2},
+                "metadata": {},
+            },
+        ]
+        _write_tree_index(tmp_save_dir, nodes)
+        mock_comm = _make_mock_comm()
+        msg = _make_msg("pdv.project.load", {"save_dir": tmp_save_dir})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_project_load(msg)
+
+        assert tree_with_comm["good_before"] == 1
+        assert tree_with_comm["good_after"] == 2
+        assert "broken" not in tree_with_comm
+
+        types_sent = [e["type"] for e in mock_comm._sent]
+        assert "pdv.project.loaded" in types_sent
+        response = [
+            e for e in mock_comm._sent if e["type"] == "pdv.project.load.response"
+        ][-1]
+        skipped = response["payload"]["skipped_nodes"]
+        assert len(skipped) == 1
+        assert skipped[0]["path"] == "broken"
+        assert skipped[0]["error"]
+
+    def test_clean_load_reports_no_skipped_nodes(self, tree_with_comm, tmp_save_dir):
+        """A fully healthy project reports an empty skipped_nodes list."""
+        _write_tree_index(
+            tmp_save_dir,
+            [
+                {
+                    "path": "x",
+                    "type": "scalar",
+                    "storage": {"backend": "inline", "format": "inline", "value": 5},
+                    "metadata": {},
+                }
+            ],
+        )
+        mock_comm = _make_mock_comm()
+        msg = _make_msg("pdv.project.load", {"save_dir": tmp_save_dir})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_project_load(msg)
+        response = [
+            e for e in mock_comm._sent if e["type"] == "pdv.project.load.response"
+        ][-1]
+        assert response["payload"]["skipped_nodes"] == []
+
     def test_sends_project_loaded_push(self, tree_with_comm, tmp_save_dir):
         """After loading, pdv.project.loaded push notification is sent."""
         _write_tree_index(tmp_save_dir, [])
@@ -199,6 +282,53 @@ class TestHandleProjectSave:
         with open(index_path) as f:
             nodes = json.load(f)
         assert isinstance(nodes, list)
+
+    def test_nan_scalar_saves_as_strictly_valid_json(
+        self, tree_with_comm, tmp_save_dir
+    ):
+        """A NaN in the tree must not corrupt tree-index.json (regression).
+
+        NaN used to be inlined, making json.dumps write a bare ``NaN``
+        token — invalid JSON that the app's JSON.parse rejects, bricking
+        project load. It now routes to pickle and the index stays
+        strictly parseable.
+        """
+        tree_with_comm["measurement"] = float("nan")
+        tree_with_comm["ok"] = 1.5
+        mock_comm = _make_mock_comm()
+        msg = _make_msg("pdv.project.save", {"save_dir": tmp_save_dir})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_project_save(msg)
+
+        index_path = os.path.join(tmp_save_dir, "tree-index.json")
+        with open(index_path) as f:
+            raw = f.read()
+
+        def _reject_constant(name):
+            raise AssertionError(f"non-finite JSON constant in index: {name}")
+
+        # Strict parse: bare NaN/Infinity tokens must be absent entirely.
+        nodes = json.loads(raw, parse_constant=_reject_constant)
+        by_path = {n["path"]: n for n in nodes}
+        assert by_path["measurement"]["storage"]["backend"] != "inline"
+        assert by_path["ok"]["storage"]["value"] == 1.5
+
+        # And the NaN round-trips back through load. No working dir on the
+        # fresh tree: load then resolves backing files against the save dir
+        # (in the app, Electron's file sync copies them to the working dir).
+        fresh = PDVTree()
+        load_comm = _make_mock_comm()
+        load_msg = _make_msg("pdv.project.load", {"save_dir": tmp_save_dir})
+        with (
+            patch.object(comms_mod, "_comm", load_comm),
+            patch.object(comms_mod, "_pdv_tree", fresh),
+        ):
+            handle_project_load(load_msg)
+        restored = fresh["measurement"]
+        assert restored != restored  # NaN
 
     def test_writes_data_files(self, tree_with_comm, tmp_save_dir):
         """Data files are written for each serializable node."""

--- a/pdv-python/tests/test_handlers_registry.py
+++ b/pdv-python/tests/test_handlers_registry.py
@@ -50,7 +50,6 @@ KNOWN_UNTESTED: dict[str, str] = {
     "pdv.tree.delete": "no handler-level test; tree mutation covered indirectly",
     "pdv.tree.rename": "semantics covered by test_tree_handlers.py::TestRename — handler entry point untested",
     "pdv.tree.move": "semantics covered by test_tree_handlers.py::TestMove — handler entry point untested",
-    "pdv.tree.duplicate": "semantics covered by test_tree_handlers.py::TestDuplicate — handler entry point untested",
     "pdv.tree.resolve_file": "no test for resolve_file handler entry point",
     "pdv.script.params": "no test for late param fetch",
     "pdv.module.register": "no test for module registration message handler",

--- a/pdv-python/tests/test_namespace.py
+++ b/pdv-python/tests/test_namespace.py
@@ -61,6 +61,77 @@ class TestPDVNamespace:
         assert "pdv_tree" in ns
 
 
+class TestPDVNamespaceMutatorBypass:
+    """The non-dunder dict mutators must not bypass protection.
+
+    Regression tests: pop()/clear()/update()/setdefault() inherited from
+    dict used to silently remove or clobber pdv_tree — notably IPython's
+    %reset, which calls user_ns.clear().
+    """
+
+    def _ns(self) -> PDVNamespace:
+        ns = PDVNamespace()
+        dict.__setitem__(ns, "pdv_tree", "TREE")
+        ns["other"] = 1
+        return ns
+
+    def test_pop_protected_raises(self):
+        ns = self._ns()
+        with pytest.raises(PDVProtectedNameError):
+            ns.pop("pdv_tree")
+        assert ns["pdv_tree"] == "TREE"
+
+    def test_pop_normal_allowed(self):
+        ns = self._ns()
+        assert ns.pop("other") == 1
+        assert "other" not in ns
+
+    def test_update_protected_raises_and_merges_nothing(self):
+        ns = self._ns()
+        with pytest.raises(PDVProtectedNameError):
+            ns.update({"pdv_tree": "CLOBBER", "new_var": 2})
+        assert ns["pdv_tree"] == "TREE"
+        assert "new_var" not in ns  # all-or-nothing
+
+    def test_update_normal_allowed(self):
+        ns = self._ns()
+        ns.update({"a": 1}, b=2)
+        assert ns["a"] == 1
+        assert ns["b"] == 2
+
+    def test_clear_preserves_protected(self):
+        """%reset calls user_ns.clear() — pdv_tree must survive it."""
+        ns = self._ns()
+        tree_obj = ns["pdv_tree"]
+        ns.clear()
+        assert ns["pdv_tree"] is tree_obj
+        assert "other" not in ns
+
+    def test_setdefault_protected_raises_when_absent(self):
+        ns = PDVNamespace()
+        with pytest.raises(PDVProtectedNameError):
+            ns.setdefault("pdv_tree", "sneaky")
+
+    def test_setdefault_protected_reads_existing(self):
+        ns = self._ns()
+        assert ns.setdefault("pdv_tree", "ignored") == "TREE"
+
+    def test_setdefault_normal_allowed(self):
+        ns = self._ns()
+        assert ns.setdefault("fresh", 7) == 7
+        assert ns["fresh"] == 7
+
+    def test_popitem_never_pops_protected(self):
+        ns = PDVNamespace()
+        dict.__setitem__(ns, "pdv_tree", "TREE")
+        ns["only_other"] = 1
+        key, value = ns.popitem()
+        assert key == "only_other"
+        with pytest.raises(KeyError):
+            ns.popitem()  # only pdv_tree remains
+        assert ns["pdv_tree"] == "TREE"
+
+
 class TestWorkingDir:
     def test_working_dir_returns_tree_working_dir(self, tmp_path, monkeypatch):
         import pdv  # noqa: PLC0415

--- a/pdv-python/tests/test_serialization.py
+++ b/pdv-python/tests/test_serialization.py
@@ -185,6 +185,39 @@ class TestSerializeAndDeserialize:
         )
         assert value == 1 + 2j
 
+    @pytest.mark.parametrize(
+        "bad_float", [float("nan"), float("inf"), float("-inf")]
+    )
+    def test_nonfinite_float_not_inlined(self, tmp_working_dir, bad_float):
+        """NaN/inf must NOT inline: json.dumps would emit bare NaN/Infinity
+        tokens, which are invalid JSON and break the app's JSON.parse of
+        tree-index.json. They route to pickle instead (regression)."""
+        from pdv.serialization import _can_inline_json
+
+        assert _can_inline_json(bad_float) is False
+        descriptor = serialize_node("f", bad_float, tmp_working_dir)
+        assert descriptor["storage"]["backend"] != "inline"
+        assert descriptor["storage"]["format"] == "pickle"
+        value = deserialize_node(
+            descriptor["storage"], tmp_working_dir, trusted=True
+        )
+        if bad_float != bad_float:  # NaN
+            assert value != value
+        else:
+            assert value == bad_float
+
+    def test_nonfinite_inside_list_not_inlined(self, tmp_working_dir):
+        """A NaN nested in a list poisons the whole list for inlining."""
+        from pdv.serialization import _can_inline_json
+
+        assert _can_inline_json([1.0, float("nan")]) is False
+        descriptor = serialize_node("l", [1.0, float("nan")], tmp_working_dir)
+        assert descriptor["storage"]["backend"] != "inline"
+
+    def test_finite_float_still_inlines(self, tmp_working_dir):
+        descriptor = serialize_node("f", 3.14, tmp_working_dir)
+        assert descriptor["storage"]["backend"] == "inline"
+
     def test_set_sequence_pickle_roundtrip(self, tmp_working_dir):
         """sets aren't JSON-native, so they pickle and round-trip as sets."""
         descriptor = serialize_node("s", {1, 2, 3, 4}, tmp_working_dir)

--- a/pdv-python/tests/test_tree_copy.py
+++ b/pdv-python/tests/test_tree_copy.py
@@ -1,0 +1,205 @@
+"""
+pdv-python/tests/test_tree_copy.py — PDVTree copy/pickle/get consistency.
+
+Regression tests for the dict-subclass holes fixed in the data-integrity
+batch:
+
+- ``copy.deepcopy``/``pickle`` raised ``TypeError: cannot pickle
+  '_thread.lock' object`` because every instance carried a debounce lock
+  and timer — which made ``pdv.tree.duplicate`` (folder duplication in
+  the UI) fail unconditionally.
+- ``dict.get`` was not dot-path aware, so ``tree.get('a.b')`` returned
+  the default while ``tree['a.b']`` worked.
+- ``dict.copy`` returned a plain ``dict``, silently dropping the PDVTree
+  type and instance state.
+- ``PDVTree({'a.b': 1})`` stored a literal dotted key that
+  ``__getitem__`` could never retrieve.
+
+The duplicate-handler test drives the real ``pdv.tree.duplicate`` entry
+point via ``_on_comm_message`` — it is the shipping-bug regression.
+"""
+
+import copy
+import pickle
+import uuid as uuid_mod
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import pdv.comms as comms_mod
+from pdv.errors import PDVKeyError, PDVPathError
+from pdv.tree import PDVModule, PDVScript, PDVTree
+
+
+class TestDeepcopyPickle:
+    def _sample_tree(self) -> PDVTree:
+        tree = PDVTree()
+        tree["folder.data"] = [1, 2, 3]
+        tree["folder.script"] = PDVScript(uuid="u1", filename="fit.py")
+        tree["scalar"] = 42
+        return tree
+
+    def test_deepcopy_succeeds_and_is_independent(self):
+        tree = self._sample_tree()
+        clone = copy.deepcopy(tree["folder"])
+        assert isinstance(clone, PDVTree)
+        assert clone["data"] == [1, 2, 3]
+        clone["data"].append(4)
+        assert tree["folder.data"] == [1, 2, 3]
+
+    def test_deepcopy_of_root_is_detached(self, tree_with_comm):
+        tree_with_comm["a.b"] = 1
+        clone = copy.deepcopy(tree_with_comm)
+        assert clone._send_fn is None
+        # Mutating the detached clone must not raise or notify precisely.
+        clone["a.c"] = 2
+        assert "a.c" not in tree_with_comm
+
+    def test_pickle_roundtrip_items_and_attrs(self, tmp_working_dir):
+        tree = self._sample_tree()
+        tree._set_working_dir(tmp_working_dir)
+        restored = pickle.loads(pickle.dumps(tree))
+        assert isinstance(restored, PDVTree)
+        assert restored["scalar"] == 42
+        assert restored["folder.data"] == [1, 2, 3]
+        assert isinstance(restored["folder.script"], PDVScript)
+        assert restored["folder.script"].uuid == "u1"
+        assert restored._working_dir == tmp_working_dir
+        assert restored._send_fn is None
+
+    def test_pickle_roundtrip_pdvmodule_subclass(self):
+        mod = PDVModule(module_id="m1", name="Demo", version="1.0")
+        mod["inputs.x"] = 3.5
+        restored = pickle.loads(pickle.dumps(mod))
+        assert isinstance(restored, PDVModule)
+        assert restored.module_id == "m1"
+        assert restored.name == "Demo"
+        assert restored["inputs.x"] == 3.5
+
+    def test_deepcopy_tree_nested_inside_plain_container(self):
+        inner = PDVTree()
+        inner["k"] = 1
+        holder = {"trees": [inner]}
+        clone = copy.deepcopy(holder)
+        assert isinstance(clone["trees"][0], PDVTree)
+        assert clone["trees"][0]["k"] == 1
+
+
+class TestDuplicateHandlerEntryPoint:
+    """Drive the real pdv.tree.duplicate handler (the shipping bug)."""
+
+    def _dispatch(self, tree: PDVTree, msg_type: str, payload: dict) -> list[dict]:
+        sent: list[dict[str, Any]] = []
+        mock_comm = MagicMock()
+        mock_comm.send.side_effect = lambda data: sent.append(data)
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree),
+        ):
+            comms_mod._on_comm_message(
+                {
+                    "pdv_version": comms_mod.PDV_PROTOCOL_VERSION,
+                    "msg_id": str(uuid_mod.uuid4()),
+                    "in_reply_to": None,
+                    "type": msg_type,
+                    "payload": payload,
+                }
+            )
+        return sent
+
+    def test_duplicate_folder_node_succeeds(self, tree_with_comm):
+        tree_with_comm["folder"] = PDVTree()
+        tree_with_comm["folder.x"] = [1, 2]
+        sent = self._dispatch(
+            tree_with_comm,
+            "pdv.tree.duplicate",
+            {"path": "folder", "new_path": "folder_copy"},
+        )
+        responses = [e for e in sent if e.get("type") == "pdv.tree.duplicate.response"]
+        assert responses, f"no duplicate response in {sent}"
+        payload = responses[-1]["payload"]
+        assert payload.get("duplicated") is True, payload
+        assert isinstance(tree_with_comm["folder_copy"], PDVTree)
+        assert tree_with_comm["folder_copy.x"] == [1, 2]
+        # Deep copy: mutating the clone leaves the original untouched.
+        tree_with_comm["folder_copy.x"].append(3)
+        assert tree_with_comm["folder.x"] == [1, 2]
+
+    def test_duplicate_missing_path_errors_cleanly(self, tree_with_comm):
+        sent = self._dispatch(
+            tree_with_comm,
+            "pdv.tree.duplicate",
+            {"path": "nope", "new_path": "copy"},
+        )
+        responses = [e for e in sent if e.get("type") == "pdv.tree.duplicate.response"]
+        assert responses
+        assert responses[-1]["status"] == "error"
+        assert responses[-1]["payload"]["code"] == "tree.path_not_found"
+
+
+class TestGetDotPath:
+    def test_get_resolves_dot_paths(self):
+        tree = PDVTree()
+        tree["a.b"] = 42
+        assert tree.get("a.b") == 42
+        assert tree.get("a.b") == tree["a.b"]
+
+    def test_get_returns_default_for_missing(self):
+        tree = PDVTree()
+        assert tree.get("missing") is None
+        assert tree.get("missing", 5) == 5
+        assert tree.get("a.b.c", "d") == "d"
+
+    def test_get_plain_key_still_works(self):
+        tree = PDVTree()
+        tree["top"] = "v"
+        assert tree.get("top") == "v"
+
+
+class TestCopyOverride:
+    def test_copy_preserves_type_and_state(self, tmp_working_dir):
+        tree = PDVTree()
+        tree._set_working_dir(tmp_working_dir)
+        tree["a.b"] = 1
+        c = tree.copy()
+        assert type(c) is PDVTree
+        assert c._working_dir == tmp_working_dir
+        assert c["a.b"] == 1
+
+    def test_copy_is_shallow_and_detached(self, tree_with_comm):
+        tree_with_comm["a"] = [1]
+        c = tree_with_comm.copy()
+        assert c._send_fn is None
+        assert c["a"] is tree_with_comm["a"]
+
+    def test_copy_preserves_subclass(self):
+        mod = PDVModule(module_id="m1", name="Demo", version="1.0")
+        mod["k"] = 1
+        c = mod.copy()
+        assert type(c) is PDVModule
+        assert c.module_id == "m1"
+        assert c["k"] == 1
+
+
+class TestConstructorNormalization:
+    def test_dotted_keys_expand_to_nested_nodes(self):
+        tree = PDVTree({"a.b": 1})
+        assert tree["a.b"] == 1
+        assert isinstance(tree["a"], PDVTree)
+        assert dict.__contains__(tree, "a")
+        assert not dict.__contains__(tree, "a.b")
+
+    def test_plain_mapping_and_kwargs(self):
+        tree = PDVTree({"x": 1}, y=2)
+        assert tree["x"] == 1
+        assert tree["y"] == 2
+
+    def test_non_string_keys_rejected(self):
+        with pytest.raises((PDVPathError, PDVKeyError, TypeError)):
+            PDVTree({1: "one"})
+
+    def test_roundtrip_getitem_contains_get_agree(self):
+        tree = PDVTree({"a.b": 1})
+        assert "a.b" in tree
+        assert tree.get("a.b") == 1


### PR DESCRIPTION
## Summary

First batch of data-integrity/correctness fixes from the full-repo audit (2026-07-07). All findings below were reproduced before fixing.

### pdv-python

- **PDVTree deepcopy/pickle crash** — every instance carried a `threading.Lock`/`Timer`, so `copy.deepcopy`/`pickle.dumps` raised `TypeError`; this made **folder duplication in the UI fail unconditionally** (`handle_tree_duplicate` deepcopies the node). Fixed with `__getstate__`/`__setstate__` that drop and rebuild runtime-only state.
- **NaN corrupts tree-index.json** — non-finite floats were inlined and `json.dumps` wrote bare `NaN`/`Infinity` tokens (invalid JSON; the app's `JSON.parse` rejects the whole index at load). Non-finite floats now route to pickle in both `_can_inline_json` **and** the scalar fast-path (which never consulted `_can_inline_json`); index dump uses `allow_nan=False` as a loud backstop.
- **PDVTree dict-subclass consistency** — dot-path-aware `get()`, type-preserving detached `copy()`, constructor normalizes dotted keys and rejects non-string keys.
- **Resilient project load** — one corrupt/missing backing file no longer aborts the whole load; unloadable nodes are skipped and reported via `skipped_nodes` in the load response, and `pdv.project.loaded` still fires.
- **Namespace protection bypass** — `update`/`pop`/`popitem`/`setdefault` now respect protected names; `clear()` preserves `pdv_tree`, so IPython's `%reset` no longer wipes the tree.

### Renderer

- [x] GUI editor: Delete on the root row wiped every input/action descriptor — root delete is now a no-op in both the reducer and the keyhandler
- [x] GUI editor: dropping a container into its own descendant corrupted the layout, and dropping it onto itself silently deleted the subtree — MOVE_NODE now rejects both (segment-wise ancestor check)
- [x] Namelist array fields ate commas while typing — raw draft held while focused, parsed on blur
- [x] Module window hung on "Loading module…" on early errors — error state now clears/outranks loading
- [x] Code-cell autosave fired an IPC + disk write per keystroke — the debounce now coalesces, flushing only on unmount/kernel change

## Test plan

- [x] `pdv-python` full suite: **602 passed, 2 pre-existing skips**
- [x] New regression tests: `test_tree_copy.py` (drives the real `pdv.tree.duplicate` handler entry point; registry allowlist shrunk), NaN/±inf serialization + save→strict-parse→load round-trip, loader skip-and-report, namespace mutator coverage
- [x] **Dependency sweep (`pdv-python/scripts/sweep-deps.sh`): all green** — every cell across Python 3.10–3.14 × extras (bare/data/copy/dev) × highest/lowest-direct resolution installed and passed
- [x] Renderer: new reducer/component/hook unit tests written to fail against the buggy code first (editor-state, NamelistField, useCodeCellsPersistence); full Electron unit suite **643 passed**, typecheck clean
- [x] Playwright e2e: 14/17 locally with a real kernel (the 3 "failures" were the app being quit mid-test while the machine was in use); CI's headless Playwright job is the authoritative signal and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)