### PR TITLE
Lifecycle robustness batch + new-project environment UX

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1475,9 +1475,10 @@ uv-mode hinges on PDV's existing split between the **working directory** (§6.1 
 | `project.json` | ✓ | — |
 | `pyproject.toml` | ✓ | ✓ (materialized on open, written back on save) |
 | `uv.lock` | ✓ | ✓ (materialized on open, written back on save) |
+| `.python-version` | ✓ | ✓ (uv's native interpreter pin, written at creation from the New Project dialog's version choice) |
 | `.venv/` | — | ✓ (built by `uv sync`; **never** persisted) |
 
-`pyproject.toml` and `uv.lock` are two more project files that ride the existing materialize-on-open / write-on-save flow used for the tree. `.venv/` is the only uv artifact never copied to the save directory.
+`pyproject.toml`, `uv.lock`, and `.python-version` are three more project files that ride the existing materialize-on-open / write-on-save flow used for the tree (`ENV_FILES` in `project-file-sync.ts`). `.venv/` is the only uv artifact never copied to the save directory.
 
 The consequences are all deliberate:
 
@@ -1510,14 +1511,14 @@ For `mode: "uv"`, the authoritative dependency specification is the `pyproject.t
 
 | Field | Type | Description |
 |---|---|---|
-| `environment.mode` | string | `"uv"` or `"shared"`. Absent (legacy `"1.1"` manifests) is treated as `"shared"`. |
-| `environment.python_version` | string? | Requested Python version (e.g. `"3.12"`), uv-mode only. If absent, uv picks the newest interpreter it can find or install. |
+| `environment.mode` | string | `"uv"` or `"shared"`. Absent (legacy `"1.1"` manifests) is treated as `"shared"`. Both modes are recorded explicitly at save time from the active kernel's environment metadata. |
+| `environment.python_version` | string? | The `major.minor` Python version the session actually ran on, uv-mode only — resolved by probing the live venv interpreter at kernel start and recorded on every save. The working/save-dir `.python-version` pin (§10.5.3) is what drives `uv sync --python` on reopen; the manifest field is a fallback for pre-pin projects and for display. |
 
 No venv path and no project identifier are stored. The venv always lives at `<working-dir>/.venv/`, derived from the session's working directory, so there is nothing machine-specific to record.
 
 A `"1.1"` manifest opened by a 1.2-capable app is upgraded in place on next save: `schema_version` becomes `"1.2"` and `environment.mode` defaults to `"shared"`. No `pyproject.toml` is created — an existing project is never silently turned into a uv project.
 
-The legacy top-level `interpreter_path` field from §6.2 is retained for `mode: "shared"` (it records which env was used at last save so it can be pre-selected on reopen) and is ignored for `mode: "uv"`.
+The top-level `interpreter_path` field from §6.2 is **authoritative for `mode: "shared"`**: it records the interpreter the kernel actually spawned on (from the per-kernel environment metadata the main process keeps, `kernelEnvMeta`), not the app-wide config value. On reopen it is probed via `environment.check`; if the environment is gone the user is warned and offered the Default Runtime selector. For `mode: "uv"` no `interpreter_path` is recorded — the venv path is ephemeral, and mode + version pin are the environment's identity.
 
 #### 10.5.6 The `uv` Binary
 
@@ -1541,11 +1542,19 @@ where `<venv-python>` is `<working-dir>/.venv/bin/python` (`...\.venv\Scripts\py
 
 #### 10.5.8 New Project Flow
 
-1. The user chooses a save directory (File → New Project).
-2. PDV writes `project.json` (`environment.mode: "uv"`) and a `pyproject.toml` seeded from the user-level default-packages list (§10.5.14). `python_version` defaults to the newest interpreter uv reports.
-3. PDV runs `uv sync` in the working directory, streaming output to the environment activity panel behind a blocking modal.
+Clicking **New Python Project** on the welcome screen opens the **New Project dialog** — the one moment the environment choice is free, so it is made here and recorded, not changed later (§10.5.19). The project itself stays unsaved until the first explicit Save; the dialog configures only the environment:
+
+- **Python version** — a dropdown over `SUPPORTED_PYTHON_VERSIONS` (`electron/main/python-versions.ts`, kept in sync with pdv-python's `requires-python`), defaulting to `DEFAULT_PYTHON_VERSION` (one behind the newest supported, for wheel availability). Missing interpreters are downloaded automatically by uv (§10.5.15).
+- **Initial packages** — prefilled from the user-level default-packages list (§10.5.14); comma-separated PEP 508 specs, validated by uv itself.
+- **Advanced: use an existing environment** — a mode toggle for the conda/cluster case (§10.5.17). Opening it *replaces* the uv fields with the embedded environment selector (its own confirm and install buttons suppressed via `hideConfirm`/`hideInstallButton`), so the two paths are mutually exclusive and the footer's primary button is the **single always-visible action**: **Create** when the highlighted environment has a compatible pdv-python; **Install pdv-python** when that is the required next step (driving the selector's install flow through its `actionsRef`, then flipping to Create on the post-install re-probe); disabled with the reason in its tooltip otherwise (no selection, no-GIL build). Nothing the user must click is ever below the scroll. Confirming starts a shared-mode session on that interpreter, session-scoped (the global config is untouched); the choice reaches the manifest as `mode: "shared"` + `interpreter_path` on first save.
+
+On Create (uv path):
+
+1. `kernels.start` receives the choices via `KernelUvContext` (`{ newProject, pythonVersion, packages }`); `pythonVersion` is validated against `SUPPORTED_PYTHON_VERSIONS`.
+2. PDV writes a `pyproject.toml` seeded from the chosen packages and a `.python-version` pin into the fresh working directory.
+3. PDV runs `uv sync --python <version>` there, streaming output to the environment activity panel behind a blocking modal.
 4. PDV installs `pdv-python` (§10.5.7).
-5. The kernel launches against `<working-dir>/.venv` and §4.1's startup sequence proceeds.
+5. The kernel launches against `<working-dir>/.venv` and §4.1's startup sequence proceeds. The resolved venv version and interpreter are recorded in the per-kernel environment metadata for later manifest writes (§10.5.5).
 
 #### 10.5.9 Project Open Flow
 
@@ -1567,7 +1576,7 @@ On failure the app surfaces uv's output verbatim and offers **Retry** and **Canc
 
 #### 10.5.10 Project Save Flow
 
-On `project.save`, `pyproject.toml` and `uv.lock` are written from the working directory back into the save directory alongside the tree (§8.1). Both can change mid-session — `pdv.install()` and the package UI mutate them — so both are part of every save. `.venv/` is never saved.
+On `project.save`, `pyproject.toml`, `uv.lock`, and `.python-version` are written from the working directory back into the save directory alongside the tree (§8.1). The first two can change mid-session — `pdv.install()` and the package UI mutate them — so all are part of every save. `.venv/` is never saved. The manifest additionally records the environment (`mode`, `python_version` / `interpreter_path`) from the active kernel's metadata (§10.5.5).
 
 #### 10.5.11 `pdv.install()` — In-Kernel Installs
 
@@ -1588,16 +1597,17 @@ In shared mode (no project venv) the kernel is not given a uv binary path, and `
 
 A `ModuleNotFoundError` raised by a code cell is detected in the kernel's output stream, and the console renders an affordance beneath the traceback: a one-click `Install with pdv.install("<name>")` action that runs the install for the user. Detection is not restricted to a curated package list — any missing module name is offered. A wrong suggestion (a typo, a missing local module) costs only an ignored button; the discoverability win for users who do not know `pdv.install()` exists is worth that.
 
-#### 10.5.13 Package Management UI
+#### 10.5.13 Project Environment Tab (Package Management UI)
 
-A **Packages** tab in the project settings is the friendly face over `uv add` / `uv remove` / `uv lock --upgrade-package`. Users never have to read `pyproject.toml`.
+The **Project Environment** settings tab (tab id `packages`) answers "what is this session running on" and is the friendly face over `uv add` / `uv remove` / `uv lock --upgrade-package`. Users never have to read `pyproject.toml`.
 
 The tab:
-- Lists direct dependencies parsed from `pyproject.toml`'s `[project].dependencies` array, each with its installed version.
+- Opens with an environment header driven by the `environment:activeInfo` IPC channel (backed by the main process's per-kernel `kernelEnvMeta` map): a mode badge ("uv-managed · shareable" vs "external environment"), the interpreter the kernel actually spawned on, and its Python version.
+- For uv mode, lists direct dependencies parsed from `pyproject.toml`'s `[project].dependencies` array, each with its installed version.
 - Supports add (PyPI name with optional version spec), remove, and per-package upgrade.
 - Runs every operation through `uv` so `uv.lock` stays consistent, and refreshes the kernel's import caches afterward exactly as §10.5.11 does.
 - Streams output to the same environment activity panel used by bootstrap.
-- Offers an "Edit pyproject.toml" escape hatch; the main process re-runs `uv sync` after any external edit.
+- For shared mode, shows the environment header plus a note that packages are managed by the external environment's own tooling and that changing an existing project's environment is a planned dedicated action (issue #335), not a settings toggle.
 
 PDV never parses or resolves dependency constraints itself — everything is delegated to `uv`.
 
@@ -1607,7 +1617,7 @@ A user-level setting (Settings → Python) holds a list of PEP 508 dependency sp
 
 #### 10.5.15 Python Version Acquisition
 
-If `environment.python_version` names an interpreter uv cannot find, `uv` can download one via `uv python install`. Because that is a tens-of-megabytes download, PDV gates it behind an explicit confirmation dialog the first time it is needed for a project ("This project requests Python 3.12, which is not installed. Download it now? (≈ 40 MB)"). Downloaded interpreters land in uv's standard location (§10.5.6) and are shared with any system `uv`.
+If the pinned version (`.python-version` / `--python`) names an interpreter uv cannot find, `uv sync` downloads one automatically as part of environment materialization — uv's default behavior, which PDV does not override. The download streams through the same blocking environment-setup modal as the rest of the sync, and the New Project dialog notes next to the version dropdown that missing versions are downloaded automatically. Downloaded interpreters land in uv's standard location (§10.5.6) and are shared with any system `uv`, so the tens-of-megabytes cost is paid once per machine per version.
 
 #### 10.5.16 Developer Mode (editable `pdv-python`)
 
@@ -1628,6 +1638,15 @@ The editable install is preferred over a `PYTHONPATH` shim because it both keeps
 All `uv` invocations in the main process go through one module, `electron/main/uv-runner.ts` — a single spawn helper that locates the bundled binary (or the `uv.binaryPath` override), runs `uv sync` / `add` / `remove` / `lock` / `pip install` / `python install`, and streams stdout/stderr over IPC to the environment activity panel. No other file in the main process spawns `uv` directly.
 
 The one uv invocation *outside* the main process is `pdv.install()` in the kernel (§10.5.11), which spawns `uv add` itself using the binary path the main process resolved with `uv-runner`'s resolver and passed to the kernel at init.
+
+#### 10.5.19 Default Runtime vs Project Environment
+
+The environment is a **property of the project, not of the app** — the settings UI is split along that line:
+
+- **Default Runtime tab** (tab id `runtime`, the environment selector): global scope only. It sets the interpreter used for the first run, shared-mode sessions started outside a project's own choice, and Julia. When a session is `ready`, selecting an environment there writes the global config **for future sessions only**, with an explanatory note — it never stops, restarts, or re-homes the live session. (The pre-rescope behavior — stop the kernel and relaunch shared-mode on the new interpreter — silently demoted uv projects to shared mode.) When no session is ready (first run, start-failure recovery, missing-interpreter fallback on open), the selector keeps its save-and-start behavior, which those flows depend on.
+- **Project Environment tab** (§10.5.13): per-project scope — what the active session actually runs on, and uv package management.
+
+There is deliberately **no mid-project environment switching**. The choice is made once in the New Project dialog (§10.5.8) and recorded in the manifest; a guarded, explicit "Change project environment…" action is tracked as issue #335.
 
 ---
 
@@ -1659,9 +1678,9 @@ The API surface:
 - `window.pdv.modules.*` — module management: `listInstalled`, `install`, `importToProject`, `listImported`, `removeImport`, `saveSettings`, `runAction`, `checkUpdates`, `uninstall`, `update`
 - `window.pdv.moduleWindows.*` — module GUI windows: `open`, `close`, `context`, `executeInMain`; push: `onExecuteRequest(cb) → unsub`
 - `window.pdv.guiEditor.*` — GUI editor and viewer windows: `open` (editor), `openViewer` (standalone GUI viewer), `context`, `read`, `save`
-- `window.pdv.environment.*` — Python environment management: `list`, `check`, `install`, `refresh`; push: `onInstallOutput(cb) → unsub`
+- `window.pdv.environment.*` — Python environment management: `list`, `check`, `install`, `refresh`, `activeInfo` (active kernel's environment metadata — mode, interpreter, Python version — for the Project Environment tab), plus the uv package UI: `listPackages`, `addPackage`, `removePackage`, `upgradePackage`; push: `onInstallOutput(cb) → unsub`, `onEnvActivity(cb) → unsub` (streaming uv output)
 - `window.pdv.chrome.*` — window chrome controls: `getInfo`, `minimize`, `toggleMaximize`, `close`; push: `onStateChanged(cb) → unsub`
-- `window.pdv.system.*` — constant host facts injected at preload time: `platform` (the main process's `process.platform`). Exposed as a plain value, not a function — it never changes during a session, so it needs no IPC channel
+- `window.pdv.system.*` — constant host facts injected at preload time: `platform` (the main process's `process.platform`), `supportedPythonVersions` and `defaultPythonVersion` (the New Project dialog's version range, from `python-versions.ts`). Exposed as plain values, not functions — they never change during a session, so they need no IPC channel
 - `window.pdv.launchers.*` — action-bar external-app launchers: `openAgent` (launch the configured AI agent in a terminal), `openWorkingDir` (open the active kernel's working directory in the configured editor/IDE), `checkAvailability` (probe whether a terminal/editor/file-manager is installed, without launching it — used to gate Settings Save)
 - `window.pdv.progress.*` — operation progress: push only: `onProgress(cb) → unsub`
 - `window.pdv.menu.*` — menu bridge: `updateRecentProjects(paths)`, `onAction(cb) → unsub`
@@ -1770,18 +1789,23 @@ The `chrome.*` IPC namespace (§11.2) provides the renderer with platform-specif
 
 ### 11.6 Kernel Restart with Project Reload
 
-When `kernels.restart()` is called while a project is loaded, the main process automatically preserves and reloads project state:
+When `kernels.restart()` is called, the main process automatically preserves and reloads project state:
 
-1. **Snapshot the uv environment** (uv mode only): before the old working directory is deleted, read its `pyproject.toml` and `uv.lock` into memory. This captures any packages installed during the session (e.g. via `pdv.install()`, §10.5.11) that may not yet be in the save directory.
-2. Stop the old kernel, start a new one (preserving `activeProjectDir`)
-3. **Re-materialize the uv environment** (uv mode only): write the snapshot into the new working directory and run the §10.5.9 sequence (`uv sync` → install `pdv-python`), launching the new kernel against the project venv interpreter. Shared-mode kernels skip this and relaunch on the app-selected interpreter as before.
-4. Send `project.onReloading` push with `{ status: "reloading" }` — renderer shows overlay
-5. Copy project files from the save directory to the new kernel's working directory
-6. Call `projectManager.load()` to re-populate the tree via `pdv.project.load`
-7. Re-run module setup (`pdv.modules.setup`)
-8. Send `project.onReloading` push with `{ status: "ready" }` — renderer removes overlay
+1. **Pre-restart tree snapshot**: attempt a fresh `.autosave` snapshot while the old session is still alive (§8.4 flow 3) — but **only when the server process is alive and idle**. Liveness is checked via the process state (`getKernelProcessState` / `status === "dead"`), not `executionState` alone, because the execution state stays stale-`idle` after a crash. The snapshot's kernel comm is bounded to 5 s (instead of the default 30 s) so a wedged-but-alive server cannot stall the restart. When skipped or failed, the most recent timer autosave serves as the snapshot.
+2. **Snapshot the uv environment** (uv mode only): before the old working directory is deleted, read its `pyproject.toml`, `uv.lock`, and `.python-version` into memory. This captures any packages installed during the session (e.g. via `pdv.install()`, §10.5.11) that may not yet be in the save directory. Hardening: if the old working directory is gone but the saved project has a `pyproject.toml`, the environment is rebuilt from the save directory instead of silently falling back to a shared-mode start.
+3. Stop the old kernel, start a new one (preserving `activeProjectDir` and carrying the per-kernel environment metadata to the new kernel id)
+4. **Re-materialize the uv environment** (uv mode only): write the snapshot into the new working directory and run the §10.5.9 sequence (`uv sync --python <pin>` → install `pdv-python`), launching the new kernel against the project venv interpreter. Shared-mode kernels skip this and relaunch on the app-selected interpreter as before.
+5. Send `project.onReloading` push with `{ status: "reloading" }` — renderer shows overlay
+6. Copy project files from the save directory to the new kernel's working directory, overlaying the `.autosave` snapshot when one exists (unsaved sessions restore via the welcome screen's recovery routine instead)
+7. Call `projectManager.load()` to re-populate the tree via `pdv.project.load`
+8. Re-run module setup (`pdv.modules.setup`)
+9. Send `project.onReloading` push with `{ status: "ready" }` — renderer removes overlay
 
-This ensures the project venv, tree state, module bindings, and `sys.path` configuration survive kernel restarts. Because the renderer's environment-mode indicator reflects the project (not the individual kernel), it stays correct across a restart that re-materializes the same venv.
+`kernels.restart` returns a `KernelRestartResult` — `{ kernel, restoredFromAutosave }` — so the renderer can tell the user what came back ("restored from the last autosave" vs "starting fresh") in the console.
+
+**Crash recovery.** The kernel crash handler (`onCrash`) deliberately does **not** delete the crashed kernel's working directory or its map entry: the directory holds the uv env spec the restart snapshots and any `.autosave` of an unsaved session. (It used to delete it, which silently demoted a crashed uv project to shared mode and destroyed unsaved work.) `kernels.restart` and `kernels.stop` clean the directory up; if the user quits instead, the stale `session.lock` surfaces it on the welcome screen as a recoverable session (§8.4). The StatusBar offers the ⟳ Restart control both while connected and in the `error` state when a restartable session exists (`canRestart`, i.e. a kernel id is known) — a crashed session can be restarted; a failed start cannot, and its recovery flows through the environment-setup retry surfaces instead.
+
+This ensures the project venv, tree state, module bindings, and `sys.path` configuration survive kernel restarts — including crashes. Because the renderer's environment-mode indicator reflects the project (not the individual kernel), it stays correct across a restart that re-materializes the same venv.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1358,13 +1358,17 @@ The cache covers in-memory data kinds — ndarray, DataFrame, Series, scalar, te
 
 **Save / autosave serialization.** Both `IPC.project.save` and `IPC.autosave.run` acquire a single FIFO mutex inside `ProjectManager` (`runWithSaveLock`). When the autosave timer fires while an explicit save is in flight, the autosave queues until the save finishes. When the user clicks Save while an autosave is in flight, Save queues the same way. Combined with the kernel-busy deferral via `consumeAutosavePending`, this means autosave never overlaps an explicit save's main-process post-save side effects (manifest writes, module mirror).
 
-**Two recovery flows.**
+**Three recovery flows.**
 
 1. **Recovery on project open.** When the user opens a project that has a `<saveDir>/.autosave/` younger than (or independent of) the canonical save, the renderer prompts: "Restore autosaved changes?" If yes, the main process copies any file-backed nodes from `.autosave/` into the kernel working dir and calls `projectManager.load(saveDir, { treeIndexDir: <saveDir>/.autosave, codeCellsDir: <saveDir>/.autosave })`. The kernel reads `tree-index.json` from the override directory; everything else (the `save_dir` argument, the kernel's `_set_save_dir`) is unchanged. After a successful load the `.autosave/` directory is cleared.
 
 2. **Recovery on welcome screen (unsaved sessions).** When the welcome screen renders, the renderer calls `IPC.autosave.scanWorkingDirs`, which lists `pdv-*` subdirectories of the working-dir base that contain `.autosave/tree-index.json`. Each entry is shown under "Recoverable Unsaved Sessions" with a Recover and a Discard button.
     - **Recover** starts the kernel (deferring via the welcome-screen pending-action ref if needed), then calls `IPC.autosave.recoverUnsaved(orphanDir)`. The handler copies file-backed nodes from `<orphan>/.autosave/` into the new kernel's working dir, calls `projectManager.load(workingDir, { treeIndexDir: …, codeCellsDir: … })`, mirrors `code-cells.json`, runs module setup, and then deletes the orphan directory. The renderer leaves `currentProjectDir = null` so the project remains in the unsaved state — the user is expected to Save As to keep it.
     - **Discard** calls `IPC.autosave.deleteOrphan(orphanDir)`, which removes the directory wholesale.
+
+3. **Restart preservation.** A user-initiated restart (the StatusBar **⟳ Restart** control, driving `IPC.kernels.restart`) must not lose in-memory work. Before the old session is torn down, the restart handler takes a snapshot: if the session is idle it hands the current code-cell tabs back and runs the same `performAutosave` core as the timer, writing a fresh `.autosave/` next to the active project (or in the working dir for an unsaved session). A non-idle session — often *why* the user is restarting — is not snapshotted; the handler falls back to whatever the last timer autosave left. After the new session is ready, restore reuses the two flows above:
+    - **Saved project:** the same overlay + `treeIndexDir`/`codeCellsDir` override recipe as flow 1, gated on a snapshot actually existing (`ProjectManager.checkForAutosave`).
+    - **Unsaved session:** the old working dir is kept (the restart's `preserveOldDir` path skips its deletion) and handed to the flow-2 `recoverUnsavedAfterRestart` routine. If restore fails for any reason, the old dir is left on disk, so the session reappears under "Recoverable Unsaved Sessions" on the next launch — restart degrades to flow 2 rather than losing data.
 
 **Status bar feedback.** After every successful autosave, the status bar shows "Autosaved at HH:MM:SS" (left of the checksum diamond). The timestamp clears when the user opens a different project; the next autosave repopulates it.
 

--- a/electron/e2e/code-cell.spec.ts
+++ b/electron/e2e/code-cell.spec.ts
@@ -9,13 +9,14 @@
 import { test, expect } from "@playwright/test";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 
 let launched: LaunchedApp;
 
 test.beforeAll(async () => {
   launched = await launchPDV();
   // Boot the kernel once for both cases.
-  await launched.window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(launched.window);
   await expectKernelReady(launched.window);
 });
 

--- a/electron/e2e/console-autoscroll.spec.ts
+++ b/electron/e2e/console-autoscroll.spec.ts
@@ -16,12 +16,13 @@
 import { test, expect } from "@playwright/test";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 
 let launched: LaunchedApp;
 
 test.beforeAll(async () => {
   launched = await launchPDV();
-  await launched.window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(launched.window);
   await expectKernelReady(launched.window);
 });
 

--- a/electron/e2e/crash-restart.spec.ts
+++ b/electron/e2e/crash-restart.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * crash-restart.spec.ts — Recovering a crashed session from the status bar.
+ *
+ * Regression coverage for the crash-recovery fixes (§11.6):
+ * - The ⟳ Restart control must appear when the session dies (it used to
+ *   render only while connected — gone exactly when needed).
+ * - The crash handler must NOT delete the working directory (it used to,
+ *   destroying the uv env spec and any `.autosave` snapshot).
+ * - Restart after a crash reloads the tree from the last autosave and says
+ *   so in the console.
+ *
+ * Flow: new project → value in tree → force an autosave → kill the kernel
+ * process from inside itself → Disconnected + Restart visible → click →
+ * session returns with the tree restored and live.
+ */
+
+import { test, expect } from "@playwright/test";
+import { expectKernelReady } from "./helpers/kernel-status";
+import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
+
+let launched: LaunchedApp;
+
+test.beforeAll(async () => {
+  launched = await launchPDV();
+  await createNewPythonProject(launched.window);
+  await expectKernelReady(launched.window);
+});
+
+test.afterAll(async () => {
+  await launched?.cleanup();
+});
+
+test("crashed session restarts from the status bar and restores the tree", async () => {
+  test.setTimeout(180_000);
+  const { window } = launched;
+
+  // Put a value in the tree.
+  const editor = window.getByRole("textbox", { name: "Editor content" });
+  await editor.focus();
+  await window.keyboard.type("pdv_tree['crash_survivor'] = 456");
+  await window.getByRole("button", { name: "Execute" }).click();
+  await expect(
+    window.locator(".tree-row", { hasText: "crash_survivor" }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Force an autosave so the crash-restart has a snapshot to restore from
+  // (the timer autosave would do this eventually; the test can't wait 5 min).
+  await window.evaluate(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (window as any).pdv.autosave.run({ tabs: [], activeTabId: 1 });
+  });
+
+  // Kill the kernel process from inside itself — a hard crash, not a stop.
+  await editor.focus();
+  const modifier = process.platform === "darwin" ? "Meta" : "Control";
+  await window.keyboard.press(`${modifier}+a`);
+  await window.keyboard.type("import os, signal; os.kill(os.getpid(), signal.SIGKILL)");
+  await window.getByRole("button", { name: "Execute" }).click();
+
+  // The crash push flips the status to error ("Disconnected") — and the
+  // restart control must be offered in exactly this state.
+  const status = window.locator('[data-testid="kernel-status"]');
+  await expect(status).toHaveAttribute("data-status", "error", { timeout: 30_000 });
+  const restart = window.locator('[data-testid="restart-session"]');
+  await expect(restart).toBeVisible();
+
+  // Restart and wait for the new session.
+  await restart.click();
+  await expect(status).toHaveAttribute("data-status", "starting", { timeout: 30_000 });
+  await expectKernelReady(window);
+
+  // The console reports what came back...
+  await expect(window.locator(".log-stdout").first()).toContainText(
+    /restored from the last autosave/i,
+    { timeout: 30_000 },
+  );
+
+  // ...the tree value survived...
+  await expect(
+    window.locator(".tree-row", { hasText: "crash_survivor" }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // ...and is live in the new session.
+  await editor.focus();
+  await window.keyboard.press(`${modifier}+a`);
+  await window.keyboard.type("pdv_tree['crash_survivor']");
+  await window.getByRole("button", { name: "Execute" }).click();
+  await expect(window.locator(".log-result").last()).toHaveText("456", {
+    timeout: 30_000,
+  });
+});

--- a/electron/e2e/execute-error.spec.ts
+++ b/electron/e2e/execute-error.spec.ts
@@ -17,12 +17,13 @@
 import { test, expect } from "@playwright/test";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 
 let launched: LaunchedApp;
 
 test.beforeAll(async () => {
   launched = await launchPDV();
-  await launched.window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(launched.window);
   await expectKernelReady(launched.window);
 });
 

--- a/electron/e2e/helpers/launch.ts
+++ b/electron/e2e/helpers/launch.ts
@@ -14,7 +14,6 @@ import * as os from "os";
 import * as path from "path";
 
 const ELECTRON_ROOT = path.resolve(__dirname, "..", "..");
-const PYTHON_PACKAGE_DIR = path.resolve(ELECTRON_ROOT, "..", "pdv-python");
 // Persistent matplotlib font cache shared across E2E runs. Without this, every
 // fresh temp HOME forces matplotlib to rebuild its font cache (~15-20s), which
 // pushes pdv.bootstrap past the 15s readyTimeoutMs in kernel-session.ts.
@@ -44,12 +43,6 @@ export interface LaunchedApp {
   cleanup: () => Promise<void>;
 }
 
-function withPythonPath(): string {
-  const existing = process.env.PYTHONPATH;
-  return existing
-    ? `${PYTHON_PACKAGE_DIR}${path.delimiter}${existing}`
-    : PYTHON_PACKAGE_DIR;
-}
 
 async function seedPreferences(
   homeDir: string,
@@ -172,7 +165,17 @@ export async function launchPDV(opts: LaunchOptions = {}): Promise<LaunchedApp> 
     } catch {
       // Already closed (test may have done it explicitly).
     }
-    await fs.rm(homeDir, { recursive: true, force: true });
+    // app.close() resolves before the OS has necessarily flushed every last
+    // write the closing session made under HOME/.PDV (a final autosave, the
+    // restart-reload's file copies). If one lands mid-walk, a plain recursive
+    // rm throws ENOTEMPTY. maxRetries/retryDelay is Node's built-in handling
+    // for exactly this class of transient rmdir race.
+    await fs.rm(homeDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
   };
 
   return { app, window, homeDir, cleanup };

--- a/electron/e2e/helpers/new-project.ts
+++ b/electron/e2e/helpers/new-project.ts
@@ -1,0 +1,21 @@
+/**
+ * new-project.ts — Start a new Python project through the setup dialog.
+ *
+ * Since the New Project dialog landed, clicking "New Python Project" on the
+ * welcome screen opens a setup dialog (Python version, packages, advanced
+ * existing-env option) instead of booting a kernel directly. Every spec that
+ * cold-starts a project goes through this helper so the extra Create click
+ * lives in one place.
+ */
+
+import type { Page } from "@playwright/test";
+
+/**
+ * Click "New Python Project" on the welcome screen, then confirm the setup
+ * dialog with its defaults (Python version + default packages), which kicks
+ * off the uv environment build and kernel boot.
+ */
+export async function createNewPythonProject(window: Page): Promise<void> {
+  await window.getByRole("button", { name: "New Python Project" }).click();
+  await window.getByTestId("new-project-create").click();
+}

--- a/electron/e2e/kernel-handshake-failure.spec.ts
+++ b/electron/e2e/kernel-handshake-failure.spec.ts
@@ -18,6 +18,7 @@ import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const electronPackage = require("../package.json") as { version: string };
 
@@ -73,7 +74,7 @@ test.afterAll(async () => {
 
 test("bootstrap failure surfaces the multi-line diagnostic in the env-settings dialog", async () => {
   const { window } = launched;
-  await window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(window);
 
   // New Python Project boots a uv-mode kernel, so a bootstrap-step handshake
   // failure now routes through launchUvKernel → setUvSync({phase:"failed"}),

--- a/electron/e2e/mcp-agent-coupling.spec.ts
+++ b/electron/e2e/mcp-agent-coupling.spec.ts
@@ -30,6 +30,7 @@ import { test, expect } from "@playwright/test";
 import type { McpStatus, PDVApi } from "../renderer/src/types/pdv";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 
 let launched: LaunchedApp;
 
@@ -41,7 +42,7 @@ test.beforeAll(async () => {
       mcp: { mutatingToolsEnabled: true, pdvRunEnabled: true },
     },
   });
-  await launched.window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(launched.window);
   await expectKernelReady(launched.window);
 });
 

--- a/electron/e2e/namespace.spec.ts
+++ b/electron/e2e/namespace.spec.ts
@@ -15,12 +15,13 @@
 import { test, expect } from "@playwright/test";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 
 let launched: LaunchedApp;
 
 test.beforeAll(async () => {
   launched = await launchPDV();
-  await launched.window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(launched.window);
   await expectKernelReady(launched.window);
 });
 

--- a/electron/e2e/new-project-dialog.spec.ts
+++ b/electron/e2e/new-project-dialog.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * new-project-dialog.spec.ts — Creation-time environment setup (§10.5.8).
+ *
+ * The New Project dialog is the creation-time home of the environment
+ * choice: Python version (pinned via uv's `.python-version`), initial
+ * packages, and (behind Advanced) an existing shared environment. This spec
+ * pins the default uv path end to end:
+ *
+ * 1. Welcome → New Python Project opens the dialog with the defaults
+ *    (default version preselected, default packages prefilled).
+ * 2. Create boots a uv kernel.
+ * 3. Saving records `environment.mode: "uv"` + a resolved `python_version`
+ *    in project.json, and the `.python-version` pin lands in the save dir.
+ */
+
+import { test, expect } from "@playwright/test";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { expectKernelReady } from "./helpers/kernel-status";
+import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { sendMenuAction } from "./helpers/menu-action";
+
+let launched: LaunchedApp;
+
+test.beforeAll(async () => {
+  launched = await launchPDV();
+});
+
+test.afterAll(async () => {
+  await launched?.cleanup();
+});
+
+test("dialog defaults → uv project → manifest records environment", async () => {
+  test.setTimeout(180_000);
+  const { window } = launched;
+  const saveDir = await fs.mkdtemp(path.join(os.tmpdir(), "pdv-e2e-newproj-"));
+
+  try {
+    // ── 1. The welcome button opens the dialog with defaults ─────────────
+    await window.getByRole("button", { name: "New Python Project" }).click();
+    const dialog = window.getByTestId("new-project-dialog");
+    await expect(dialog).toBeVisible();
+    // Default packages prefilled from config (numpy, matplotlib).
+    await expect(window.getByTestId("new-project-packages")).toHaveValue(
+      /numpy.*matplotlib/,
+    );
+
+    // ── 2. Create with defaults boots a uv kernel ────────────────────────
+    await window.getByTestId("new-project-create").click();
+    await expect(dialog).toBeHidden();
+    await expectKernelReady(window);
+
+    // ── 3. Save → manifest + pin land in the save dir ────────────────────
+    await sendMenuAction(launched.app, { action: "project:save", path: saveDir });
+    await expect
+      .poll(async () => {
+        try {
+          await fs.stat(path.join(saveDir, "project.json"));
+          return true;
+        } catch {
+          return false;
+        }
+      }, { timeout: 30_000 })
+      .toBe(true);
+
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(saveDir, "project.json"), "utf8"),
+    ) as {
+      environment?: { mode?: string; python_version?: string };
+      interpreter_path?: string;
+    };
+    expect(manifest.environment?.mode).toBe("uv");
+    // Resolved from the live venv interpreter at kernel start.
+    expect(manifest.environment?.python_version).toMatch(/^3\.\d+$/);
+    // uv projects never record an interpreter path — the venv is ephemeral.
+    expect(manifest.interpreter_path).toBeUndefined();
+
+    // The uv version pin rides ENV_FILES into the save dir.
+    const pin = await fs.readFile(path.join(saveDir, ".python-version"), "utf8");
+    expect(pin.trim()).toMatch(/^3\.\d+$/);
+  } finally {
+    await fs.rm(saveDir, { recursive: true, force: true });
+  }
+});

--- a/electron/e2e/project-roundtrip-checksum.spec.ts
+++ b/electron/e2e/project-roundtrip-checksum.spec.ts
@@ -21,6 +21,7 @@ import * as os from "os";
 import * as path from "path";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 import { sendMenuAction } from "./helpers/menu-action";
 
 const MOD = process.platform === "darwin" ? "Meta" : "Control";
@@ -208,7 +209,7 @@ pdv_tree["nested_types.edges.complex_nested"] = {
 `;
 
 async function bootKernel(window: Page): Promise<void> {
-  await window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(window);
   await expectKernelReady(window);
   // The POPULATE script imports pandas + xarray. A fresh uv project is
   // seeded only with the user's defaultPackages (numpy + matplotlib), so

--- a/electron/e2e/project-save-load.spec.ts
+++ b/electron/e2e/project-save-load.spec.ts
@@ -16,11 +16,12 @@ import * as os from "os";
 import * as path from "path";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 import { stubDialog } from "./helpers/dialog-mock";
 import { sendMenuAction } from "./helpers/menu-action";
 
 async function bootKernel(window: import("@playwright/test").Page): Promise<void> {
-  await window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(window);
   await expectKernelReady(window);
 }
 

--- a/electron/e2e/restart-preserves-tree.spec.ts
+++ b/electron/e2e/restart-preserves-tree.spec.ts
@@ -16,12 +16,13 @@
 import { test, expect } from "@playwright/test";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 
 let launched: LaunchedApp;
 
 test.beforeAll(async () => {
   launched = await launchPDV();
-  await launched.window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(launched.window);
   await expectKernelReady(launched.window);
 });
 

--- a/electron/e2e/restart-preserves-tree.spec.ts
+++ b/electron/e2e/restart-preserves-tree.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * restart-preserves-tree.spec.ts — Restarting the session keeps the tree.
+ *
+ * Regression coverage for the restart data-loss fix: restarting used to
+ * wipe the in-memory tree (unsaved sessions entirely; saved projects
+ * reverted to their last explicit save). The restart flow now snapshots
+ * the tree into `.autosave` while the old session is still alive and
+ * restores it into the new one, and the StatusBar exposes the Restart
+ * control that drives it.
+ *
+ * Flow: new unsaved project → put a value in the tree → StatusBar
+ * Restart → session comes back → the value is still in the tree and
+ * still readable from a code cell.
+ */
+
+import { test, expect } from "@playwright/test";
+import { expectKernelReady } from "./helpers/kernel-status";
+import { launchPDV, type LaunchedApp } from "./helpers/launch";
+
+let launched: LaunchedApp;
+
+test.beforeAll(async () => {
+  launched = await launchPDV();
+  await launched.window.getByRole("button", { name: "New Python Project" }).click();
+  await expectKernelReady(launched.window);
+});
+
+test.afterAll(async () => {
+  await launched?.cleanup();
+});
+
+test("tree survives a session restart in an unsaved project", async () => {
+  test.setTimeout(180_000);
+  const { window } = launched;
+
+  // Put a value in the tree and confirm it shows up.
+  const editor = window.getByRole("textbox", { name: "Editor content" });
+  await editor.focus();
+  await window.keyboard.type("pdv_tree['restart_survivor'] = 123");
+  await window.getByRole("button", { name: "Execute" }).click();
+  await expect(
+    window.locator(".tree-row", { hasText: "restart_survivor" }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Restart via the StatusBar control. Wait for the status to leave
+  // "ready" so the follow-up ready-wait can't pass on the old session.
+  const status = window.locator('[data-testid="kernel-status"]');
+  await window.locator('[data-testid="restart-session"]').click();
+  await expect(status).toHaveAttribute("data-status", "starting", {
+    timeout: 30_000,
+  });
+  await expectKernelReady(window);
+
+  // The tree value must have survived the restart...
+  await expect(
+    window.locator(".tree-row", { hasText: "restart_survivor" }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // ...and be live in the new session, not just displayed.
+  await editor.focus();
+  await window.keyboard.press(process.platform === "darwin" ? "Meta+a" : "Control+a");
+  await window.keyboard.type("pdv_tree['restart_survivor']");
+  await window.getByRole("button", { name: "Execute" }).click();
+  await expect(window.locator(".log-result").last()).toHaveText("123", {
+    timeout: 30_000,
+  });
+});

--- a/electron/e2e/script-run.spec.ts
+++ b/electron/e2e/script-run.spec.ts
@@ -21,12 +21,13 @@ import * as fs from "fs/promises";
 import type { PDVApi } from "../renderer/src/types/pdv";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 
 let launched: LaunchedApp;
 
 test.beforeAll(async () => {
   launched = await launchPDV();
-  await launched.window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(launched.window);
   await expectKernelReady(launched.window);
 });
 

--- a/electron/e2e/startup.spec.ts
+++ b/electron/e2e/startup.spec.ts
@@ -9,6 +9,7 @@
 import { test, expect } from "@playwright/test";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 
 let launched: LaunchedApp;
 
@@ -28,10 +29,24 @@ test("welcome screen is visible on startup", async () => {
 
 test("clicking New Python Project boots a kernel and reaches Connected", async () => {
   const { window } = launched;
-  await window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(window);
 
   // The kernel transitions: disconnected → starting → ready. Assert against
   // the underlying state machine value via `data-status` so a UI copy change
   // doesn't break this spec.
   await expectKernelReady(window);
+});
+
+test("with a session running, the Default Runtime tab is future-sessions-only (§10.5.19)", async () => {
+  const { window } = launched;
+  // Depends on the previous test's booted kernel (tests in this file run in
+  // order against one app instance).
+  await expectKernelReady(window);
+
+  // Open Settings → Default Runtime via the status-bar runtime chip.
+  await window.getByTestId("runtime-chip").click();
+  await expect(window.getByTestId("runtime-future-note")).toBeVisible({ timeout: 15_000 });
+  await expect(window.getByTestId("runtime-future-note")).toContainText(/future sessions/i);
+  // Close settings so later specs start from a clean UI.
+  await window.getByRole("button", { name: "Close settings" }).click();
 });

--- a/electron/e2e/tree-create-and-run.spec.ts
+++ b/electron/e2e/tree-create-and-run.spec.ts
@@ -11,12 +11,13 @@
 import { test, expect } from "@playwright/test";
 import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
 
 let launched: LaunchedApp;
 
 test.beforeAll(async () => {
   launched = await launchPDV();
-  await launched.window.getByRole("button", { name: "New Python Project" }).click();
+  await createNewPythonProject(launched.window);
   await expectKernelReady(launched.window);
 });
 

--- a/electron/main/app.ts
+++ b/electron/main/app.ts
@@ -237,7 +237,7 @@ export async function createWindow(
   // immediately confirm (clean), then calls `confirmClose`, which sets
   // `allowClose=true` and re-invokes `app.quit()`. On the second pass we fall
   // through the `allowClose` gate and the quit proceeds normally.
-  app.on("before-quit", (event) => {
+  const beforeQuitGuard = (event: Electron.Event): void => {
     if (skipCloseGuard || allowClose) {
       isQuittingGlobal = true;
       quitRequestPending = false;
@@ -251,6 +251,14 @@ export async function createWindow(
     event.preventDefault();
     quitRequestPending = true;
     win.webContents.send(IPC.push.requestClose);
+  };
+  app.on("before-quit", beforeQuitGuard);
+  // The guard belongs to this window. Detach it when the window goes away:
+  // otherwise every macOS close → activate → re-create cycle stacks another
+  // handler whose destroyed-window branch flips isQuittingGlobal before the
+  // live window's guard has decided whether to block the quit.
+  win.on("closed", () => {
+    app.removeListener("before-quit", beforeQuitGuard);
   });
 
   // Reset in-memory project state on every renderer load/reload so that stale

--- a/electron/main/atomic-write.ts
+++ b/electron/main/atomic-write.ts
@@ -46,6 +46,7 @@
  */
 
 import * as fs from "fs/promises";
+import * as fsSync from "fs";
 import * as path from "path";
 
 /**
@@ -121,6 +122,38 @@ export async function atomicWriteJson(
 ): Promise<void> {
   const body = JSON.stringify(value, null, indent) + "\n";
   await atomicWriteFile(filePath, body, "utf8");
+}
+
+/**
+ * Synchronous variant of {@link atomicWriteFile}.
+ *
+ * For callers that must stay synchronous — notably ``ConfigStore``'s
+ * ``persist()``, whose write of ``preferences.json`` previously used a
+ * bare ``writeFileSync``: a crash mid-write left a torn file that the
+ * next boot backed up and reset, silently discarding all settings
+ * (including the persisted MCP auth token).
+ *
+ * @param filePath - Absolute path of the file to write.
+ * @param data - Contents to write, encoded as UTF-8.
+ * @returns Nothing.
+ * @throws {Error} When the parent directory cannot be created, the temp
+ *   file cannot be written, or the rename fails. The temp file is
+ *   removed before the error propagates.
+ */
+export function atomicWriteFileSync(filePath: string, data: string): void {
+  fsSync.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmp = filePath + TMP_SUFFIX;
+  try {
+    fsSync.writeFileSync(tmp, data, "utf8");
+    fsSync.renameSync(tmp, filePath);
+  } catch (err) {
+    try {
+      fsSync.rmSync(tmp, { force: true });
+    } catch {
+      /* best-effort temp cleanup; the original error propagates */
+    }
+    throw err;
+  }
 }
 
 /**

--- a/electron/main/config.ts
+++ b/electron/main/config.ts
@@ -17,6 +17,8 @@
 import * as fs from "fs";
 import * as path from "path";
 
+import { atomicWriteFileSync } from "./atomic-write";
+
 import {
   TERMINAL_PRESET_LIST,
   type AgentLauncherConfig,
@@ -615,8 +617,11 @@ export class ConfigStore {
     }
   }
 
-  // Persist current in-memory state to disk.
+  // Persist current in-memory state to disk. Atomic (tmp + rename): a
+  // crash mid-write must not tear preferences.json — the loader treats
+  // an unparseable file as corrupt and resets ALL settings, including
+  // the persisted MCP auth token.
   private persist(): void {
-    fs.writeFileSync(this.configPath, JSON.stringify(this.state, null, 2), "utf8");
+    atomicWriteFileSync(this.configPath, JSON.stringify(this.state, null, 2));
   }
 }

--- a/electron/main/environment-detector.ts
+++ b/electron/main/environment-detector.ts
@@ -24,6 +24,7 @@ import * as os from "os";
 import * as fs from "fs";
 import { BrowserWindow } from "electron";
 import { coreVersion, getAppVersion } from "./pdv-protocol";
+import { parseMajorMinor } from "./python-versions";
 
 const execFileAsync = promisify(execFile);
 
@@ -293,6 +294,33 @@ export class EnvironmentDetector {
    */
   static async listAll(): Promise<DetectedEnvironment[]> {
     return EnvironmentDetector.detectEnvironments();
+  }
+
+  /**
+   * Resolve the ``major.minor`` Python version of an interpreter.
+   *
+   * Runs ``<python> --version`` with {@link PROBE_TIMEOUT_MS}. Used to
+   * record the authoritative Python version of a kernel's environment in
+   * the project manifest (§10.5). Never throws.
+   *
+   * @param pythonPath - Path to the Python executable to probe.
+   * @returns The ``"major.minor"`` string (e.g. ``"3.13"``), or undefined
+   *   when the executable is missing, times out, or prints no version.
+   */
+  static async resolvePythonMajorMinor(
+    pythonPath: string
+  ): Promise<string | undefined> {
+    try {
+      const { stdout, stderr } = await execFileAsync(
+        pythonPath,
+        ["--version"],
+        { timeout: PROBE_TIMEOUT_MS }
+      );
+      // Python 2 prints to stderr; Python 3 prints to stdout.
+      return parseMajorMinor((stdout + stderr).trim());
+    } catch {
+      return undefined;
+    }
   }
 
   /**

--- a/electron/main/index.test.ts
+++ b/electron/main/index.test.ts
@@ -931,10 +931,14 @@ describe("Step 5 IPC handlers", () => {
   it("kernels:restart falls back to stop+start when restart() is absent", async () => {
     const { kernelManager } = setup();
     const restart = getHandler(IPC.kernels.restart);
-    const result = (await restart({}, "kernel-1")) as KernelInfo;
+    const result = (await restart({}, "kernel-1")) as {
+      kernel: KernelInfo;
+      restoredFromAutosave: boolean;
+    };
     expect(kernelManager.stop).toHaveBeenCalledWith("kernel-1");
     expect(kernelManager.start).toHaveBeenCalled();
-    expect(result).toMatchObject({ id: expect.any(String), status: "idle" });
+    expect(result.kernel).toMatchObject({ id: expect.any(String), status: "idle" });
+    expect(result.restoredFromAutosave).toBe(false);
   });
 
   it("kernels:complete delegates to KernelManager.complete", async () => {
@@ -1205,6 +1209,10 @@ describe("Step 5 IPC handlers", () => {
     expect(projectManager.save).toHaveBeenCalledWith("/tmp/project", cells, {
       language: "python",
       interpreterPath: undefined,
+      projectName: undefined,
+      // No active kernel in this harness → explicit shared-mode recording
+      // (§10.5): the manifest states its environment rather than omitting it.
+      environment: { mode: "shared" },
     });
     expect(result).toEqual({ checksum: "abc123", nodeCount: 0 });
   });

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,7 +1,7 @@
 /**
  * index.ts — IPC handler registration and comm push forwarding.
  *
- * Registers all `ipcMain.handle(...)` channels consumed by the preload
+ * Registers all `handleIpc(...)` channels consumed by the preload
  * `window.pdv` API. Each handler translates renderer requests into either:
  * - direct `KernelManager` operations, or
  * - PDV comm requests via `CommRouter`.
@@ -15,7 +15,8 @@
  * ipc.ts — channel constants and API types
  */
 
-import { ipcMain, BrowserWindow, app } from "electron";
+import { BrowserWindow, app } from "electron";
+import { handleIpc, removeAllIpcHandlers } from "./ipc-registry";
 import * as fs from "fs/promises";
 import * as fsSync from "fs";
 import * as os from "os";
@@ -25,7 +26,10 @@ import { CommRouter } from "./comm-router";
 import { QueryRouter } from "./query-router";
 import { EnvironmentDetector } from "./environment-detector";
 import { buildEditorSpawn, resolveEditorSpawn } from "./editor-spawn";
-import { registerKernelIpcHandlers } from "./ipc-register-kernels";
+import {
+  registerKernelIpcHandlers,
+  removeKernelMemoryListener,
+} from "./ipc-register-kernels";
 import { registerModulesIpcHandlers } from "./ipc-register-modules";
 import { registerProjectIpcHandlers } from "./ipc-register-project";
 import { shouldBumpOnSwap } from "./mcp/generation-guard";
@@ -96,97 +100,6 @@ const DEFAULT_CONFIG: PDVConfig = {
   showCallableVariables: false,
   autoRefreshNamespace: false,
 };
-
-const REGISTERED_CHANNELS: readonly string[] = [
-  IPC.kernels.list,
-  IPC.kernels.start,
-  IPC.kernels.stop,
-  IPC.kernels.execute,
-  IPC.kernels.interrupt,
-  IPC.kernels.restart,
-  IPC.kernels.complete,
-  IPC.kernels.inspect,
-  IPC.kernels.validate,
-  IPC.tree.list,
-  IPC.tree.get,
-  IPC.tree.createScript,
-  IPC.tree.createNote,
-  IPC.tree.addFile,
-  IPC.tree.createNode,
-  IPC.tree.rename,
-  IPC.tree.move,
-  IPC.tree.duplicate,
-  IPC.tree.invokeHandler,
-  IPC.tree.delete,
-  IPC.namespace.query,
-  IPC.namespace.inspect,
-  IPC.script.edit,
-  IPC.script.run,
-  IPC.script.getParams,
-  IPC.note.save,
-  IPC.note.read,
-  IPC.modules.listInstalled,
-  IPC.modules.install,
-  IPC.modules.checkUpdates,
-  IPC.modules.importToProject,
-  IPC.modules.listImported,
-  IPC.modules.saveSettings,
-  IPC.modules.runAction,
-  IPC.modules.removeImport,
-  IPC.modules.uninstall,
-  IPC.modules.update,
-  IPC.namelist.read,
-  IPC.namelist.write,
-  IPC.project.save,
-  IPC.project.load,
-  IPC.project.new,
-  IPC.project.peekLanguages,
-  IPC.project.peekManifest,
-  IPC.config.get,
-  IPC.config.set,
-  IPC.themes.get,
-  IPC.themes.save,
-  IPC.themes.openDir,
-  IPC.codeCells.load,
-  IPC.codeCells.save,
-  IPC.menu.updateRecentProjects,
-  IPC.menu.updateEnabled,
-  IPC.menu.getModel,
-  IPC.menu.popup,
-  IPC.chrome.getInfo,
-  IPC.chrome.minimize,
-  IPC.chrome.toggleMaximize,
-  IPC.chrome.close,
-  IPC.app.confirmClose,
-  IPC.moduleWindows.open,
-  IPC.moduleWindows.close,
-  IPC.moduleWindows.context,
-  IPC.moduleWindows.executeInMain,
-  IPC.guiEditor.open,
-  IPC.guiEditor.openViewer,
-  IPC.guiEditor.context,
-  IPC.guiEditor.read,
-  IPC.guiEditor.save,
-  IPC.tree.createGui,
-  IPC.files.pickExecutable,
-  IPC.files.pickFile,
-  IPC.files.pickDirectory,
-  IPC.about.getVersion,
-  IPC.updater.checkForUpdates,
-  IPC.updater.downloadUpdate,
-  IPC.updater.installUpdate,
-  IPC.updater.openReleasesPage,
-  IPC.environment.list,
-  IPC.environment.check,
-  IPC.environment.install,
-  IPC.environment.refresh,
-  IPC.autosave.run,
-  IPC.autosave.clear,
-  IPC.autosave.check,
-  IPC.autosave.scanWorkingDirs,
-  IPC.autosave.recoverUnsaved,
-  IPC.autosave.deleteOrphan,
-];
 
 interface PushSubscription {
   commRouter: CommRouter;
@@ -436,7 +349,7 @@ function clearPushSubscriptions(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Register all `ipcMain.handle(...)` channels required by Step 5.
+ * Register all `handleIpc(...)` channels required by Step 5.
  *
  * @param win - Main browser window used for push forwarding.
  * @param kernelManager - Kernel manager instance.
@@ -597,6 +510,13 @@ export function registerIpcHandlers(
     getDefaultPackages: () => readConfig(configStore).defaultPackages ?? [],
     getUvBinaryPath: () => readConfig(configStore).uv?.binaryPath,
     bindActiveProjectModules,
+    // Function declarations below in this scope — hoisted, so referencing
+    // them here is safe. Defined next to the autosave IPC handlers whose
+    // logic they share.
+    autosaveBeforeRestart,
+    recoverUnsavedAfterRestart: async (orphanDir: string) => {
+      await recoverUnsavedSession(orphanDir);
+    },
   });
 
   // Aggregate module aliases from the active on-disk manifest plus any
@@ -751,7 +671,7 @@ export function registerIpcHandlers(
       console.warn("[env] failed to refresh kernel import caches:", err);
     }
   };
-  ipcMain.handle(IPC.environment.listPackages, async (): Promise<ProjectPackage[]> => {
+  handleIpc(IPC.environment.listPackages, async (): Promise<ProjectPackage[]> => {
     if (!activeKernelId) return [];
     const workingDir = kernelWorkingDirs.get(activeKernelId);
     if (!workingDir) return [];
@@ -783,7 +703,7 @@ export function registerIpcHandlers(
       return { spec, name, installedVersion: installed.get(name) };
     });
   });
-  ipcMain.handle(
+  handleIpc(
     IPC.environment.addPackage,
     async (_event, specs: string[]): Promise<EnvironmentInstallResult> => {
       const result = await uvAdd(specs, pkgRunOptions());
@@ -791,7 +711,7 @@ export function registerIpcHandlers(
       return { success: result.success, output: result.output };
     }
   );
-  ipcMain.handle(
+  handleIpc(
     IPC.environment.removePackage,
     async (_event, names: string[]): Promise<EnvironmentInstallResult> => {
       const result = await uvRemove(names, pkgRunOptions());
@@ -799,7 +719,7 @@ export function registerIpcHandlers(
       return { success: result.success, output: result.output };
     }
   );
-  ipcMain.handle(
+  handleIpc(
     IPC.environment.upgradePackage,
     async (_event, names: string[]): Promise<EnvironmentInstallResult> => {
       const opts = pkgRunOptions();
@@ -825,7 +745,19 @@ export function registerIpcHandlers(
     win.webContents.send(IPC.push.autosaveTrigger);
   }
 
-  ipcMain.handle(IPC.autosave.run, async (_event, codeCells: unknown) => {
+  /**
+   * Core autosave routine, shared by the renderer-triggered
+   * ``autosave.run`` IPC handler and the pre-restart snapshot.
+   *
+   * Saves the tree into ``<baseDir>/.autosave`` (the project dir when one
+   * is active, else the session working dir) and mirrors the
+   * manifest/module sidecars needed for recovery.
+   *
+   * @param codeCells - Code-cell state to bundle with the snapshot.
+   * @returns ``{ saved: boolean }`` — false when there is nowhere to save
+   *   (no project dir or working dir) or the kernel-side save failed.
+   */
+  async function performAutosave(codeCells: CodeCellData): Promise<{ saved: boolean }> {
     const baseDir = activeProjectDir || kernelWorkingDirs.get(activeKernelId ?? "");
     if (!baseDir) {
       console.warn(
@@ -853,7 +785,7 @@ export function registerIpcHandlers(
       win.webContents.send(IPC.push.autosaveStarted);
       try {
         const autosaveDir = autosaveDirFor(baseDir);
-        const result = await projectManager.autosave(autosaveDir, codeCells as CodeCellData);
+        const result = await projectManager.autosave(autosaveDir, codeCells);
         if (result === null) return { saved: false };
 
         await mirrorAutosaveSidecars(
@@ -874,9 +806,53 @@ export function registerIpcHandlers(
         win.webContents.send(IPC.push.autosaveEnded);
       }
     });
+  }
+
+  handleIpc(IPC.autosave.run, async (_event, codeCells: unknown) => {
+    return performAutosave(codeCells as CodeCellData);
   });
 
-  ipcMain.handle(IPC.autosave.clear, async (_event, dir?: string) => {
+  /**
+   * Pre-restart snapshot (see ``RegisterKernelIpcHandlersOptions``).
+   *
+   * Reads the code cells from the working dir's ``code-cells.json`` (the
+   * renderer mirrors its tabs there on a debounce, so the on-disk copy is
+   * at most one debounce window behind) and takes a fresh autosave. When
+   * the server is not idle — a hung server is often *why* the user is
+   * restarting — the fresh save is skipped rather than stalling the
+   * restart on a comm request that may never answer; any snapshot from
+   * the timer-based autosave loop is reported instead.
+   *
+   * @param kernelId - The server session being restarted.
+   * @returns True when ``<baseDir>/.autosave`` holds a usable snapshot.
+   */
+  async function autosaveBeforeRestart(kernelId: string): Promise<boolean> {
+    const workingDir = kernelWorkingDirs.get(kernelId);
+    const baseDir = activeProjectDir || workingDir;
+    if (!baseDir) return false;
+
+    if (kernelManager.getExecutionState(kernelId) === "idle") {
+      let codeCells: CodeCellData = { tabs: [], activeTabId: 1 };
+      if (workingDir) {
+        try {
+          codeCells = JSON.parse(
+            await fs.readFile(path.join(workingDir, "code-cells.json"), "utf8"),
+          ) as CodeCellData;
+        } catch {
+          /* no cells mirrored yet — snapshot the tree with empty cells */
+        }
+      }
+      const result = await performAutosave(codeCells);
+      if (result.saved) return true;
+    } else {
+      console.warn(
+        "[autosave] pre-restart snapshot skipped: server not idle; falling back to the last timer autosave",
+      );
+    }
+    return (await ProjectManager.checkForAutosave(baseDir)).exists;
+  }
+
+  handleIpc(IPC.autosave.clear, async (_event, dir?: string) => {
     const target = dir || activeProjectDir || kernelWorkingDirs.get(activeKernelId ?? "");
     if (target) {
       // Order matters: clear the kernel-side cache *before* deleting the
@@ -891,11 +867,11 @@ export function registerIpcHandlers(
     }
   });
 
-  ipcMain.handle(IPC.autosave.check, async (_event, dir: string) => {
+  handleIpc(IPC.autosave.check, async (_event, dir: string) => {
     return ProjectManager.checkForAutosave(dir);
   });
 
-  ipcMain.handle(IPC.autosave.scanWorkingDirs, async () => {
+  handleIpc(IPC.autosave.scanWorkingDirs, async () => {
     const config = readConfig(configStore);
     const base = config.workingDirBase || path.join(os.homedir(), ".PDV", "working");
     const results = await ProjectManager.scanForAutosaves(base);
@@ -908,7 +884,20 @@ export function registerIpcHandlers(
       : results;
   });
 
-  ipcMain.handle(IPC.autosave.recoverUnsaved, async (_event, orphanDir: string) => {
+  /**
+   * Restore an unsaved session's ``.autosave`` snapshot from ``orphanDir``
+   * into the active session's working dir, load the tree/cells from it,
+   * and delete the orphan. Shared by the welcome screen's Recover flow
+   * (``autosave.recoverUnsaved``) and the post-restart recovery callback
+   * passed to ``registerKernelIpcHandlers``.
+   *
+   * @param orphanDir - Working directory of the orphaned session.
+   * @returns The recovered code cells and any files that could not be
+   *   copied from the orphan.
+   * @throws {Error} When there is no active server session to recover
+   *   into, or the orphan dir is the active working dir.
+   */
+  async function recoverUnsavedSession(orphanDir: string) {
     if (!activeKernelId) {
       throw new Error("Cannot recover unsaved session: no active kernel");
     }
@@ -1016,9 +1005,13 @@ export function registerIpcHandlers(
       projectName: null,
       missingFiles: missingFiles.length > 0 ? missingFiles : undefined,
     };
+  }
+
+  handleIpc(IPC.autosave.recoverUnsaved, async (_event, orphanDir: string) => {
+    return recoverUnsavedSession(orphanDir);
   });
 
-  ipcMain.handle(IPC.autosave.deleteOrphan, async (_event, orphanDir: string) => {
+  handleIpc(IPC.autosave.deleteOrphan, async (_event, orphanDir: string) => {
     // Defense in depth: the renderer-side scan already filters this out, but
     // never let a bug or stale list cause us to rm -rf the live working dir.
     const activeWorkingDir = activeKernelId ? kernelWorkingDirs.get(activeKernelId) : undefined;
@@ -1156,20 +1149,20 @@ export function setMcpServerInstance(
  */
 function registerEnvironmentIpcHandlers(win: BrowserWindow, configStore: ConfigStore): void {
 
-  ipcMain.handle(IPC.environment.list, async () => {
+  handleIpc(IPC.environment.list, async () => {
     const config = configStore.getAll();
     return EnvironmentDetector.listEnvironmentInfo(config.pythonPath);
   });
 
-  ipcMain.handle(IPC.environment.check, async (_event, pythonPath: string) => {
+  handleIpc(IPC.environment.check, async (_event, pythonPath: string) => {
     return EnvironmentDetector.checkEnvironment(pythonPath);
   });
 
-  ipcMain.handle(IPC.environment.install, async (_event, pythonPath: string) => {
+  handleIpc(IPC.environment.install, async (_event, pythonPath: string) => {
     return EnvironmentDetector.installPDVFromBundle(pythonPath, win, IPC.push.installOutput);
   });
 
-  ipcMain.handle(IPC.environment.refresh, async () => {
+  handleIpc(IPC.environment.refresh, async () => {
     EnvironmentDetector.clearCache();
     const config = configStore.getAll();
     return EnvironmentDetector.listEnvironmentInfo(config.pythonPath);
@@ -1282,9 +1275,8 @@ export function registerCommPushForwarding(
  * @returns Nothing.
  */
 export function unregisterIpcHandlers(): void {
-  for (const channel of REGISTERED_CHANNELS) {
-    ipcMain.removeHandler(channel);
-  }
+  removeAllIpcHandlers();
+  removeKernelMemoryListener();
   if (trackedExecutionStateListener) {
     trackedExecutionStateListener.km.removeListener(
       "kernel:executionState",

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -61,6 +61,7 @@ import {
   ModuleHealthWarning,
   NamespaceQueryOptions,
   PDVConfig,
+  type ActiveEnvironmentInfo,
   type CodeCellData,
   type EnvironmentInstallResult,
   type McpStatus,
@@ -109,6 +110,15 @@ interface PushSubscription {
 
 const pushSubscriptions: PushSubscription[] = [];
 const kernelWorkingDirs = new Map<string, string>();
+/**
+ * Per-kernel environment metadata: mode (uv vs shared), the interpreter the
+ * kernel actually spawned on, and its resolved Python version. Populated by
+ * `kernels.start`/`kernels.restart`, deleted on stop; survives crashes so a
+ * crash-restart can carry the environment over. Authoritative source for
+ * the manifest's `environment`/`interpreter_path` fields at save time
+ * (§10.5) and for the Project Environment settings tab (`environment:activeInfo`).
+ */
+const kernelEnvMeta = new Map<string, ActiveEnvironmentInfo>();
 const crashHandlers = new Map<string, (id: string) => void>();
 const projectManifestMutationQueue = new Map<string, Promise<void>>();
 let activeKernelManagerRef: KernelManager | null = null;
@@ -469,6 +479,7 @@ export function registerIpcHandlers(
     projectManager,
     moduleManager,
     kernelWorkingDirs,
+    kernelEnvMeta,
     crashHandlers,
     resetProjectState: () => {
       activeProjectDir = null;
@@ -615,6 +626,8 @@ export function registerIpcHandlers(
         : "python";
       return lang === "julia" ? config.juliaPath : config.pythonPath;
     },
+    getActiveKernelEnvMeta: () =>
+      activeKernelId ? kernelEnvMeta.get(activeKernelId) : undefined,
     onExplicitSaveCompleted: (saveDir) => {
       void ProjectManager.clearAutosave(saveDir);
       projectManager.resetAutosaveTimer();
@@ -647,7 +660,7 @@ export function registerIpcHandlers(
     commRouter,
   });
 
-  registerEnvironmentIpcHandlers(win, configStore);
+  registerEnvironmentIpcHandlers(win, configStore, () => activeKernelId);
 
   // --- Packages tab (ARCHITECTURE.md §10.5.13) -----------------------------
   // Per-project package CRUD: list declared deps paired with installed
@@ -754,10 +767,15 @@ export function registerIpcHandlers(
    * manifest/module sidecars needed for recovery.
    *
    * @param codeCells - Code-cell state to bundle with the snapshot.
+   * @param opts - Optional overrides forwarded to ``projectManager.autosave``
+   *   (``timeoutMs`` bounds the kernel comm request).
    * @returns ``{ saved: boolean }`` — false when there is nowhere to save
    *   (no project dir or working dir) or the kernel-side save failed.
    */
-  async function performAutosave(codeCells: CodeCellData): Promise<{ saved: boolean }> {
+  async function performAutosave(
+    codeCells: CodeCellData,
+    opts?: { timeoutMs?: number },
+  ): Promise<{ saved: boolean }> {
     const baseDir = activeProjectDir || kernelWorkingDirs.get(activeKernelId ?? "");
     if (!baseDir) {
       console.warn(
@@ -785,7 +803,7 @@ export function registerIpcHandlers(
       win.webContents.send(IPC.push.autosaveStarted);
       try {
         const autosaveDir = autosaveDirFor(baseDir);
-        const result = await projectManager.autosave(autosaveDir, codeCells);
+        const result = await projectManager.autosave(autosaveDir, codeCells, opts);
         if (result === null) return { saved: false };
 
         await mirrorAutosaveSidecars(
@@ -817,11 +835,15 @@ export function registerIpcHandlers(
    *
    * Reads the code cells from the working dir's ``code-cells.json`` (the
    * renderer mirrors its tabs there on a debounce, so the on-disk copy is
-   * at most one debounce window behind) and takes a fresh autosave. When
-   * the server is not idle — a hung server is often *why* the user is
-   * restarting — the fresh save is skipped rather than stalling the
-   * restart on a comm request that may never answer; any snapshot from
-   * the timer-based autosave loop is reported instead.
+   * at most one debounce window behind) and takes a fresh autosave. The
+   * fresh save is attempted only when the server process is alive AND
+   * idle: a hung or crashed server is often *why* the user is restarting,
+   * and ``executionState`` can report a stale "idle" after a crash (the
+   * process exit handler never resets it), so process liveness is checked
+   * explicitly. When skipped, any snapshot from the timer-based autosave
+   * loop is reported instead. The comm request is bounded to 5 s so a
+   * wedged-but-alive server can't stall the restart on the default 30 s
+   * timeout.
    *
    * @param kernelId - The server session being restarted.
    * @returns True when ``<baseDir>/.autosave`` holds a usable snapshot.
@@ -831,7 +853,13 @@ export function registerIpcHandlers(
     const baseDir = activeProjectDir || workingDir;
     if (!baseDir) return false;
 
-    if (kernelManager.getExecutionState(kernelId) === "idle") {
+    const proc = kernelManager.getKernelProcessState(kernelId);
+    const dead =
+      !proc ||
+      proc.exitCode !== null ||
+      proc.killed ||
+      kernelManager.getKernel(kernelId)?.status === "dead";
+    if (!dead && kernelManager.getExecutionState(kernelId) === "idle") {
       let codeCells: CodeCellData = { tabs: [], activeTabId: 1 };
       if (workingDir) {
         try {
@@ -842,11 +870,13 @@ export function registerIpcHandlers(
           /* no cells mirrored yet — snapshot the tree with empty cells */
         }
       }
-      const result = await performAutosave(codeCells);
+      const result = await performAutosave(codeCells, { timeoutMs: 5000 });
       if (result.saved) return true;
     } else {
       console.warn(
-        "[autosave] pre-restart snapshot skipped: server not idle; falling back to the last timer autosave",
+        dead
+          ? "[autosave] pre-restart snapshot skipped: server process is dead; falling back to the last timer autosave"
+          : "[autosave] pre-restart snapshot skipped: server not idle; falling back to the last timer autosave",
       );
     }
     return (await ProjectManager.checkForAutosave(baseDir)).exists;
@@ -1143,11 +1173,25 @@ export function setMcpServerInstance(
 }
 
 /**
- * Register IPC handlers for Python environment discovery and installation.
+ * Register IPC handlers for Python environment discovery and installation,
+ * plus the active kernel's environment metadata (`environment:activeInfo`,
+ * consumed by the Project Environment settings tab).
  *
  * @param win - Main BrowserWindow for streaming install output.
+ * @param configStore - Config store for the configured interpreter path.
+ * @param getActiveKernelId - Accessor for the active kernel id, used to look
+ *   up `kernelEnvMeta`.
  */
-function registerEnvironmentIpcHandlers(win: BrowserWindow, configStore: ConfigStore): void {
+function registerEnvironmentIpcHandlers(
+  win: BrowserWindow,
+  configStore: ConfigStore,
+  getActiveKernelId: () => string | null
+): void {
+
+  handleIpc(IPC.environment.activeInfo, async () => {
+    const kernelId = getActiveKernelId();
+    return kernelId ? (kernelEnvMeta.get(kernelId) ?? null) : null;
+  });
 
   handleIpc(IPC.environment.list, async () => {
     const config = configStore.getAll();
@@ -1294,6 +1338,7 @@ export function unregisterIpcHandlers(): void {
     }
   }
   kernelWorkingDirs.clear();
+  kernelEnvMeta.clear();
   crashHandlers.clear();
   clearPushSubscriptions();
 }

--- a/electron/main/ipc-register-app-state.ts
+++ b/electron/main/ipc-register-app-state.ts
@@ -10,7 +10,8 @@
  * - Push forwarding between comm router and renderer.
  */
 
-import { BrowserWindow as ElectronBrowserWindow, app, dialog, ipcMain, shell, type BrowserWindow } from "electron";
+import { BrowserWindow as ElectronBrowserWindow, app, dialog, shell, type BrowserWindow } from "electron";
+import { handleIpc } from "./ipc-registry";
 import * as fs from "fs/promises";
 import * as fsSync from "fs";
 import * as path from "path";
@@ -126,24 +127,27 @@ export function registerAppStateIpcHandlers(
     }
     win.webContents.send(IPC.push.chromeStateChanged, buildWindowChromeInfo(win));
   };
+  // Deliberately untracked: these attach to the BrowserWindow itself and are
+  // released when the window is destroyed, unlike listeners on long-lived
+  // objects (app, KernelManager) which must be detached on re-registration.
   win.on("maximize", pushWindowChromeState);
   win.on("unmaximize", pushWindowChromeState);
   win.on("enter-full-screen", pushWindowChromeState);
   win.on("leave-full-screen", pushWindowChromeState);
 
-  ipcMain.handle(IPC.config.get, async () => readConfig(configStore));
+  handleIpc(IPC.config.get, async () => readConfig(configStore));
 
-  ipcMain.handle(IPC.about.getVersion, () => app.getVersion());
+  handleIpc(IPC.about.getVersion, () => app.getVersion());
 
-  ipcMain.handle(IPC.about.openRepoPage, async () => {
+  handleIpc(IPC.about.openRepoPage, async () => {
     await shell.openExternal("https://github.com/matt-pharr/physics-data-viewer");
   });
 
-  ipcMain.handle(IPC.about.openIssuesPage, async () => {
+  handleIpc(IPC.about.openIssuesPage, async () => {
     await shell.openExternal("https://github.com/matt-pharr/physics-data-viewer/issues");
   });
 
-  ipcMain.handle(IPC.about.openDocsPage, async () => {
+  handleIpc(IPC.about.openDocsPage, async () => {
     // Version-pinned docs URL. `app.getVersion()` reads the running
     // build's package.json version, so users always see the docs that
     // match the binary they're running — even if they're on an older
@@ -154,13 +158,13 @@ export function registerAppStateIpcHandlers(
 
   // Auto-updater
   initAutoUpdater(win, configStore);
-  ipcMain.handle(IPC.updater.checkForUpdates, async () => { await checkForUpdates(configStore); });
-  ipcMain.handle(IPC.updater.downloadUpdate, async () => { await downloadUpdate(); });
-  ipcMain.handle(IPC.updater.installUpdate, async () => { installUpdate(); });
-  ipcMain.handle(IPC.updater.openReleasesPage, async () => { await openReleasesPage(); });
-  ipcMain.handle(IPC.updater.getStatus, async () => getUpdateStatus());
+  handleIpc(IPC.updater.checkForUpdates, async () => { await checkForUpdates(configStore); });
+  handleIpc(IPC.updater.downloadUpdate, async () => { await downloadUpdate(); });
+  handleIpc(IPC.updater.installUpdate, async () => { installUpdate(); });
+  handleIpc(IPC.updater.openReleasesPage, async () => { await openReleasesPage(); });
+  handleIpc(IPC.updater.getStatus, async () => getUpdateStatus());
 
-  ipcMain.handle(IPC.config.set, async (_event, updates: Partial<PDVConfig>) => {
+  handleIpc(IPC.config.set, async (_event, updates: Partial<PDVConfig>) => {
     const prev = readConfig(configStore);
     const merged: PDVConfig = { ...prev, ...updates };
     for (const key of Object.keys(updates) as Array<keyof PDVConfig>) {
@@ -188,7 +192,7 @@ export function registerAppStateIpcHandlers(
     return next;
   });
 
-  ipcMain.handle(IPC.window.setBackgroundColor, (event, color: string) => {
+  handleIpc(IPC.window.setBackgroundColor, (event, color: string) => {
     // Sync the BrowserWindow's native background to the active theme's
     // bg-primary so live-resize gestures don't expose OS-default white.
     // Look up the source window so multi-window setups (gui-editor,
@@ -198,9 +202,9 @@ export function registerAppStateIpcHandlers(
     sourceWin?.setBackgroundColor(color);
   });
 
-  ipcMain.handle(IPC.themes.get, async () => savedThemes);
+  handleIpc(IPC.themes.get, async () => savedThemes);
 
-  ipcMain.handle(IPC.themes.save, async (_event, theme: Theme) => {
+  handleIpc(IPC.themes.save, async (_event, theme: Theme) => {
     const existing = savedThemes.findIndex((entry) => entry.name === theme.name);
     if (existing >= 0) {
       savedThemes[existing] = theme;
@@ -213,35 +217,35 @@ export function registerAppStateIpcHandlers(
     return true;
   });
 
-  ipcMain.handle(IPC.themes.openDir, async () => {
+  handleIpc(IPC.themes.openDir, async () => {
     await fs.mkdir(themesDir, { recursive: true });
     return shell.openPath(themesDir);
   });
 
-  ipcMain.handle(IPC.menu.updateRecentProjects, async (_event, paths: string[]) => {
+  handleIpc(IPC.menu.updateRecentProjects, async (_event, paths: string[]) => {
     updateRecentProjectsMenu(Array.isArray(paths) ? paths : []);
     return true;
   });
 
-  ipcMain.handle(IPC.menu.updateEnabled, async (_event, state: Record<string, boolean>) => {
+  handleIpc(IPC.menu.updateEnabled, async (_event, state: Record<string, boolean>) => {
     updateMenuEnabled(state);
     return true;
   });
 
-  ipcMain.handle(IPC.menu.getModel, async () => getTopLevelMenuModel());
+  handleIpc(IPC.menu.getModel, async () => getTopLevelMenuModel());
 
-  ipcMain.handle(IPC.menu.popup, async (_event, menuId: "file" | "edit" | "view" | "window", x: number, y: number) =>
+  handleIpc(IPC.menu.popup, async (_event, menuId: "file" | "edit" | "view" | "window", x: number, y: number) =>
     popupTopLevelMenu(menuId, x, y)
   );
 
-  ipcMain.handle(IPC.chrome.getInfo, async () => buildWindowChromeInfo(win));
+  handleIpc(IPC.chrome.getInfo, async () => buildWindowChromeInfo(win));
 
-  ipcMain.handle(IPC.chrome.minimize, async () => {
+  handleIpc(IPC.chrome.minimize, async () => {
     win.minimize();
     return true;
   });
 
-  ipcMain.handle(IPC.chrome.toggleMaximize, async () => {
+  handleIpc(IPC.chrome.toggleMaximize, async () => {
     if (win.isMaximized()) {
       win.unmaximize();
     } else {
@@ -250,7 +254,7 @@ export function registerAppStateIpcHandlers(
     return win.isMaximized();
   });
 
-  ipcMain.handle(IPC.chrome.close, async () => {
+  handleIpc(IPC.chrome.close, async () => {
     // Route through the same close-confirmation flow as the OS-level close
     // (`win.on('close')` in app.ts) so the title-bar X also prompts about
     // unsaved changes. The renderer will call `IPC.app.confirmClose` once
@@ -265,13 +269,13 @@ export function registerAppStateIpcHandlers(
     return true;
   });
 
-  ipcMain.handle(IPC.app.setDocumentEdited, async (_event, edited: boolean) => {
+  handleIpc(IPC.app.setDocumentEdited, async (_event, edited: boolean) => {
     if (!win.isDestroyed()) {
       win.setDocumentEdited(Boolean(edited));
     }
   });
 
-  ipcMain.handle(IPC.app.confirmClose, async () => {
+  handleIpc(IPC.app.confirmClose, async () => {
     setAllowClose(true);
     // During a real quit (Cmd+Q, autoUpdater restart, OS logout), call
     // app.quit() instead of win.close(). app.quit() will close the window
@@ -293,7 +297,7 @@ export function registerAppStateIpcHandlers(
     }
   });
 
-  ipcMain.handle(IPC.files.pickExecutable, async () => {
+  handleIpc(IPC.files.pickExecutable, async () => {
     const result = await dialog.showOpenDialog({ properties: ["openFile"] });
     if (result.canceled || result.filePaths.length === 0) {
       return null;
@@ -301,7 +305,7 @@ export function registerAppStateIpcHandlers(
     return result.filePaths[0] ?? null;
   });
 
-  ipcMain.handle(IPC.files.pickFile, async () => {
+  handleIpc(IPC.files.pickFile, async () => {
     const result = await dialog.showOpenDialog({ properties: ["openFile"] });
     if (result.canceled || result.filePaths.length === 0) {
       return null;
@@ -309,7 +313,7 @@ export function registerAppStateIpcHandlers(
     return result.filePaths[0] ?? null;
   });
 
-  ipcMain.handle(IPC.files.pickDirectory, async (_event, defaultPath?: string) => {
+  handleIpc(IPC.files.pickDirectory, async (_event, defaultPath?: string) => {
     const result = await dialog.showOpenDialog({
       properties: ["openDirectory", "createDirectory"],
       defaultPath: defaultPath || undefined,

--- a/electron/main/ipc-register-coverage.test.ts
+++ b/electron/main/ipc-register-coverage.test.ts
@@ -110,7 +110,7 @@ vi.mock("./module-manifest-writer", () => ({
   writeModuleManifest: vi.fn(async () => undefined),
 }));
 
-import { IPC } from "./ipc";
+import { IPC, type ActiveEnvironmentInfo } from "./ipc";
 import { registerKernelIpcHandlers } from "./ipc-register-kernels";
 import { registerTreeNamespaceScriptIpcHandlers } from "./ipc-register-tree-namespace-script";
 import { registerModulesIpcHandlers } from "./ipc-register-modules";
@@ -177,6 +177,7 @@ function setupAll(): void {
     autoRefreshNamespace: false,
   });
   const kernelWorkingDirs = new Map<string, string>();
+  const kernelEnvMeta = new Map<string, ActiveEnvironmentInfo>();
   const crashHandlers = new Map<string, (id: string) => void>();
 
   registerKernelIpcHandlers({
@@ -187,6 +188,7 @@ function setupAll(): void {
     projectManager,
     moduleManager,
     kernelWorkingDirs,
+    kernelEnvMeta,
     crashHandlers,
     resetProjectState: vi.fn(),
     resetKernelState: vi.fn(),
@@ -250,6 +252,7 @@ function setupAll(): void {
     runSerializedProjectManifestMutation: async (_dir, fn) => fn(),
     getMainWindow: () => win.win,
     getInterpreterPath: () => "/usr/bin/python3",
+    getActiveKernelEnvMeta: () => undefined,
   });
   registerAppStateIpcHandlers({
     win: win.win,

--- a/electron/main/ipc-register-coverage.test.ts
+++ b/electron/main/ipc-register-coverage.test.ts
@@ -197,6 +197,8 @@ function setupAll(): void {
     getDefaultPackages: () => [],
     getUvBinaryPath: () => undefined,
     bindActiveProjectModules: vi.fn(async () => undefined),
+    autosaveBeforeRestart: vi.fn(async () => false),
+    recoverUnsavedAfterRestart: vi.fn(async () => undefined),
   });
   registerTreeNamespaceScriptIpcHandlers({
     kernelManager,

--- a/electron/main/ipc-register-gui-editor.test.ts
+++ b/electron/main/ipc-register-gui-editor.test.ts
@@ -23,6 +23,12 @@ const fsMocks = vi.hoisted(() => ({
   writeFile: vi.fn(async (_path: string, _contents: string, _encoding?: string) => undefined),
 }));
 
+// `save` delegates to atomicWriteFile (tmp + rename) so a crash can't
+// tear the .gui.json manifest; mock at that seam rather than raw fs.
+const atomicWriteMocks = vi.hoisted(() => ({
+  atomicWriteFile: vi.fn(async (_path: string, _contents: string | Buffer) => undefined),
+}));
+
 vi.mock("electron", () => ({
   ipcMain: {
     handle: ipcRegistry.ipcHandle,
@@ -33,6 +39,10 @@ vi.mock("electron", () => ({
 vi.mock("fs/promises", () => ({
   readFile: fsMocks.readFile,
   writeFile: fsMocks.writeFile,
+}));
+
+vi.mock("./atomic-write", () => ({
+  atomicWriteFile: atomicWriteMocks.atomicWriteFile,
 }));
 
 import { IPC } from "./ipc";
@@ -182,10 +192,9 @@ describe("guiEditor:save", () => {
       manifest,
     });
 
-    expect(fsMocks.writeFile).toHaveBeenCalledTimes(1);
-    const [filePath, contents, encoding] = fsMocks.writeFile.mock.calls[0];
+    expect(atomicWriteMocks.atomicWriteFile).toHaveBeenCalledTimes(1);
+    const [filePath, contents] = atomicWriteMocks.atomicWriteFile.mock.calls[0];
     expect(filePath).toBe("/tmp/working/ui.gui.json");
-    expect(encoding).toBe("utf-8");
     expect(contents).toBe(JSON.stringify(manifest, null, 2) + "\n");
     expect(result).toEqual({ success: true });
   });
@@ -195,7 +204,7 @@ describe("guiEditor:save", () => {
     commRouter.request.mockResolvedValueOnce(
       makeOkResponse({ file_path: "/tmp/working/ui.gui.json" }),
     );
-    fsMocks.writeFile.mockRejectedValueOnce(new Error("EACCES"));
+    atomicWriteMocks.atomicWriteFile.mockRejectedValueOnce(new Error("EACCES"));
     setup({ commRouter });
 
     const result = (await getHandler(IPC.guiEditor.save)({}, {

--- a/electron/main/ipc-register-gui-editor.ts
+++ b/electron/main/ipc-register-gui-editor.ts
@@ -11,8 +11,9 @@
  * - GUI manifest validation or editing logic.
  */
 
-import { ipcMain } from "electron";
+import { handleIpc } from "./ipc-registry";
 import * as fs from "fs/promises";
+import { atomicWriteFile } from "./atomic-write";
 
 import {
   IPC,
@@ -70,7 +71,7 @@ export function registerGuiEditorIpcHandlers(
 ): void {
   const { guiEditorWindowManager, guiViewerWindowManager, commRouter } = options;
 
-  ipcMain.handle(
+  handleIpc(
     IPC.guiEditor.open,
     async (
       _event,
@@ -88,7 +89,7 @@ export function registerGuiEditorIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.guiEditor.openViewer,
     async (
       _event,
@@ -106,7 +107,7 @@ export function registerGuiEditorIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.guiEditor.context,
     async (event): Promise<GuiEditorContext | null> => {
       return guiEditorWindowManager.getContextForSender(event.sender.id)
@@ -114,7 +115,7 @@ export function registerGuiEditorIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.guiEditor.read,
     async (_event, treePath: string): Promise<GuiEditorReadResult> => {
       try {
@@ -131,13 +132,14 @@ export function registerGuiEditorIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.guiEditor.save,
     async (_event, request: GuiEditorSaveRequest): Promise<GuiEditorSaveResult> => {
       try {
         const filePath = await resolveGuiFilePath(commRouter, request.treePath);
         const json = JSON.stringify(request.manifest, null, 2) + "\n";
-        await fs.writeFile(filePath, json, "utf-8");
+        // Atomic: a crash mid-save must not tear the .gui.json manifest.
+        await atomicWriteFile(filePath, json);
         return { success: true };
       } catch (error) {
         return {

--- a/electron/main/ipc-register-kernels.test.ts
+++ b/electron/main/ipc-register-kernels.test.ts
@@ -39,6 +39,7 @@ const moduleRuntimeMocks = vi.hoisted(() => ({
 const projectFileSyncMocks = vi.hoisted(() => ({
   copyFilesForLoad: vi.fn(async () => undefined),
   copyEnvFilesForLoad: vi.fn(async () => []),
+  overlayAutosaveTreeFiles: vi.fn(async () => undefined),
 }));
 
 const uvEnvironmentMocks = vi.hoisted(() => ({
@@ -66,6 +67,7 @@ vi.mock("./uv-environment", () => uvEnvironmentMocks);
 
 import { IPC } from "./ipc";
 import { registerKernelIpcHandlers } from "./ipc-register-kernels";
+import { ProjectManager } from "./project-manager";
 import {
   createBrowserWindowMock,
   createCommRouterMock,
@@ -104,6 +106,8 @@ interface Harness {
   getDefaultPackages: Mock<() => string[]>;
   getUvBinaryPath: Mock<() => string | undefined>;
   bindActiveProjectModules: Mock<(kernelId: string | null) => Promise<void>>;
+  autosaveBeforeRestart: Mock<(kernelId: string) => Promise<boolean>>;
+  recoverUnsavedAfterRestart: Mock<(orphanDir: string) => Promise<void>>;
 }
 
 function setup(): Harness {
@@ -136,6 +140,8 @@ function setup(): Harness {
     getDefaultPackages: vi.fn(() => []),
     getUvBinaryPath: vi.fn(() => undefined),
     bindActiveProjectModules: vi.fn(async () => undefined),
+    autosaveBeforeRestart: vi.fn(async () => false),
+    recoverUnsavedAfterRestart: vi.fn(async () => undefined),
   };
   registerKernelIpcHandlers({
     win: win.win,
@@ -155,6 +161,8 @@ function setup(): Harness {
     getDefaultPackages: harness.getDefaultPackages,
     getUvBinaryPath: harness.getUvBinaryPath,
     bindActiveProjectModules: harness.bindActiveProjectModules,
+    autosaveBeforeRestart: harness.autosaveBeforeRestart,
+    recoverUnsavedAfterRestart: harness.recoverUnsavedAfterRestart,
   });
   return harness;
 }
@@ -230,6 +238,57 @@ describe("kernels:start", () => {
   });
 });
 
+describe("start/stop/restart serialization", () => {
+  it("serializes concurrent start calls — the second waits for the first (regression)", async () => {
+    // The old implementation awaited the previous lock promise BEFORE
+    // swapping in its own, so two calls arriving together both saw the
+    // same settled promise and both entered their bodies, racing on the
+    // shared commRouter. The lock must be swapped synchronously.
+    const harness = setup();
+    const events: string[] = [];
+    let finishFirst!: () => void;
+    const firstGate = new Promise<void>((r) => { finishFirst = r; });
+    let call = 0;
+    harness.kernelManager.start = vi.fn(async () => {
+      call += 1;
+      const id = `k${call}`;
+      events.push(`begin:${id}`);
+      if (call === 1) await firstGate;
+      events.push(`end:${id}`);
+      return makeKernelInfo({ id });
+    });
+
+    const p1 = getHandler(IPC.kernels.start)({}, { language: "python" });
+    const p2 = getHandler(IPC.kernels.start)({}, { language: "python" });
+
+    // Let any incorrectly-unblocked second call run its continuations.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(events).toEqual(["begin:k1"]);
+
+    finishFirst();
+    await Promise.all([p1, p2]);
+    expect(events).toEqual(["begin:k1", "end:k1", "begin:k2", "end:k2"]);
+  });
+
+  it("releases the lock when the serialized operation throws", async () => {
+    const harness = setup();
+    harness.kernelManager.start = vi
+      .fn(async () => makeKernelInfo({ id: "k2" }))
+      .mockRejectedValueOnce(new Error("spawn failed"));
+
+    await expect(
+      getHandler(IPC.kernels.start)({}, { language: "python" }),
+    ).rejects.toThrow(/spawn failed/);
+
+    // The failed first operation must not leave the lock held.
+    const result = (await getHandler(IPC.kernels.start)({}, {
+      language: "python",
+    })) as { id: string };
+    expect(result.id).toBe("k2");
+  });
+});
+
 describe("kernels:stop", () => {
   it("removes the working dir, clears the active kernel, detaches routers", async () => {
     const harness = setup();
@@ -271,7 +330,129 @@ describe("kernels:restart", () => {
       "/projects/x",
       "/tmp/new-wd",
     );
-    expect(harness.projectManager.load).toHaveBeenCalledWith("/projects/x");
+    // No autosave snapshot → plain load, no tree-index override.
+    expect(harness.projectManager.load).toHaveBeenCalledWith(
+      "/projects/x",
+      undefined,
+    );
+  });
+
+  it("snapshots the tree before teardown (autosave runs before stop)", async () => {
+    const harness = setup();
+    const events: string[] = [];
+    harness.autosaveBeforeRestart.mockImplementation(async () => {
+      events.push("autosave");
+      return false;
+    });
+    (harness.kernelManager.stop as Mock).mockImplementation(async () => {
+      events.push("stop");
+    });
+    (harness.kernelManager.getKernel as Mock).mockReturnValue(
+      makeKernelInfo({ id: "old", language: "python" }),
+    );
+    (harness.kernelManager.start as Mock).mockResolvedValueOnce(
+      makeKernelInfo({ id: "new", language: "python" }),
+    );
+
+    await getHandler(IPC.kernels.restart)({}, "old");
+    expect(events).toEqual(["autosave", "stop"]);
+  });
+
+  it("unsaved session with a snapshot: preserves the old working dir and recovers it after restart", async () => {
+    const harness = setup();
+    harness.autosaveBeforeRestart.mockResolvedValue(true);
+    (harness.getActiveProjectDir as Mock).mockReturnValue(null);
+    harness.kernelWorkingDirs.set("old", "/tmp/old-wd");
+    (harness.kernelManager.getKernel as Mock).mockReturnValue(
+      makeKernelInfo({ id: "old", language: "python" }),
+    );
+    (harness.kernelManager.start as Mock).mockResolvedValueOnce(
+      makeKernelInfo({ id: "new", language: "python" }),
+    );
+
+    await getHandler(IPC.kernels.restart)({}, "old");
+
+    // The old dir must survive teardown — it holds the .autosave snapshot.
+    expect(harness.projectManager.deleteWorkingDir).not.toHaveBeenCalledWith(
+      "/tmp/old-wd",
+    );
+    // ...and the recovery routine re-imports it into the new session.
+    expect(harness.recoverUnsavedAfterRestart).toHaveBeenCalledWith("/tmp/old-wd");
+  });
+
+  it("unsaved session without a snapshot: old behavior (dir deleted, no recovery)", async () => {
+    const harness = setup();
+    harness.autosaveBeforeRestart.mockResolvedValue(false);
+    (harness.getActiveProjectDir as Mock).mockReturnValue(null);
+    harness.kernelWorkingDirs.set("old", "/tmp/old-wd");
+    (harness.kernelManager.getKernel as Mock).mockReturnValue(
+      makeKernelInfo({ id: "old", language: "python" }),
+    );
+    (harness.kernelManager.start as Mock).mockResolvedValueOnce(
+      makeKernelInfo({ id: "new", language: "python" }),
+    );
+
+    await getHandler(IPC.kernels.restart)({}, "old");
+
+    expect(harness.projectManager.deleteWorkingDir).toHaveBeenCalledWith(
+      "/tmp/old-wd",
+    );
+    expect(harness.recoverUnsavedAfterRestart).not.toHaveBeenCalled();
+  });
+
+  it("saved project with a snapshot: reloads from the autosave overlay", async () => {
+    const harness = setup();
+    harness.autosaveBeforeRestart.mockResolvedValue(true);
+    (harness.getActiveProjectDir as Mock).mockReturnValue("/projects/x");
+    (harness.kernelManager.getKernel as Mock).mockReturnValue(
+      makeKernelInfo({ id: "old", language: "python" }),
+    );
+    (harness.kernelManager.start as Mock).mockResolvedValueOnce(
+      makeKernelInfo({ id: "new", language: "python" }),
+    );
+    harness.kernelWorkingDirs.set("new", "/tmp/new-wd");
+    const checkSpy = vi
+      .spyOn(ProjectManager, "checkForAutosave")
+      .mockResolvedValue({ exists: true, timestamp: "2026-07-07T00:00:00Z" });
+
+    try {
+      await getHandler(IPC.kernels.restart)({}, "old");
+    } finally {
+      checkSpy.mockRestore();
+    }
+
+    const autosaveDir = path.join("/projects/x", ".autosave");
+    expect(projectFileSyncMocks.copyFilesForLoad).toHaveBeenCalledWith(
+      "/projects/x",
+      "/tmp/new-wd",
+    );
+    expect(projectFileSyncMocks.overlayAutosaveTreeFiles).toHaveBeenCalledWith(
+      autosaveDir,
+      "/tmp/new-wd",
+    );
+    expect(harness.projectManager.load).toHaveBeenCalledWith("/projects/x", {
+      treeIndexDir: autosaveDir,
+      codeCellsDir: autosaveDir,
+    });
+  });
+
+  it("restart still completes when recovery of the preserved session fails", async () => {
+    const harness = setup();
+    harness.autosaveBeforeRestart.mockResolvedValue(true);
+    harness.recoverUnsavedAfterRestart.mockRejectedValue(new Error("recover boom"));
+    (harness.getActiveProjectDir as Mock).mockReturnValue(null);
+    harness.kernelWorkingDirs.set("old", "/tmp/old-wd");
+    (harness.kernelManager.getKernel as Mock).mockReturnValue(
+      makeKernelInfo({ id: "old", language: "python" }),
+    );
+    (harness.kernelManager.start as Mock).mockResolvedValueOnce(
+      makeKernelInfo({ id: "new", language: "python" }),
+    );
+
+    const restarted = (await getHandler(IPC.kernels.restart)({}, "old")) as {
+      id: string;
+    };
+    expect(restarted.id).toBe("new");
   });
 
   it("re-materializes the uv environment and relaunches into the venv", async () => {

--- a/electron/main/ipc-register-kernels.test.ts
+++ b/electron/main/ipc-register-kernels.test.ts
@@ -26,6 +26,7 @@ const ipcRegistry = vi.hoisted(() => {
 const envDetectorMocks = vi.hoisted(() => ({
   checkPDVInstalled: vi.fn(async () => ({ installed: true })),
   checkJuliaPDVInstalled: vi.fn(async () => ({ installed: true })),
+  resolvePythonMajorMinor: vi.fn(async () => "3.13"),
 }));
 
 const kernelSessionMocks = vi.hoisted(() => ({
@@ -57,6 +58,7 @@ vi.mock("./environment-detector", () => ({
   EnvironmentDetector: {
     checkPDVInstalled: envDetectorMocks.checkPDVInstalled,
     checkJuliaPDVInstalled: envDetectorMocks.checkJuliaPDVInstalled,
+    resolvePythonMajorMinor: envDetectorMocks.resolvePythonMajorMinor,
   },
 }));
 
@@ -65,7 +67,7 @@ vi.mock("./module-runtime", () => moduleRuntimeMocks);
 vi.mock("./project-file-sync", () => projectFileSyncMocks);
 vi.mock("./uv-environment", () => uvEnvironmentMocks);
 
-import { IPC } from "./ipc";
+import { IPC, type ActiveEnvironmentInfo } from "./ipc";
 import { registerKernelIpcHandlers } from "./ipc-register-kernels";
 import { ProjectManager } from "./project-manager";
 import {
@@ -93,6 +95,7 @@ interface Harness {
   projectManager: ReturnType<typeof createProjectManagerMock>;
   moduleManager: ReturnType<typeof createModuleManagerMock>;
   kernelWorkingDirs: Map<string, string>;
+  kernelEnvMeta: Map<string, ActiveEnvironmentInfo>;
   crashHandlers: Map<string, (id: string) => void>;
   // Typed Mocks so each field is structurally assignable to the typed
   // callback the registration function expects, while still exposing
@@ -118,6 +121,7 @@ function setup(): Harness {
   const projectManager = createProjectManagerMock();
   const moduleManager = createModuleManagerMock();
   const kernelWorkingDirs = new Map<string, string>();
+  const kernelEnvMeta = new Map<string, ActiveEnvironmentInfo>();
   const crashHandlers = new Map<string, (id: string) => void>();
   let activeId: string | null = null;
   const harness: Harness = {
@@ -128,6 +132,7 @@ function setup(): Harness {
     projectManager,
     moduleManager,
     kernelWorkingDirs,
+    kernelEnvMeta,
     crashHandlers,
     resetProjectState: vi.fn(),
     resetKernelState: vi.fn(),
@@ -151,6 +156,7 @@ function setup(): Harness {
     projectManager,
     moduleManager,
     kernelWorkingDirs,
+    kernelEnvMeta: harness.kernelEnvMeta,
     crashHandlers,
     resetProjectState: harness.resetProjectState,
     resetKernelState: harness.resetKernelState,
@@ -172,6 +178,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   envDetectorMocks.checkPDVInstalled.mockResolvedValue({ installed: true });
   envDetectorMocks.checkJuliaPDVInstalled.mockResolvedValue({ installed: true });
+  envDetectorMocks.resolvePythonMajorMinor.mockResolvedValue("3.13");
 });
 
 afterEach(() => {
@@ -220,7 +227,12 @@ describe("kernels:start", () => {
     ).rejects.toThrow(/missing PDVKernel/);
   });
 
-  it("crash handler cleans up working dir and pushes kernelCrashed to renderer", async () => {
+  it("crash handler preserves the working dir and pushes kernelCrashed to renderer", async () => {
+    // Regression (§11.6): the crash handler used to delete the working dir,
+    // destroying the uv env spec (pyproject.toml/uv.lock/.python-version)
+    // and any unsaved-session `.autosave` — a crashed uv project would
+    // silently restart in shared mode. The dir and its map entry must
+    // survive until kernels.restart / kernels.stop clean them up.
     const harness = setup();
     harness.kernelManager.start = vi.fn(async () => makeKernelInfo({ id: "kx" }));
     const result = (await getHandler(IPC.kernels.start)({}, {
@@ -230,11 +242,102 @@ describe("kernels:start", () => {
     harness.kernelWorkingDirs.set(result.id, "/tmp/working");
     const onCrash = harness.crashHandlers.get(result.id)!;
     await onCrash(result.id);
-    expect(harness.projectManager.deleteWorkingDir).toHaveBeenCalledWith("/tmp/working");
+    expect(harness.projectManager.deleteWorkingDir).not.toHaveBeenCalled();
+    expect(harness.kernelWorkingDirs.get(result.id)).toBe("/tmp/working");
+    expect(harness.commRouter.detach).toHaveBeenCalled();
     expect(harness.win.webContentsSend).toHaveBeenCalledWith(
       IPC.push.kernelCrashed,
       { kernelId: result.id },
     );
+  });
+});
+
+describe("kernels:start — new uv project (§10.5.8)", () => {
+  function setupUvStart(): { harness: Harness; wd: string } {
+    const harness = setup();
+    const wd = fs.mkdtempSync(path.join(os.tmpdir(), "pdv-newproj-"));
+    (harness.projectManager.createWorkingDir as Mock).mockResolvedValue(wd);
+    uvEnvironmentMocks.materializeUvEnvironment.mockResolvedValue({
+      success: true,
+      venvPython: path.join(wd, ".venv", "bin", "python"),
+      output: "",
+    });
+    return { harness, wd };
+  }
+
+  it("writes pyproject from the chosen packages, pins .python-version, passes --python, launches into the venv", async () => {
+    const { harness, wd } = setupUvStart();
+    try {
+      await getHandler(IPC.kernels.start)(
+        {},
+        { language: "python" },
+        { newProject: true, pythonVersion: "3.12", packages: ["scipy>=1.10", "xarray"] },
+      );
+      const pyproject = fs.readFileSync(path.join(wd, "pyproject.toml"), "utf8");
+      expect(pyproject).toContain("scipy>=1.10");
+      expect(pyproject).toContain("xarray");
+      expect(fs.readFileSync(path.join(wd, ".python-version"), "utf8").trim()).toBe("3.12");
+      const materializeOpts = uvEnvironmentMocks.materializeUvEnvironment.mock.calls.at(-1)?.[1] as
+        | { pythonVersion?: string }
+        | undefined;
+      expect(materializeOpts?.pythonVersion).toBe("3.12");
+      const startArg = (harness.kernelManager.start as Mock).mock.calls.at(-1)?.[0] as {
+        env: { PYTHON_PATH: string };
+      };
+      expect(startArg.env.PYTHON_PATH).toBe(path.join(wd, ".venv", "bin", "python"));
+    } finally {
+      fs.rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the default version and the user's default packages", async () => {
+    const { harness, wd } = setupUvStart();
+    harness.getDefaultPackages.mockReturnValue(["numpy", "matplotlib"]);
+    try {
+      await getHandler(IPC.kernels.start)({}, { language: "python" }, { newProject: true });
+      const pyproject = fs.readFileSync(path.join(wd, "pyproject.toml"), "utf8");
+      expect(pyproject).toContain("numpy");
+      expect(pyproject).toContain("matplotlib");
+      expect(fs.readFileSync(path.join(wd, ".python-version"), "utf8").trim()).toBe("3.13");
+    } finally {
+      fs.rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an unsupported Python version before touching the filesystem", async () => {
+    const { harness, wd } = setupUvStart();
+    try {
+      await expect(
+        getHandler(IPC.kernels.start)(
+          {},
+          { language: "python" },
+          { newProject: true, pythonVersion: "2.7" },
+        ),
+      ).rejects.toThrow(/Unsupported Python version "2\.7"/);
+      expect(harness.projectManager.createWorkingDir).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("records uv env metadata for the new kernel (environment:activeInfo source)", async () => {
+    const { harness, wd } = setupUvStart();
+    envDetectorMocks.resolvePythonMajorMinor.mockResolvedValue("3.12");
+    harness.kernelManager.start = vi.fn(async () => makeKernelInfo({ id: "kuv" }));
+    try {
+      await getHandler(IPC.kernels.start)(
+        {},
+        { language: "python" },
+        { newProject: true, pythonVersion: "3.12" },
+      );
+      expect(harness.kernelEnvMeta.get("kuv")).toEqual({
+        mode: "uv",
+        interpreterPath: path.join(wd, ".venv", "bin", "python"),
+        pythonVersion: "3.12",
+      });
+    } finally {
+      fs.rmSync(wd, { recursive: true, force: true });
+    }
   });
 });
 
@@ -322,9 +425,12 @@ describe("kernels:restart", () => {
     harness.kernelWorkingDirs.set("new", "/tmp/new-wd");
 
     const restarted = (await getHandler(IPC.kernels.restart)({}, "old")) as {
-      id: string;
+      kernel: { id: string };
+      restoredFromAutosave: boolean;
     };
-    expect(restarted.id).toBe("new");
+    expect(restarted.kernel.id).toBe("new");
+    // No autosave snapshot → the renderer is told nothing was restored.
+    expect(restarted.restoredFromAutosave).toBe(false);
     expect(harness.resetKernelState).toHaveBeenCalled();
     expect(projectFileSyncMocks.copyFilesForLoad).toHaveBeenCalledWith(
       "/projects/x",
@@ -450,9 +556,12 @@ describe("kernels:restart", () => {
     );
 
     const restarted = (await getHandler(IPC.kernels.restart)({}, "old")) as {
-      id: string;
+      kernel: { id: string };
+      restoredFromAutosave: boolean;
     };
-    expect(restarted.id).toBe("new");
+    expect(restarted.kernel.id).toBe("new");
+    // Recovery failed, so nothing was actually restored.
+    expect(restarted.restoredFromAutosave).toBe(false);
   });
 
   it("re-materializes the uv environment and relaunches into the venv", async () => {
@@ -461,6 +570,7 @@ describe("kernels:restart", () => {
     const newDir = fs.mkdtempSync(path.join(os.tmpdir(), "pdv-restart-new-"));
     fs.writeFileSync(path.join(oldDir, "pyproject.toml"), "[project]\nname = 'x'\n");
     fs.writeFileSync(path.join(oldDir, "uv.lock"), "version = 1\n");
+    fs.writeFileSync(path.join(oldDir, ".python-version"), "3.11\n");
 
     (harness.kernelManager.getKernel as Mock).mockReturnValue(
       makeKernelInfo({ id: "old", language: "python" }),
@@ -489,6 +599,15 @@ describe("kernels:restart", () => {
       expect(fs.readFileSync(path.join(newDir, "pyproject.toml"), "utf8")).toContain(
         "[project]",
       );
+      // The version pin rode the snapshot into the new working dir and was
+      // forwarded to uv sync --python (§10.5.8).
+      expect(fs.readFileSync(path.join(newDir, ".python-version"), "utf8").trim()).toBe(
+        "3.11",
+      );
+      const rematerializeOpts = uvEnvironmentMocks.materializeUvEnvironment.mock.calls.at(-1)?.[1] as
+        | { pythonVersion?: string }
+        | undefined;
+      expect(rematerializeOpts?.pythonVersion).toBe("3.11");
       // The new kernel launched against the venv interpreter, not system python.
       const startArg = (harness.kernelManager.start as Mock).mock.calls.at(-1)?.[0];
       expect(startArg.env.PYTHON_PATH).toBe(venvPython);

--- a/electron/main/ipc-register-kernels.ts
+++ b/electron/main/ipc-register-kernels.ts
@@ -16,7 +16,8 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 
-import { BrowserWindow, ipcMain } from "electron";
+import { BrowserWindow } from "electron";
+import { handleIpc } from "./ipc-registry";
 
 import { CommRouter } from "./comm-router";
 import { QueryRouter } from "./query-router";
@@ -27,11 +28,40 @@ import { initializeKernelSession } from "./kernel-session";
 import { executeAndTranscribe, TranscriptWriter } from "./mcp/transcript";
 import type { ModuleManager } from "./module-manager";
 import { setupProjectModuleNamespaces } from "./module-runtime";
-import { copyEnvFilesForLoad, copyFilesForLoad } from "./project-file-sync";
+import { copyEnvFilesForLoad, copyFilesForLoad, overlayAutosaveTreeFiles } from "./project-file-sync";
 import { ProjectManager } from "./project-manager";
+import { autosaveDirFor } from "./autosave-sidecars";
 import { materializeUvEnvironment } from "./uv-environment";
 import { resolveUvBinary } from "./uv-runner";
 import { generatePyproject } from "./pyproject";
+
+/**
+ * The `kernel:memoryRss` listener currently attached to a KernelManager,
+ * tracked so teardown can detach it. The KernelManager outlives windows,
+ * so an untracked listener would accumulate once per window re-creation.
+ * Mirrors `trackedExecutionStateListener` in `index.ts`.
+ */
+let trackedMemoryListener:
+  | { km: KernelManager; fn: (kernelId: string, rssBytes: number) => void }
+  | null = null;
+
+/**
+ * Detach the tracked `kernel:memoryRss` listener, if any.
+ *
+ * Called on re-registration (below) and from `unregisterIpcHandlers()` in
+ * `index.ts` so registration and teardown stay symmetric.
+ *
+ * @returns Nothing.
+ */
+export function removeKernelMemoryListener(): void {
+  if (trackedMemoryListener) {
+    trackedMemoryListener.km.removeListener(
+      "kernel:memoryRss",
+      trackedMemoryListener.fn,
+    );
+    trackedMemoryListener = null;
+  }
+}
 
 interface RegisterKernelIpcHandlersOptions {
   win: BrowserWindow;
@@ -53,6 +83,21 @@ interface RegisterKernelIpcHandlersOptions {
   /** Optional `uv` binary override from config (§10.5.6); undefined = bundled. */
   getUvBinaryPath: () => string | undefined;
   bindActiveProjectModules: (kernelId: string | null) => Promise<void>;
+  /**
+   * Best-effort tree snapshot taken while the old Jupyter server is still
+   * alive, so a restart never loses in-memory work. Returns true when a
+   * usable ``.autosave`` snapshot exists afterwards — fresh, or a fallback
+   * to the most recent timer autosave when the server is too busy to
+   * answer a save request (a hung server is often *why* the user is
+   * restarting). Must never throw.
+   */
+  autosaveBeforeRestart: (kernelId: string) => Promise<boolean>;
+  /**
+   * Restore an unsaved session's ``.autosave`` snapshot from the preserved
+   * old working directory into the freshly started session, then delete
+   * the old directory. Same routine the welcome screen's "Recover" uses.
+   */
+  recoverUnsavedAfterRestart: (orphanDir: string) => Promise<void>;
 }
 
 /**
@@ -63,17 +108,26 @@ interface RegisterKernelIpcHandlersOptions {
  * @param kernelId       - Kernel whose working dir should be cleaned up.
  * @param kernelWorkingDirs - Map of kernel IDs to working directory paths.
  * @param crashHandlers  - Map of kernel IDs to crash handler functions.
+ * @param preserveDir    - Keep the directory on disk (still unregisters it
+ *   and the crash handler). Used by restart when the directory holds an
+ *   unsaved session's ``.autosave`` snapshot that the post-restart
+ *   recovery step reads — and, should that step never run, the directory
+ *   surfaces on the welcome screen as a recoverable session instead of
+ *   being lost.
  */
 async function cleanupKernelWorkingDir(
   projectManager: ProjectManager,
   kernelManager: KernelManager,
   kernelId: string,
   kernelWorkingDirs: Map<string, string>,
-  crashHandlers: Map<string, (id: string) => void>
+  crashHandlers: Map<string, (id: string) => void>,
+  preserveDir = false
 ): Promise<void> {
   const oldDir = kernelWorkingDirs.get(kernelId);
   if (oldDir) {
-    await projectManager.deleteWorkingDir(oldDir);
+    if (!preserveDir) {
+      await projectManager.deleteWorkingDir(oldDir);
+    }
     kernelWorkingDirs.delete(kernelId);
   }
   const handler = crashHandlers.get(kernelId);
@@ -111,6 +165,8 @@ export function registerKernelIpcHandlers(
     getDefaultPackages,
     getUvBinaryPath,
     bindActiveProjectModules,
+    autosaveBeforeRestart,
+    recoverUnsavedAfterRestart,
   } = options;
 
   /**
@@ -193,47 +249,72 @@ export function registerKernelIpcHandlers(
 
   // Forward periodic kernel-memory snapshots to the renderer. Registered once
   // for this window/manager pair (the payload carries `kernelId` so a single
-  // listener serves any number of kernels).
-  kernelManager.on("kernel:memoryRss", (kernelId: string, rssBytes: number) => {
+  // listener serves any number of kernels). Tracked so re-registration (e.g.
+  // macOS window re-creation) detaches the previous window's listener from
+  // the long-lived KernelManager instead of stacking a duplicate that pushes
+  // to a destroyed webContents.
+  removeKernelMemoryListener();
+  const memoryListener = (kernelId: string, rssBytes: number): void => {
     if (win.isDestroyed()) return;
     win.webContents.send(IPC.push.kernelMemory, {
       kernelId,
       rssBytes,
       timestamp: Date.now(),
     });
-  });
+  };
+  kernelManager.on("kernel:memoryRss", memoryListener);
+  trackedMemoryListener = { km: kernelManager, fn: memoryListener };
 
-  // Serialize kernel start/restart so concurrent calls cannot race on
-  // the shared commRouter (which causes "CommRouter detached" rejections).
+  // Serialize start/stop/restart of the Jupyter server process so concurrent
+  // calls cannot race on the shared commRouter (which causes "CommRouter
+  // detached" rejections).
   let startMutex: Promise<unknown> = Promise.resolve();
 
   /**
-   * Wait for the previous mutex-serialized operation to settle. Errors from
-   * the prior operation are logged (with the operation name) but NOT
-   * propagated, so the next operation can still run on a serialized turn.
-   * Without this log, prior failures would silently disappear via
-   * `previous.catch(() => {})`.
+   * Run ``fn`` while holding the start/stop/restart serialization lock.
+   *
+   * The queue promise is swapped in **synchronously** — before any await —
+   * so every concurrent caller observes the previous holder's promise and
+   * chains behind it. (The previous implementation awaited the old promise
+   * first and swapped afterwards; two calls arriving together both saw the
+   * same settled promise and both proceeded, defeating the serialization.)
+   * Same pattern as ``ProjectManager.runWithSaveLock``.
+   *
+   * The lock promise is resolved in ``finally`` and never rejects; the
+   * catch below only fires if a future refactor changes that, so a prior
+   * failure still can't silently vanish.
+   *
+   * @param operation - Label for the warn log (e.g. ``"kernels.start"``).
+   * @param fn - Operation to run exclusively.
+   * @returns The value returned by ``fn``.
+   * @throws Whatever ``fn`` throws — after releasing the lock.
    */
-  async function awaitPreviousMutex(operation: string): Promise<void> {
-    try {
-      await startMutex;
-    } catch (err) {
+  async function withStartLock<T>(
+    operation: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const prior = startMutex;
+    let release!: () => void;
+    startMutex = new Promise<void>((r) => { release = r; });
+    await prior.catch((err) => {
       console.warn(
-        `[ipc-register-kernels] Prior kernel-mutex operation rejected before ${operation}:`,
+        `[ipc-register-kernels] Prior serialized operation rejected before ${operation}:`,
         err
       );
+    });
+    try {
+      return await fn();
+    } finally {
+      release();
     }
   }
 
-  ipcMain.handle(IPC.kernels.list, async () => {
+  handleIpc(IPC.kernels.list, async () => {
     return kernelManager.list();
   });
 
-  ipcMain.handle(IPC.kernels.start, async (_event, spec, uvContext) => {
-    await awaitPreviousMutex("kernels.start");
-    let release!: () => void;
-    startMutex = new Promise<void>((r) => { release = r; });
-    try {
+  handleIpc(IPC.kernels.start, async (_event, spec, uvContext) => {
+    return withStartLock("kernels.start", async () => {
     let requestedSpec = spec as Parameters<KernelManager["start"]>[0];
     const requestedLanguage = requestedSpec?.language ?? "python";
     const uv = uvContext as { saveDir?: string; newProject?: boolean } | undefined;
@@ -315,16 +396,11 @@ export function registerKernelIpcHandlers(
     kernelManager.on("kernel:crashed", onCrash);
 
     return kernel;
-    } finally {
-      release();
-    }
+    });
   });
 
-  ipcMain.handle(IPC.kernels.stop, async (_event, kernelId: string) => {
-    await awaitPreviousMutex("kernels.stop");
-    let release!: () => void;
-    startMutex = new Promise<void>((r) => { release = r; });
-    try {
+  handleIpc(IPC.kernels.stop, async (_event, kernelId: string) => {
+    return withStartLock("kernels.stop", async () => {
       await cleanupKernelWorkingDir(projectManager, kernelManager, kernelId, kernelWorkingDirs, crashHandlers);
       projectManager.clearCachedKernelResults();
       await kernelManager.stop(kernelId);
@@ -334,12 +410,10 @@ export function registerKernelIpcHandlers(
       commRouter.detach();
       queryRouter.detach();
       return true;
-    } finally {
-      release();
-    }
+    });
   });
 
-  ipcMain.handle(IPC.kernels.execute, async (event, kernelId, request) => {
+  handleIpc(IPC.kernels.execute, async (event, kernelId, request) => {
     const id = kernelId as string;
     const workingDir = kernelWorkingDirs.get(id);
     const transcript = workingDir ? new TranscriptWriter(workingDir) : null;
@@ -352,16 +426,30 @@ export function registerKernelIpcHandlers(
     );
   });
 
-  ipcMain.handle(IPC.kernels.interrupt, async (_event, kernelId: string) => {
+  handleIpc(IPC.kernels.interrupt, async (_event, kernelId: string) => {
     await kernelManager.interrupt(kernelId);
     return true;
   });
 
-  ipcMain.handle(IPC.kernels.restart, async (_event, kernelId: string) => {
-    await awaitPreviousMutex("kernels.restart");
-    let release!: () => void;
-    startMutex = new Promise<void>((r) => { release = r; });
+  handleIpc(IPC.kernels.restart, async (_event, kernelId: string) => {
+    return withStartLock("kernels.restart", async () => {
+    // Snapshot the tree while the old server is still alive so a restart
+    // never loses in-memory work — for saved projects the snapshot lands
+    // in <projectDir>/.autosave and is restored by the reload below; for
+    // unsaved sessions it lands in <workingDir>/.autosave and is restored
+    // via the same routine the welcome screen's "Recover" uses.
+    let hasSnapshot = false;
     try {
+      hasSnapshot = await autosaveBeforeRestart(kernelId);
+    } catch (err) {
+      console.warn("[ipc-register-kernels] pre-restart autosave failed:", err);
+    }
+    const projectDirBeforeRestart = getActiveProjectDir();
+    const oldWorkingDir = kernelWorkingDirs.get(kernelId);
+    // Unsaved session with a snapshot: keep the old working dir on disk
+    // through the teardown — the snapshot lives inside it.
+    const preserveOldDir = !projectDirBeforeRestart && hasSnapshot && !!oldWorkingDir;
+
     // Restart preserves activeProjectDir — only reset kernel-scoped state.
     resetKernelState();
 
@@ -399,7 +487,14 @@ export function registerKernelIpcHandlers(
         }
       }
 
-      await cleanupKernelWorkingDir(projectManager, kernelManager, kernelId, kernelWorkingDirs, crashHandlers);
+      await cleanupKernelWorkingDir(
+        projectManager,
+        kernelManager,
+        kernelId,
+        kernelWorkingDirs,
+        crashHandlers,
+        preserveOldDir
+      );
       await kernelManager.stop(kernelId);
 
       let preCreatedWorkingDir: string | undefined;
@@ -439,46 +534,75 @@ export function registerKernelIpcHandlers(
     const restarted = await doRestart();
     setActiveKernelId(restarted.id);
 
-    // If a project was active, auto-reload it into the new kernel.
+    // If a project was active, auto-reload it into the new kernel — from
+    // the pre-restart .autosave snapshot when one exists, so unsaved
+    // changes survive the restart (same overlay + tree-index override
+    // recipe as the project-open recovery path in ipc-register-project).
     const activeProjectDir = getActiveProjectDir();
     if (activeProjectDir) {
       win.webContents.send(IPC.push.projectReloading, { status: "reloading" });
       try {
+        const autosaveDir = autosaveDirFor(activeProjectDir);
+        const restoreFromAutosave =
+          hasSnapshot &&
+          (await ProjectManager.checkForAutosave(activeProjectDir)).exists;
         const newWorkingDir = kernelWorkingDirs.get(restarted.id);
         if (newWorkingDir) {
           await copyFilesForLoad(activeProjectDir, newWorkingDir);
+          if (restoreFromAutosave) {
+            await overlayAutosaveTreeFiles(autosaveDir, newWorkingDir);
+          }
         }
-        await projectManager.load(activeProjectDir);
+        await projectManager.load(
+          activeProjectDir,
+          restoreFromAutosave
+            ? { treeIndexDir: autosaveDir, codeCellsDir: autosaveDir }
+            : undefined
+        );
         await setupModuleNamespaces(restarted.id);
       } finally {
         win.webContents.send(IPC.push.projectReloading, { status: "ready" });
       }
     } else {
       await setupModuleNamespaces(restarted.id);
+      // Unsaved session: restore the preserved snapshot into the new
+      // session. Failure is non-fatal — the old dir stays on disk and the
+      // welcome screen offers it as a recoverable session next launch.
+      if (preserveOldDir && oldWorkingDir) {
+        win.webContents.send(IPC.push.projectReloading, { status: "reloading" });
+        try {
+          await recoverUnsavedAfterRestart(oldWorkingDir);
+        } catch (err) {
+          console.warn(
+            "[ipc-register-kernels] post-restart recovery failed; the old session remains recoverable from the welcome screen:",
+            err
+          );
+        } finally {
+          win.webContents.send(IPC.push.projectReloading, { status: "ready" });
+        }
+      }
     }
     await bindActiveProjectModules(restarted.id);
 
     return restarted;
-    } finally {
-      release();
-    }
+    });
   });
 
-  ipcMain.handle(
+  handleIpc(
     IPC.kernels.complete,
     async (_event, kernelId: string, code: string, cursorPos: number) => {
       return kernelManager.complete(kernelId, code, cursorPos);
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.kernels.inspect,
     async (_event, kernelId: string, code: string, cursorPos: number) => {
       return kernelManager.inspect(kernelId, code, cursorPos);
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.kernels.validate,
     async (_event, executablePath: string, language: "python" | "julia") => {
       if (!executablePath.trim()) {

--- a/electron/main/ipc-register-kernels.ts
+++ b/electron/main/ipc-register-kernels.ts
@@ -22,7 +22,7 @@ import { handleIpc } from "./ipc-registry";
 import { CommRouter } from "./comm-router";
 import { QueryRouter } from "./query-router";
 import { EnvironmentDetector } from "./environment-detector";
-import { IPC } from "./ipc";
+import { IPC, type ActiveEnvironmentInfo, type KernelRestartResult } from "./ipc";
 import { KernelManager, type KernelInfo } from "./kernel-manager";
 import { initializeKernelSession } from "./kernel-session";
 import { executeAndTranscribe, TranscriptWriter } from "./mcp/transcript";
@@ -34,6 +34,10 @@ import { autosaveDirFor } from "./autosave-sidecars";
 import { materializeUvEnvironment } from "./uv-environment";
 import { resolveUvBinary } from "./uv-runner";
 import { generatePyproject } from "./pyproject";
+import {
+  DEFAULT_PYTHON_VERSION,
+  SUPPORTED_PYTHON_VERSIONS,
+} from "./python-versions";
 
 /**
  * The `kernel:memoryRss` listener currently attached to a KernelManager,
@@ -71,6 +75,14 @@ interface RegisterKernelIpcHandlersOptions {
   projectManager: ProjectManager;
   moduleManager: ModuleManager;
   kernelWorkingDirs: Map<string, string>;
+  /**
+   * Per-kernel environment metadata (mode, actual interpreter, resolved
+   * Python version). This module populates it on start/restart and deletes
+   * entries on stop; entries survive crashes so a crash-restart carries the
+   * environment over. Read by `environment:activeInfo` and the project save
+   * handler (§10.5).
+   */
+  kernelEnvMeta: Map<string, ActiveEnvironmentInfo>;
   crashHandlers: Map<string, (id: string) => void>;
   resetProjectState: () => void;
   resetKernelState: () => void;
@@ -155,6 +167,7 @@ export function registerKernelIpcHandlers(
     projectManager,
     moduleManager,
     kernelWorkingDirs,
+    kernelEnvMeta,
     crashHandlers,
     resetProjectState,
     resetKernelState,
@@ -188,9 +201,10 @@ export function registerKernelIpcHandlers(
    * process is spawned against the venv interpreter.
    *
    * @param uv - uv context: an existing project's `saveDir` to copy env
-   *   files from, `newProject` to seed a fresh `pyproject.toml` from the
-   *   user's default packages, or an `envSnapshot` of file contents captured
-   *   before the source working dir was torn down (used on restart, §11.6).
+   *   files from, `newProject` to seed a fresh `pyproject.toml` (from
+   *   `packages`, falling back to the user's default packages, pinned to
+   *   `pythonVersion` or the default), or an `envSnapshot` of file contents
+   *   captured before the source working dir was torn down (restart, §11.6).
    * @returns The pre-created working directory and the venv interpreter path.
    * @throws {Error} When uv environment setup fails. The partially-created
    *   working directory is removed before the error propagates.
@@ -199,7 +213,9 @@ export function registerKernelIpcHandlers(
     uv: {
       saveDir?: string;
       newProject?: boolean;
-      envSnapshot?: { pyproject: string; uvLock?: string };
+      pythonVersion?: string;
+      packages?: string[];
+      envSnapshot?: { pyproject: string; uvLock?: string; pythonVersionPin?: string };
     }
   ): Promise<{ workingDir: string; venvPython: string; uvBinary: string | undefined }> {
     // The resolved uv binary travels to the kernel in pdv.init so pdv.install()
@@ -220,15 +236,35 @@ export function registerKernelIpcHandlers(
         if (uv.envSnapshot.uvLock !== undefined) {
           await fs.writeFile(path.join(workingDir, "uv.lock"), uv.envSnapshot.uvLock, "utf8");
         }
+        if (uv.envSnapshot.pythonVersionPin !== undefined) {
+          await fs.writeFile(
+            path.join(workingDir, ".python-version"),
+            uv.envSnapshot.pythonVersionPin,
+            "utf8"
+          );
+          pythonVersion = uv.envSnapshot.pythonVersionPin.trim() || undefined;
+        }
       } else if (uv.saveDir) {
         // Opening an existing uv project: copy its env files in.
         await copyEnvFilesForLoad(uv.saveDir, workingDir);
         const manifest = await ProjectManager.readManifest(uv.saveDir);
         pythonVersion = manifest.environment?.python_version;
       } else {
-        // New uv project: generate a pyproject.toml from the default packages.
-        const toml = generatePyproject({ dependencies: getDefaultPackages() });
+        // New uv project: generate a pyproject.toml from the packages chosen
+        // in the New Project dialog (falling back to the user's defaults) and
+        // pin the chosen Python version. The pin is written as uv's native
+        // `.python-version` file so it round-trips through save/open/restart
+        // via ENV_FILES (§10.5.10) without touching the manifest schema.
+        const toml = generatePyproject({
+          dependencies: uv.packages ?? getDefaultPackages(),
+        });
         await fs.writeFile(path.join(workingDir, "pyproject.toml"), toml, "utf8");
+        pythonVersion = uv.pythonVersion ?? DEFAULT_PYTHON_VERSION;
+        await fs.writeFile(
+          path.join(workingDir, ".python-version"),
+          `${pythonVersion}\n`,
+          "utf8"
+        );
       }
       const result = await materializeUvEnvironment(workingDir, {
         pythonVersion,
@@ -317,7 +353,14 @@ export function registerKernelIpcHandlers(
     return withStartLock("kernels.start", async () => {
     let requestedSpec = spec as Parameters<KernelManager["start"]>[0];
     const requestedLanguage = requestedSpec?.language ?? "python";
-    const uv = uvContext as { saveDir?: string; newProject?: boolean } | undefined;
+    const uv = uvContext as
+      | { saveDir?: string; newProject?: boolean; pythonVersion?: string; packages?: string[] }
+      | undefined;
+    if (uv?.pythonVersion && !SUPPORTED_PYTHON_VERSIONS.includes(uv.pythonVersion)) {
+      throw new Error(
+        `Unsupported Python version "${uv.pythonVersion}". Supported: ${SUPPORTED_PYTHON_VERSIONS.join(", ")}.`
+      );
+    }
 
     // Starting a new kernel always means a new session — clear any in-memory
     // project state from a previous session (pending imports, active project
@@ -331,6 +374,10 @@ export function registerKernelIpcHandlers(
     // shared-mode pdv-install check below is skipped for uv kernels.
     let preCreatedWorkingDir: string | undefined;
     let uvBinaryForInit: string | undefined;
+    // Environment metadata recorded under the new kernel's id once it has
+    // started (§10.5): mode, the interpreter it actually spawned on, and
+    // the resolved Python version. Authoritative at project-save time.
+    let envMeta: ActiveEnvironmentInfo = { mode: "shared" };
     if (uv && requestedLanguage === "python") {
       const uvEnv = await startUvEnvironment(uv);
       preCreatedWorkingDir = uvEnv.workingDir;
@@ -340,6 +387,13 @@ export function registerKernelIpcHandlers(
         language: "python",
         argv: undefined,
         env: { ...(requestedSpec?.env ?? {}), PYTHON_PATH: uvEnv.venvPython },
+      };
+      envMeta = {
+        mode: "uv",
+        interpreterPath: uvEnv.venvPython,
+        pythonVersion:
+          (await EnvironmentDetector.resolvePythonMajorMinor(uvEnv.venvPython)) ??
+          uv.pythonVersion,
       };
     } else if (requestedLanguage === "python") {
       const pythonPath =
@@ -352,6 +406,12 @@ export function registerKernelIpcHandlers(
             `Selected Python runtime is missing pdv. Install it with: cd pdv-python && ${pythonPath} -m pip install -e ".[dev]"`
           );
         }
+        envMeta = {
+          mode: "shared",
+          interpreterPath: pythonPath,
+          pythonVersion:
+            await EnvironmentDetector.resolvePythonMajorMinor(pythonPath),
+        };
       }
     } else if (requestedLanguage === "julia") {
       const juliaPath = requestedSpec?.env?.JULIA_PATH ??
@@ -363,10 +423,12 @@ export function registerKernelIpcHandlers(
             `Selected Julia runtime is missing PDVKernel. Install it with: cd pdv-julia && julia --project=. -e 'using Pkg; Pkg.instantiate()'`
           );
         }
+        envMeta = { mode: "shared", interpreterPath: juliaPath };
       }
     }
 
     const kernel = await kernelManager.start(requestedSpec);
+    kernelEnvMeta.set(kernel.id, envMeta);
     commRouter.attach(kernelManager, kernel.id);
     queryRouter.detach();
     await initializeKernelSession(
@@ -388,7 +450,13 @@ export function registerKernelIpcHandlers(
       if (crashedId !== kernel.id) return;
       commRouter.detach();
       queryRouter.detach();
-      await cleanupKernelWorkingDir(projectManager, kernelManager, crashedId, kernelWorkingDirs, crashHandlers);
+      // Deliberately do NOT delete the working directory or its map entry
+      // here: it holds the uv env spec (pyproject.toml/uv.lock/
+      // .python-version) the restart handler snapshots to rebuild the venv,
+      // and any `.autosave` of an unsaved session. `kernels.restart` and
+      // `kernels.stop` clean it up; if the user quits instead, the stale
+      // `session.lock` surfaces it on the welcome screen as a recoverable
+      // session (§11.6).
       if (getActiveKernelId() === crashedId) setActiveKernelId(null);
       win.webContents.send(IPC.push.kernelCrashed, { kernelId: crashedId });
     };
@@ -402,6 +470,7 @@ export function registerKernelIpcHandlers(
   handleIpc(IPC.kernels.stop, async (_event, kernelId: string) => {
     return withStartLock("kernels.stop", async () => {
       await cleanupKernelWorkingDir(projectManager, kernelManager, kernelId, kernelWorkingDirs, crashHandlers);
+      kernelEnvMeta.delete(kernelId);
       projectManager.clearCachedKernelResults();
       await kernelManager.stop(kernelId);
       if (getActiveKernelId() === kernelId) {
@@ -468,7 +537,9 @@ export function registerKernelIpcHandlers(
       // (ARCHITECTURE.md §10.5.9, §11.6). The snapshot carries any packages
       // installed since load (e.g. via pdv.install, §10.5.11).
       const oldWorkingDir = kernelWorkingDirs.get(kernelId);
-      let envSnapshot: { pyproject: string; uvLock?: string } | undefined;
+      let envSnapshot:
+        | { pyproject: string; uvLock?: string; pythonVersionPin?: string }
+        | undefined;
       if (current.language === "python" && oldWorkingDir) {
         try {
           const pyproject = await fs.readFile(
@@ -481,9 +552,33 @@ export function registerKernelIpcHandlers(
           } catch {
             /* lock may not exist yet */
           }
-          envSnapshot = { pyproject, uvLock };
+          let pythonVersionPin: string | undefined;
+          try {
+            pythonVersionPin = await fs.readFile(
+              path.join(oldWorkingDir, ".python-version"),
+              "utf8"
+            );
+          } catch {
+            /* pin may not exist (pre-pin project) */
+          }
+          envSnapshot = { pyproject, uvLock, pythonVersionPin };
         } catch {
           /* no pyproject.toml -> shared-mode kernel */
+        }
+      }
+
+      // Hardening: if the old working dir (or its env files) is gone but the
+      // saved project is a uv project, rebuild the env from the save dir
+      // instead of silently falling back to a shared-mode start.
+      let uvSaveDirFallback: string | undefined;
+      if (!envSnapshot && current.language === "python") {
+        const projectDir = getActiveProjectDir();
+        if (projectDir) {
+          const hasPyproject = await fs
+            .access(path.join(projectDir, "pyproject.toml"))
+            .then(() => true)
+            .catch(() => false);
+          if (hasPyproject) uvSaveDirFallback = projectDir;
         }
       }
 
@@ -497,11 +592,19 @@ export function registerKernelIpcHandlers(
       );
       await kernelManager.stop(kernelId);
 
+      // Carry the old kernel's environment metadata to the new one — the
+      // restart re-materializes the same environment, so mode/interpreter/
+      // version are unchanged (the uv branch refreshes the venv path).
+      const oldEnvMeta = kernelEnvMeta.get(kernelId);
+      kernelEnvMeta.delete(kernelId);
+
       let preCreatedWorkingDir: string | undefined;
       let uvBinaryForInit: string | undefined;
       let restarted: KernelInfo;
-      if (envSnapshot) {
-        const uvEnv = await startUvEnvironment({ envSnapshot });
+      if (envSnapshot || uvSaveDirFallback) {
+        const uvEnv = await startUvEnvironment(
+          envSnapshot ? { envSnapshot } : { saveDir: uvSaveDirFallback }
+        );
         preCreatedWorkingDir = uvEnv.workingDir;
         uvBinaryForInit = uvEnv.uvBinary;
         restarted = await kernelManager.start({
@@ -509,11 +612,19 @@ export function registerKernelIpcHandlers(
           language: current.language,
           env: { PYTHON_PATH: uvEnv.venvPython },
         });
+        kernelEnvMeta.set(restarted.id, {
+          mode: "uv",
+          interpreterPath: uvEnv.venvPython,
+          pythonVersion:
+            (await EnvironmentDetector.resolvePythonMajorMinor(uvEnv.venvPython)) ??
+            oldEnvMeta?.pythonVersion,
+        });
       } else {
         restarted = await kernelManager.start({
           name: current.name,
           language: current.language,
         });
+        kernelEnvMeta.set(restarted.id, oldEnvMeta ?? { mode: "shared" });
       }
       commRouter.attach(kernelManager, restarted.id);
       queryRouter.detach();
@@ -533,6 +644,11 @@ export function registerKernelIpcHandlers(
 
     const restarted = await doRestart();
     setActiveKernelId(restarted.id);
+
+    // Whether the session's state was actually reloaded from an autosave
+    // snapshot — returned to the renderer so it can tell the user what
+    // came back (restored work vs. a fresh session).
+    let restoredFromAutosave = false;
 
     // If a project was active, auto-reload it into the new kernel — from
     // the pre-restart .autosave snapshot when one exists, so unsaved
@@ -559,6 +675,7 @@ export function registerKernelIpcHandlers(
             ? { treeIndexDir: autosaveDir, codeCellsDir: autosaveDir }
             : undefined
         );
+        restoredFromAutosave = restoreFromAutosave;
         await setupModuleNamespaces(restarted.id);
       } finally {
         win.webContents.send(IPC.push.projectReloading, { status: "ready" });
@@ -572,6 +689,7 @@ export function registerKernelIpcHandlers(
         win.webContents.send(IPC.push.projectReloading, { status: "reloading" });
         try {
           await recoverUnsavedAfterRestart(oldWorkingDir);
+          restoredFromAutosave = true;
         } catch (err) {
           console.warn(
             "[ipc-register-kernels] post-restart recovery failed; the old session remains recoverable from the welcome screen:",
@@ -584,7 +702,7 @@ export function registerKernelIpcHandlers(
     }
     await bindActiveProjectModules(restarted.id);
 
-    return restarted;
+    return { kernel: restarted, restoredFromAutosave } satisfies KernelRestartResult;
     });
   });
 

--- a/electron/main/ipc-register-launchers.ts
+++ b/electron/main/ipc-register-launchers.ts
@@ -14,7 +14,7 @@
 
 import { spawn } from "child_process";
 
-import { ipcMain } from "electron";
+import { handleIpc } from "./ipc-registry";
 
 import { buildAgentInvocation } from "./agent-launcher";
 import type { PDVConfig } from "./config";
@@ -74,7 +74,7 @@ export function registerLaunchersIpcHandlers(
     getMcpStatus,
   } = options;
 
-  ipcMain.handle(
+  handleIpc(
     IPC.launchers.openAgent,
     async (): Promise<ScriptOperationResult> => {
       // Under E2E we never spawn an external terminal — the spawn is detached
@@ -116,7 +116,7 @@ export function registerLaunchersIpcHandlers(
     },
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.launchers.openWorkingDir,
     async (): Promise<ScriptOperationResult> => {
       if (process.env.PDV_E2E === "1") {
@@ -150,7 +150,7 @@ export function registerLaunchersIpcHandlers(
     },
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.launchers.checkAvailability,
     async (_event, check: LauncherCheck): Promise<boolean> => {
       try {

--- a/electron/main/ipc-register-module-windows.ts
+++ b/electron/main/ipc-register-module-windows.ts
@@ -11,7 +11,8 @@
  * - Module manifest or action execution logic.
  */
 
-import { BrowserWindow, ipcMain } from "electron";
+import { BrowserWindow } from "electron";
+import { handleIpc } from "./ipc-registry";
 
 import {
   IPC,
@@ -37,7 +38,7 @@ export function registerModuleWindowIpcHandlers(
 ): void {
   const { moduleWindowManager, mainWindow } = options;
 
-  ipcMain.handle(
+  handleIpc(
     IPC.moduleWindows.open,
     async (
       _event,
@@ -55,21 +56,21 @@ export function registerModuleWindowIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.moduleWindows.close,
     async (_event, alias: string): Promise<boolean> => {
       return moduleWindowManager.close(alias);
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.moduleWindows.context,
     async (event): Promise<ModuleWindowContext | null> => {
       return moduleWindowManager.getContextForSender(event.sender.id);
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.moduleWindows.executeInMain,
     async (event, code: string): Promise<void> => {
       const context = moduleWindowManager.getContextForSender(event.sender.id);

--- a/electron/main/ipc-register-modules.ts
+++ b/electron/main/ipc-register-modules.ts
@@ -14,7 +14,8 @@
 
 import * as fs from "fs/promises";
 import * as path from "path";
-import { BrowserWindow, dialog, ipcMain } from "electron";
+import { BrowserWindow, dialog } from "electron";
+import { handleIpc } from "./ipc-registry";
 
 import { CommRouter } from "./comm-router";
 import {
@@ -103,24 +104,24 @@ export function registerModulesIpcHandlers(
     runWithProjectManifestWriteLock,
   } = options;
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.listInstalled,
     async (): Promise<ModuleDescriptor[]> => moduleManager.listInstalled()
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.install,
     async (_event, request: ModuleInstallRequest): Promise<ModuleInstallResult> =>
       moduleManager.install(request)
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.checkUpdates,
     async (_event, moduleId: string): Promise<ModuleUpdateResult> =>
       moduleManager.checkUpdates(moduleId)
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.importToProject,
     async (_event, request: ModuleImportRequest): Promise<ModuleImportResult> => {
       const installedModules = await moduleManager.listInstalled();
@@ -239,7 +240,7 @@ export function registerModulesIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.createEmpty,
     async (_event, request: ModuleCreateEmptyRequest): Promise<ModuleCreateEmptyResult> => {
       // Normalize and validate the requested id. Collision detection mirrors
@@ -379,7 +380,7 @@ export function registerModulesIpcHandlers(
     },
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.updateMetadata,
     async (_event, request: ModuleUpdateMetadataRequest): Promise<ModuleUpdateMetadataResult> => {
       if (!request?.alias) {
@@ -422,7 +423,7 @@ export function registerModulesIpcHandlers(
     },
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.exportFromProject,
     async (_event, request: ModuleExportRequest): Promise<ModuleExportResult> => {
       if (!request?.alias) {
@@ -551,7 +552,7 @@ export function registerModulesIpcHandlers(
     },
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.listImported,
     async (): Promise<ImportedModuleDescriptor[]> => {
       if (!getActiveKernelId()) return [];
@@ -617,7 +618,7 @@ export function registerModulesIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.saveSettings,
     async (_event, request: ModuleSettingsRequest): Promise<ModuleSettingsResult> => {
       if (!request.values || typeof request.values !== "object" || Array.isArray(request.values)) {
@@ -674,7 +675,7 @@ export function registerModulesIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.runAction,
     async (_event, request: ModuleActionRequest): Promise<ModuleActionResult> => {
       if (!kernelManager.getKernel(request.kernelId)) {
@@ -739,7 +740,7 @@ export function registerModulesIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.removeImport,
     async (_event, moduleAlias: string): Promise<ModuleSettingsResult> => {
       const pendingImports = getPendingModuleImports();
@@ -782,13 +783,13 @@ export function registerModulesIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.uninstall,
     async (_event, moduleId: string): Promise<ModuleUninstallResult> =>
       moduleManager.uninstall(moduleId)
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.modules.update,
     async (_event, moduleId: string): Promise<ModuleInstallResult> =>
       moduleManager.update(moduleId)

--- a/electron/main/ipc-register-project.test.ts
+++ b/electron/main/ipc-register-project.test.ts
@@ -37,6 +37,11 @@ const fsMocks = vi.hoisted(() => ({
   rm: vi.fn(
     async (_path: string, _options?: { recursive?: boolean; force?: boolean }) => undefined,
   ),
+  // Default: reject (file absent) so the save handler's pyproject.toml probe
+  // classifies sessions as shared-mode unless a test opts in to uv.
+  access: vi.fn<(path: string) => Promise<void>>(async () => {
+    throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  }),
 }));
 
 const moduleRuntimeMocks = vi.hoisted(() => ({
@@ -45,6 +50,7 @@ const moduleRuntimeMocks = vi.hoisted(() => ({
 
 const projectFileSyncMocks = vi.hoisted(() => ({
   copyFilesForLoad: vi.fn(async () => [] as string[]),
+  copyEnvFilesForSave: vi.fn(async () => [] as string[]),
   overlayAutosaveTreeFiles: vi.fn(async () => undefined),
 }));
 
@@ -65,7 +71,7 @@ vi.mock("./module-runtime", () => moduleRuntimeMocks);
 vi.mock("./project-file-sync", () => projectFileSyncMocks);
 vi.mock("./module-manifest-writer", () => manifestWriterMocks);
 
-import { IPC } from "./ipc";
+import { IPC, type ActiveEnvironmentInfo } from "./ipc";
 import {
   registerProjectIpcHandlers,
   syncModuleOwnedFilesToSaveDir,
@@ -108,6 +114,7 @@ interface Harness {
   setPendingModuleSettings: Mock<(settings: Record<string, Record<string, unknown>>) => void>;
   refreshProjectModuleHealth: Mock<(dir: string | null) => Promise<ProjectManifest | null>>;
   clearModuleHealthWarnings: Mock<() => void>;
+  getActiveKernelEnvMeta: Mock<() => ActiveEnvironmentInfo | undefined>;
   onExplicitSaveCompleted: Mock<(saveDir: string) => void>;
 }
 
@@ -134,6 +141,7 @@ function setup(): Harness {
     setPendingModuleSettings: vi.fn<(settings: Record<string, Record<string, unknown>>) => void>(),
     refreshProjectModuleHealth: vi.fn<(dir: string | null) => Promise<ProjectManifest | null>>(async () => null),
     clearModuleHealthWarnings: vi.fn<() => void>(),
+    getActiveKernelEnvMeta: vi.fn<() => ActiveEnvironmentInfo | undefined>(() => undefined),
     onExplicitSaveCompleted: vi.fn<(saveDir: string) => void>(),
   };
   void activeProjectDir;
@@ -154,6 +162,7 @@ function setup(): Harness {
     runSerializedProjectManifestMutation: async (_dir, fn) => fn(),
     getMainWindow: () => win.win,
     getInterpreterPath: () => "/usr/bin/python3",
+    getActiveKernelEnvMeta: harness.getActiveKernelEnvMeta,
     onExplicitSaveCompleted: harness.onExplicitSaveCompleted,
   });
   return harness;
@@ -193,6 +202,62 @@ describe("project:save", () => {
     expect(harness.onExplicitSaveCompleted).toHaveBeenCalledWith("/save");
     expect(result.checksum).toBe("abc123");
     expect(result.projectName).toBe("demo");
+  });
+
+  it("uv project: records mode + python_version from kernel env metadata, omits interpreter_path (§10.5)", async () => {
+    const harness = setup();
+    // uv detection: the active kernel's working dir must contain a
+    // pyproject.toml — make the access probe succeed for it.
+    harness.getActiveKernelId.mockReturnValue("k1");
+    harness.kernelWorkingDirs.set("k1", "/tmp/uv-wd");
+    fsMocks.access.mockResolvedValueOnce(undefined);
+    harness.getActiveKernelEnvMeta.mockReturnValue({
+      mode: "uv",
+      interpreterPath: "/tmp/uv-wd/.venv/bin/python",
+      pythonVersion: "3.12",
+    });
+
+    await getHandler(IPC.project.save)({}, "/save", validCells);
+
+    const saveOpts = (harness.projectManager.save as Mock).mock.calls.at(-1)?.[2] as {
+      environment?: { mode: string; python_version?: string };
+      interpreterPath?: string;
+    };
+    expect(saveOpts.environment).toEqual({ mode: "uv", python_version: "3.12" });
+    // The venv path is ephemeral (lives in the working dir) — never recorded.
+    expect(saveOpts.interpreterPath).toBeUndefined();
+  });
+
+  it("shared project: records the interpreter the kernel actually spawned on", async () => {
+    const harness = setup();
+    harness.getActiveKernelId.mockReturnValue("k1");
+    // No pyproject.toml in the working dir → shared mode.
+    harness.getActiveKernelEnvMeta.mockReturnValue({
+      mode: "shared",
+      interpreterPath: "/opt/conda/envs/mpi/bin/python",
+      pythonVersion: "3.12",
+    });
+
+    await getHandler(IPC.project.save)({}, "/save", validCells);
+
+    const saveOpts = (harness.projectManager.save as Mock).mock.calls.at(-1)?.[2] as {
+      environment?: { mode: string };
+      interpreterPath?: string;
+    };
+    expect(saveOpts.environment).toEqual({ mode: "shared" });
+    expect(saveOpts.interpreterPath).toBe("/opt/conda/envs/mpi/bin/python");
+  });
+
+  it("shared project without kernel metadata: falls back to the global config interpreter", async () => {
+    const harness = setup();
+    harness.getActiveKernelEnvMeta.mockReturnValue(undefined);
+
+    await getHandler(IPC.project.save)({}, "/save", validCells);
+
+    const saveOpts = (harness.projectManager.save as Mock).mock.calls.at(-1)?.[2] as {
+      interpreterPath?: string;
+    };
+    expect(saveOpts.interpreterPath).toBe("/usr/bin/python3");
   });
 
   it("blocks save and skips state mutation when missingFiles is non-empty", async () => {

--- a/electron/main/ipc-register-project.ts
+++ b/electron/main/ipc-register-project.ts
@@ -14,7 +14,8 @@
 
 import * as fs from "fs/promises";
 import * as path from "path";
-import { ipcMain, type BrowserWindow } from "electron";
+import { type BrowserWindow } from "electron";
+import { handleIpc } from "./ipc-registry";
 
 import type { CommRouter } from "./comm-router";
 import type { CodeCellData } from "./ipc";
@@ -263,7 +264,7 @@ export function registerProjectIpcHandlers(
   // explicit save.
   let saveSeq = 0;
 
-  ipcMain.handle(
+  handleIpc(
     IPC.project.save,
     async (_event, saveDir: string, codeCells: unknown, projectName?: string) => {
       assertCodeCellData(codeCells);
@@ -405,7 +406,7 @@ export function registerProjectIpcHandlers(
     }
   );
 
-  ipcMain.handle(IPC.project.load, async (_event, saveDir: string, options?: { restoreFromAutosave?: boolean }) => {
+  handleIpc(IPC.project.load, async (_event, saveDir: string, options?: { restoreFromAutosave?: boolean }) => {
     const restoreFromAutosave = options?.restoreFromAutosave ?? false;
     const autosaveDir = path.join(saveDir, ".autosave");
 
@@ -536,7 +537,7 @@ export function registerProjectIpcHandlers(
     return path.join(workingDir, "code-cells.json");
   };
 
-  ipcMain.handle(IPC.codeCells.load, async (): Promise<CodeCellData | null> => {
+  handleIpc(IPC.codeCells.load, async (): Promise<CodeCellData | null> => {
     const filePath = codeCellsFilePath();
     if (!filePath) return null;
     try {
@@ -550,7 +551,7 @@ export function registerProjectIpcHandlers(
     }
   });
 
-  ipcMain.handle(IPC.codeCells.save, async (_event, data: unknown): Promise<boolean> => {
+  handleIpc(IPC.codeCells.save, async (_event, data: unknown): Promise<boolean> => {
     assertCodeCellData(data);
     const filePath = codeCellsFilePath();
     if (!filePath) return false;
@@ -558,7 +559,7 @@ export function registerProjectIpcHandlers(
     return true;
   });
 
-  ipcMain.handle(IPC.project.new, async () => {
+  handleIpc(IPC.project.new, async () => {
     setActiveProjectDir(null);
     setPendingModuleImports([]);
     setPendingModuleSettings({});
@@ -566,7 +567,7 @@ export function registerProjectIpcHandlers(
     return true;
   });
 
-  ipcMain.handle(
+  handleIpc(
     IPC.project.peekLanguages,
     async (_event, paths: string[]): Promise<Record<string, "python" | "julia">> => {
       const result: Record<string, "python" | "julia"> = {};
@@ -584,7 +585,7 @@ export function registerProjectIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.project.peekManifest,
     async (_event, dir: string) => {
       try {

--- a/electron/main/ipc-register-project.ts
+++ b/electron/main/ipc-register-project.ts
@@ -18,7 +18,7 @@ import { type BrowserWindow } from "electron";
 import { handleIpc } from "./ipc-registry";
 
 import type { CommRouter } from "./comm-router";
-import type { CodeCellData } from "./ipc";
+import type { ActiveEnvironmentInfo, CodeCellData } from "./ipc";
 import { IPC } from "./ipc";
 import { ModuleManager } from "./module-manager";
 import { setupProjectModuleNamespaces } from "./module-runtime";
@@ -61,7 +61,19 @@ interface RegisterProjectIpcHandlersOptions {
    */
   runSerializedProjectManifestMutation: <T>(dir: string, task: () => Promise<T>) => Promise<T>;
   getMainWindow: () => BrowserWindow | null;
+  /**
+   * Fallback interpreter path from the global config, used only when the
+   * active kernel has no recorded environment metadata (legacy sessions).
+   */
   getInterpreterPath: () => string | undefined;
+  /**
+   * Environment metadata of the active kernel (mode, actual interpreter,
+   * resolved Python version), recorded by `kernels.start`/`restart`. The
+   * authoritative source for the manifest's `environment` and
+   * `interpreter_path` fields at save time (§10.5); undefined when no
+   * kernel is active or the entry is missing.
+   */
+  getActiveKernelEnvMeta: () => ActiveEnvironmentInfo | undefined;
   /** Called after a successful explicit save to clean up autosave state. */
   onExplicitSaveCompleted?: (saveDir: string) => void;
 }
@@ -253,6 +265,7 @@ export function registerProjectIpcHandlers(
     runSerializedProjectManifestMutation,
     getMainWindow,
     getInterpreterPath,
+    getActiveKernelEnvMeta,
     onExplicitSaveCompleted,
   } = options;
 
@@ -286,11 +299,21 @@ export function registerProjectIpcHandlers(
               .catch(() => false)
           : false;
 
+        // Environment recording (§10.5): uv projects record mode + the
+        // resolved Python version (the venv path is ephemeral, so no
+        // interpreter_path); shared projects record the interpreter the
+        // kernel actually spawned on — falling back to the global config
+        // value only when no per-kernel metadata exists (legacy sessions).
+        const envMeta = getActiveKernelEnvMeta();
         const saveResult = await projectManager.save(saveDir, codeCells, {
           language: getActiveKernelLanguage(),
-          interpreterPath: getInterpreterPath(),
+          interpreterPath: isUvProject
+            ? undefined
+            : (envMeta?.interpreterPath ?? getInterpreterPath()),
           projectName,
-          environment: isUvProject ? { mode: "uv" } : undefined,
+          environment: isUvProject
+            ? { mode: "uv", python_version: envMeta?.pythonVersion }
+            : { mode: "shared" },
         });
 
         // If the serializer detected missing backing files it aborted before

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -12,7 +12,7 @@
  */
 
 import { spawn } from "child_process";
-import { ipcMain } from "electron";
+import { handleIpc } from "./ipc-registry";
 import * as fs from "fs/promises";
 import * as path from "path";
 
@@ -232,7 +232,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     return await commRouter.request(type, payload);
   };
 
-  ipcMain.handle(IPC.tree.list, async (_event, kernelId: string, nodePath = "") => {
+  handleIpc(IPC.tree.list, async (_event, kernelId: string, nodePath = "") => {
     if (!kernelManager.getKernel(kernelId)) {
       return [];
     }
@@ -243,7 +243,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     return Array.isArray(nodes) ? nodes : [];
   });
 
-  ipcMain.handle(IPC.tree.get, async (_event, kernelId: string, nodePath: string) => {
+  handleIpc(IPC.tree.get, async (_event, kernelId: string, nodePath: string) => {
     if (!kernelManager.getKernel(kernelId)) {
       throw new Error(`Kernel not found: ${kernelId}`);
     }
@@ -253,7 +253,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     return response.payload;
   });
 
-  ipcMain.handle(
+  handleIpc(
     IPC.tree.createScript,
     async (
       _event,
@@ -279,7 +279,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
       ),
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.tree.createNote,
     async (
       _event,
@@ -302,7 +302,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
       ),
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.tree.createGui,
     async (
       _event,
@@ -366,7 +366,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.tree.createLib,
     async (
       _event,
@@ -432,7 +432,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     },
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.tree.addFile,
     async (
       _event,
@@ -462,7 +462,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.namespace.query,
     async (
       _event,
@@ -502,7 +502,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.namespace.inspect,
     async (
       _event,
@@ -520,7 +520,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   );
 
-  ipcMain.handle(IPC.script.run, async (_event, kernelId: string, request: ScriptRunRequest): Promise<ScriptRunResult> => {
+  handleIpc(IPC.script.run, async (_event, kernelId: string, request: ScriptRunRequest): Promise<ScriptRunResult> => {
     const kernel = kernelManager.getKernel(kernelId);
     if (!kernel) throw new Error(`Kernel not found: ${kernelId}`);
 
@@ -583,7 +583,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     return { code, executionId, origin, result };
   });
 
-  ipcMain.handle(IPC.script.edit, async (_event, _kernelId: string, scriptPath: string) => {
+  handleIpc(IPC.script.edit, async (_event, _kernelId: string, scriptPath: string) => {
     // Under E2E we never spawn an external editor — the spawn is detached
     // (`detached: true`, `child.unref()`) so a real VS Code instance launched
     // by a test would outlive the Electron app being torn down.
@@ -626,7 +626,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   });
 
-  ipcMain.handle(
+  handleIpc(
     IPC.script.getParams,
     async (_event, _kernelId: string, treePath: string): Promise<ScriptParameter[]> => {
       const response = await commRouter.request(PDVMessageType.SCRIPT_PARAMS, {
@@ -637,7 +637,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.note.save,
     async (_event, _kernelId: string, treePath: string, content: string) => {
       try {
@@ -658,7 +658,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.note.read,
     async (_event, _kernelId: string, treePath: string) => {
       try {
@@ -678,7 +678,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.tree.invokeHandler,
     async (
       _event,
@@ -709,7 +709,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     mapResult: (payload: Record<string, unknown>) => T,
     actionLabel?: string,
   ): void {
-    ipcMain.handle(channel, async (_event, kernelId: string, ...rest: string[]): Promise<T> => {
+    handleIpc(channel, async (_event, kernelId: string, ...rest: string[]): Promise<T> => {
       if (!kernelManager.getKernel(kernelId)) {
         return { success: false, error: "No active kernel. Try restarting the kernel." } as T;
       }
@@ -756,7 +756,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     "duplicate the node",
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.tree.delete,
     async (
       _event,
@@ -778,7 +778,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.namelist.read,
     async (
       _event,
@@ -795,7 +795,7 @@ export function registerTreeNamespaceScriptIpcHandlers(
     }
   );
 
-  ipcMain.handle(
+  handleIpc(
     IPC.namelist.write,
     async (
       _event,

--- a/electron/main/ipc-registry.test.ts
+++ b/electron/main/ipc-registry.test.ts
@@ -1,0 +1,91 @@
+/**
+ * ipc-registry.test.ts — Unit tests for the self-recording IPC registry.
+ *
+ * The mock `ipcMain` here reproduces real Electron semantics faithfully —
+ * `handle()` THROWS on a duplicate registration (the coverage meta-test's
+ * mock silently overwrites, which is exactly how the original
+ * REGISTERED_CHANNELS drift bug stayed invisible to tests). The core
+ * regression: a full register → removeAll → register cycle must not
+ * throw, because that is the macOS close-window → activate → re-create
+ * path that used to crash on the 17 channels missing from the
+ * hand-maintained list.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ipcMock = vi.hoisted(() => {
+  const handlers = new Map<string, unknown>();
+  return {
+    handlers,
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: unknown) => {
+        if (handlers.has(channel)) {
+          // Real Electron behavior.
+          throw new Error(
+            `Attempted to register a second handler for '${channel}'`,
+          );
+        }
+        handlers.set(channel, handler);
+      }),
+      removeHandler: vi.fn((channel: string) => {
+        handlers.delete(channel);
+      }),
+    },
+  };
+});
+
+vi.mock("electron", () => ({ ipcMain: ipcMock.ipcMain }));
+
+import {
+  handleIpc,
+  listRegisteredIpcChannels,
+  removeAllIpcHandlers,
+} from "./ipc-registry";
+
+afterEach(() => {
+  removeAllIpcHandlers();
+  ipcMock.handlers.clear();
+  vi.clearAllMocks();
+});
+
+describe("handleIpc", () => {
+  it("registers with ipcMain and records the channel", () => {
+    const handler = vi.fn();
+    handleIpc("test:one", handler);
+    expect(ipcMock.ipcMain.handle).toHaveBeenCalledWith("test:one", handler);
+    expect(listRegisteredIpcChannels()).toEqual(["test:one"]);
+  });
+
+  it("preserves Electron's throw on duplicate registration", () => {
+    handleIpc("test:dup", vi.fn());
+    expect(() => handleIpc("test:dup", vi.fn())).toThrow(/second handler/);
+    // The failed registration must not be double-recorded.
+    expect(listRegisteredIpcChannels()).toEqual(["test:dup"]);
+  });
+});
+
+describe("removeAllIpcHandlers", () => {
+  it("removes exactly the recorded channels and clears the record", () => {
+    handleIpc("test:a", vi.fn());
+    handleIpc("test:b", vi.fn());
+    removeAllIpcHandlers();
+    expect(ipcMock.ipcMain.removeHandler).toHaveBeenCalledWith("test:a");
+    expect(ipcMock.ipcMain.removeHandler).toHaveBeenCalledWith("test:b");
+    expect(listRegisteredIpcChannels()).toEqual([]);
+  });
+
+  it("register → removeAll → register does not throw (macOS reopen regression)", () => {
+    // With the hand-maintained channel list, any channel registered but
+    // missing from the list survived unregisterIpcHandlers() and threw
+    // "second handler" when the window was re-created. With the registry,
+    // teardown is derived from the registrations, so the cycle is safe
+    // for every channel by construction.
+    const channels = ["test:x", "test:y", "test:z"];
+    for (const c of channels) handleIpc(c, vi.fn());
+    removeAllIpcHandlers();
+    expect(() => {
+      for (const c of channels) handleIpc(c, vi.fn());
+    }).not.toThrow();
+    expect(listRegisteredIpcChannels()).toEqual(channels);
+  });
+});

--- a/electron/main/ipc-registry.ts
+++ b/electron/main/ipc-registry.ts
@@ -1,0 +1,69 @@
+/**
+ * ipc-registry.ts — Self-recording wrapper around `ipcMain.handle`.
+ *
+ * Every `ipcMain.handle` registration in the main process goes through
+ * `handleIpc`, which records the channel name as a side effect. Teardown
+ * (`removeAllIpcHandlers`) then removes exactly the set of channels that
+ * were actually registered.
+ *
+ * This replaces the hand-maintained `REGISTERED_CHANNELS` list that
+ * previously lived in `index.ts`. That list had drifted: 17 registered
+ * channels were missing (so the macOS close-window → activate →
+ * re-register path threw "Attempted to register a second handler"), and
+ * 4 stale entries referenced channels that were no longer registered at
+ * all. Deriving the list from the registrations themselves makes that
+ * class of drift structurally impossible.
+ *
+ * This module does NOT own any handler logic, channel-name constants
+ * (those live in `ipc.ts`), or `ipcMain.on`-style event listeners —
+ * only `handle`/`removeHandler` bookkeeping.
+ */
+
+import { ipcMain } from "electron";
+
+/** Handler signature accepted by `ipcMain.handle`, reused verbatim. */
+type IpcInvokeHandler = Parameters<typeof ipcMain.handle>[1];
+
+/** Channels currently registered through {@link handleIpc}. */
+const registeredChannels = new Set<string>();
+
+/**
+ * Register an `ipcMain.handle` listener and record its channel for
+ * later teardown.
+ *
+ * @param channel - IPC channel name (a constant from `ipc.ts`).
+ * @param handler - Invoke handler, exactly as `ipcMain.handle` accepts.
+ * @throws Error if `ipcMain` already has a handler for `channel`
+ *   (propagated from Electron) — indicating a registration made without
+ *   a matching teardown, the exact bug this registry exists to prevent.
+ */
+export function handleIpc(channel: string, handler: IpcInvokeHandler): void {
+  ipcMain.handle(channel, handler);
+  registeredChannels.add(channel);
+}
+
+/**
+ * Remove every handler registered through {@link handleIpc} and clear
+ * the record. Called by `unregisterIpcHandlers()` before the handlers
+ * are registered anew (e.g. macOS window re-creation on activate).
+ *
+ * @returns Nothing.
+ */
+export function removeAllIpcHandlers(): void {
+  for (const channel of registeredChannels) {
+    ipcMain.removeHandler(channel);
+  }
+  registeredChannels.clear();
+}
+
+/**
+ * Snapshot of the channels currently registered through {@link handleIpc}.
+ *
+ * Exposed for tests (e.g. asserting that registration and teardown stay
+ * symmetric); production code should not need it.
+ *
+ * @returns A new array of the recorded channel names.
+ */
+export function listRegisteredIpcChannels(): string[] {
+  return [...registeredChannels];
+}

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -363,6 +363,8 @@ export const IPC = {
     removePackage: "environment:removePackage",
     /** Packages UI: `uv lock --upgrade-package <names>` + `uv sync`. */
     upgradePackage: "environment:upgradePackage",
+    /** Active kernel's environment metadata (Project Environment tab header). */
+    activeInfo: "environment:activeInfo",
   },
   /** Native file/directory picker channels. */
   files: {
@@ -1485,6 +1487,46 @@ export interface KernelUvContext {
    * default packages (§10.5.8) rather than copying from a save directory.
    */
   newProject?: boolean;
+  /**
+   * Python version for a new project's venv, chosen in the New Project
+   * dialog (e.g. `"3.13"`). Passed to `uv sync --python` and pinned in the
+   * working dir's `.python-version`. Only meaningful with `newProject`;
+   * must be one of `SUPPORTED_PYTHON_VERSIONS`.
+   */
+  pythonVersion?: string;
+  /**
+   * Initial PEP 508 dependency specs for a new project's `pyproject.toml`,
+   * chosen in the New Project dialog. Only meaningful with `newProject`;
+   * when absent, the user's global default packages are used.
+   */
+  packages?: string[];
+}
+
+/**
+ * Result of `kernels.restart`: the freshly started kernel plus whether the
+ * project state was restored from a pre-restart autosave snapshot (`true`)
+ * or the session came back empty (`false`). Drives the renderer's
+ * post-restart console message.
+ */
+export interface KernelRestartResult {
+  /** Metadata of the newly started kernel. */
+  kernel: KernelInfo;
+  /** True when tree/cell state was reloaded from an autosave snapshot. */
+  restoredFromAutosave: boolean;
+}
+
+/**
+ * Environment metadata for the active kernel, shown in the Project
+ * Environment settings tab. `null` is returned by the IPC handler when no
+ * kernel is active.
+ */
+export interface ActiveEnvironmentInfo {
+  /** Whether the session runs in a uv-managed project venv or a shared env. */
+  mode: "uv" | "shared";
+  /** Interpreter the kernel actually spawned on (venv python for uv mode). */
+  interpreterPath?: string;
+  /** Resolved `major.minor` Python version of that interpreter. */
+  pythonVersion?: string;
 }
 
 /**
@@ -1701,12 +1743,12 @@ export interface PDVApi {
      */
     interrupt(kernelId: string): Promise<boolean>;
     /**
-     * Restart a running kernel.
+     * Restart a running (or crashed) kernel.
      *
      * @param kernelId - Target kernel ID.
-     * @returns Newly started kernel metadata.
+     * @returns The new kernel plus whether state was restored from autosave.
      */
-    restart(kernelId: string): Promise<KernelInfo>;
+    restart(kernelId: string): Promise<KernelRestartResult>;
     /**
      * Request code completion from a kernel.
      *
@@ -2319,6 +2361,14 @@ export interface PDVApi {
      * @returns The uv result.
      */
     upgradePackage(names: string[]): Promise<EnvironmentInstallResult>;
+    /**
+     * Fetch the active kernel's environment metadata for the Project
+     * Environment settings tab.
+     *
+     * @returns Mode, interpreter path, and Python version of the active
+     *   kernel's environment, or `null` when no kernel is active.
+     */
+    activeInfo(): Promise<ActiveEnvironmentInfo | null>;
   };
 
   /** App configuration accessors. */
@@ -2729,6 +2779,13 @@ export interface PDVApi {
      * action-bar buttons) can branch on platform without an async call.
      */
     platform: NodeJS.Platform;
+    /**
+     * CPython minor versions offered by the New Project dialog, oldest
+     * first. Compile-time constant from `python-versions.ts`.
+     */
+    supportedPythonVersions: readonly string[];
+    /** Version preselected in the New Project dialog (e.g. `"3.13"`). */
+    defaultPythonVersion: string;
   };
 
   /** External-app launchers driven by the action bar. */

--- a/electron/main/kernel-manager.ts
+++ b/electron/main/kernel-manager.ts
@@ -342,6 +342,14 @@ async function loadZmq(): Promise<typeof import("zeromq")> {
   return import("zeromq");
 }
 
+/**
+ * ``receiveTimeout`` (ms) for the query REQ socket, so ``receive()``
+ * throws instead of blocking forever if the kernel dies (or stalls)
+ * mid-request. Shared by socket creation and by
+ * ``recreateQuerySocket`` so the replacement socket always matches.
+ */
+const QUERY_RECEIVE_TIMEOUT_MS = 10_000;
+
 // ---------------------------------------------------------------------------
 // KernelManager
 // ---------------------------------------------------------------------------
@@ -481,7 +489,8 @@ export class KernelManager extends EventEmitter {
     querySocket.linger = 0;
     // receiveTimeout prevents receive() from blocking forever if the kernel
     // dies mid-request.  The sendQueryRequest queue would deadlock otherwise.
-    (querySocket as unknown as { receiveTimeout: number }).receiveTimeout = 10_000;
+    (querySocket as unknown as { receiveTimeout: number }).receiveTimeout =
+      QUERY_RECEIVE_TIMEOUT_MS;
 
     const base = `${connectionInfo.transport}://${connectionInfo.ip}`;
     await shellSocket.connect(`${base}:${shellPort}`);
@@ -1107,11 +1116,57 @@ export class KernelManager extends EventEmitter {
           const [reply] = await managed.querySocket.receive();
           resolve(JSON.parse(reply.toString("utf-8")));
         } catch (err) {
+          // A failed send/receive (typically the receive timeout) leaves
+          // the REQ socket with an outstanding request; REQ enforces a
+          // strict send → receive alternation, so every later send() on
+          // it fails immediately. Replace the socket so one timed-out
+          // query doesn't wedge the query channel for the rest of the
+          // session. This runs inside the serialized queue, so nothing
+          // else can touch the socket mid-swap.
+          if (!managed.shuttingDown) {
+            await this.recreateQuerySocket(managed);
+          }
           reject(err);
         }
       });
     });
     return result;
+  }
+
+  /**
+   * Replace a kernel's query socket with a freshly connected one.
+   *
+   * Called from the serialized query queue after a send/receive failure
+   * (see ``sendQueryRequest``). The old socket is closed (``linger = 0``,
+   * so this never blocks) and a new REQ socket is connected to the same
+   * endpoint with the same options.
+   *
+   * @param managed - Managed kernel whose query socket to replace.
+   * @returns Nothing.
+   * @throws Never — replacement failures are logged and the next query
+   *   surfaces any persistent connection problem itself.
+   */
+  private async recreateQuerySocket(managed: ManagedKernel): Promise<void> {
+    try {
+      managed.querySocket.close();
+    } catch {
+      /* already closed */
+    }
+    try {
+      const zmq = await loadZmq();
+      const fresh = new zmq.Request();
+      fresh.linger = 0;
+      (fresh as unknown as { receiveTimeout: number }).receiveTimeout =
+        QUERY_RECEIVE_TIMEOUT_MS;
+      const ci = managed.connectionInfo;
+      await fresh.connect(`${ci.transport}://${ci.ip}:${ci.query_port}`);
+      managed.querySocket = fresh;
+    } catch (err) {
+      console.warn(
+        "[KernelManager] Failed to recreate query socket after error:",
+        err,
+      );
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/electron/main/module-manager.test.ts
+++ b/electron/main/module-manager.test.ts
@@ -241,6 +241,79 @@ describe("ModuleManager", () => {
     expect(installed.some((entry) => entry.id === "git_mod")).toBe(true);
   });
 
+  it("git reinstall reporting up_to_date leaves the installed files untouched (regression)", async () => {
+    // The github path used to replaceDirectory BEFORE the duplicate-install
+    // check, so a reinstall rewrote the module on disk even while returning
+    // up_to_date against the unchanged index — files and index could
+    // disagree. Duplicate installs must not touch the installed files;
+    // only a user-confirmed update() replaces them.
+    const repoSource = path.join(tmpDir, "repo-reinstall");
+    await fs.mkdir(repoSource, { recursive: true });
+    await runGit(repoSource, ["init"]);
+    await runGit(repoSource, ["config", "user.email", "pdv-tests@example.com"]);
+    await runGit(repoSource, ["config", "user.name", "PDV Tests"]);
+    await writeModuleFixture(repoSource, "reinstall_mod", "1.0.0");
+    await runGit(repoSource, ["add", "."]);
+    await runGit(repoSource, ["commit", "-m", "initial module"]);
+
+    const first = await manager.install({
+      source: { type: "github", location: repoSource },
+    });
+    expect(first.status).toBe("installed");
+    const installPath = first.module!.installPath!;
+
+    // Marker: a local change inside the installed copy. A reinstall that
+    // rewrites the directory would wipe it.
+    const markerPath = path.join(installPath, "scripts", "run.py");
+    await fs.writeFile(markerPath, "# locally modified marker\n", "utf8");
+
+    const second = await manager.install({
+      source: { type: "github", location: repoSource },
+    });
+    expect(second.success).toBe(true);
+    expect(second.status).toBe("up_to_date");
+    expect(await fs.readFile(markerPath, "utf8")).toBe(
+      "# locally modified marker\n",
+    );
+  });
+
+  it("git reinstall of a newer version reports update_available without replacing files", async () => {
+    const repoSource = path.join(tmpDir, "repo-newer");
+    await fs.mkdir(repoSource, { recursive: true });
+    await runGit(repoSource, ["init"]);
+    await runGit(repoSource, ["config", "user.email", "pdv-tests@example.com"]);
+    await runGit(repoSource, ["config", "user.name", "PDV Tests"]);
+    await writeModuleFixture(repoSource, "newer_mod", "1.0.0");
+    await runGit(repoSource, ["add", "."]);
+    await runGit(repoSource, ["commit", "-m", "v1.0.0"]);
+
+    const first = await manager.install({
+      source: { type: "github", location: repoSource },
+    });
+    const installPath = first.module!.installPath!;
+
+    await writeModuleFixture(repoSource, "newer_mod", "1.1.0");
+    await runGit(repoSource, ["add", "."]);
+    await runGit(repoSource, ["commit", "-m", "v1.1.0"]);
+
+    const second = await manager.install({
+      source: { type: "github", location: repoSource },
+    });
+    expect(second.status).toBe("update_available");
+    expect(second.currentVersion).toBe("1.0.0");
+
+    // On-disk manifest still carries the installed version until the
+    // user confirms the update through update().
+    const manifestRaw = await fs.readFile(
+      path.join(installPath, "pdv-module.json"),
+      "utf8",
+    );
+    expect(JSON.parse(manifestRaw).version).toBe("1.0.0");
+
+    const installed = await manager.listInstalled();
+    expect(installed.find((m) => m.id === "newer_mod")?.version).toBe("1.0.0");
+  });
+
   it("resolves canonical script bindings from manifest actions", async () => {
     const localSource = path.join(tmpDir, "binding-source");
     await writeModuleFixture(localSource, "binding_mod", "1.0.0", [

--- a/electron/main/module-manager.ts
+++ b/electron/main/module-manager.ts
@@ -22,6 +22,8 @@ import { statSync } from "fs";
 import * as path from "path";
 import { promisify } from "util";
 
+import { atomicWriteJson } from "./atomic-write";
+
 import type {
   ModuleDescriptor,
   ModuleHealthWarning,
@@ -1063,9 +1065,6 @@ export class ModuleManager {
       const moduleDir = path.join(this.packagesRoot, manifest.id);
       const previous = index.modules[manifest.id];
 
-      await this.replaceDirectory(stagingDir, moduleDir);
-      didMoveStaging = true;
-
       const descriptor: ModuleDescriptor = {
         id: manifest.id,
         name: manifest.name,
@@ -1078,6 +1077,15 @@ export class ModuleManager {
         upstream: manifest.upstream ?? normalizedSource.location,
       };
       if (previous) {
+        // Duplicate install: report the update status WITHOUT touching
+        // the installed files — the staged clone is discarded by the
+        // `finally` below. (This used to replaceDirectory first, so a
+        // reinstall overwrote the module on disk even while returning
+        // `up_to_date` and keeping the old index entry: files and index
+        // could disagree. The local-source path already returned before
+        // touching moduleDir; this now matches it and `install()`'s
+        // documented duplicate-install contract. A user-confirmed
+        // update goes through `update()`, which replaces deliberately.)
         const status = this.duplicateInstallStatus(previous, descriptor);
         this.recordUpdateCheck(index, descriptor, status);
         await this.writeIndex(index);
@@ -1089,6 +1097,9 @@ export class ModuleManager {
           currentRevision: previous.revision,
         };
       }
+
+      await this.replaceDirectory(stagingDir, moduleDir);
+      didMoveStaging = true;
       this.upsertIndex(index, descriptor);
       await this.writeIndex(index);
       return {
@@ -1167,7 +1178,8 @@ export class ModuleManager {
    * @param index - Index payload to write.
    */
   private async writeIndex(index: ModuleStoreIndex): Promise<void> {
-    await fs.writeFile(this.indexPath, JSON.stringify(index, null, 2), "utf8");
+    // Atomic: a torn module-index.json would orphan every installed module.
+    await atomicWriteJson(this.indexPath, index);
   }
 
   /**

--- a/electron/main/project-file-sync.test.ts
+++ b/electron/main/project-file-sync.test.ts
@@ -148,4 +148,20 @@ describe("copyEnvFilesForLoad() / copyEnvFilesForSave()", () => {
     expect(copied).toEqual(["pyproject.toml"]);
     expect(await fs.readFile(path.join(saveDir, "uv.lock"), "utf8")).toBe("good-lock\n");
   });
+
+  it("round-trips the .python-version pin through save and open (§10.5.8)", async () => {
+    await fs.writeFile(path.join(workingDir, "pyproject.toml"), "[project]\n");
+    await fs.writeFile(path.join(workingDir, ".python-version"), "3.12\n");
+
+    const savedNames = await copyEnvFilesForSave(workingDir, saveDir);
+    expect(savedNames).toContain(".python-version");
+
+    const otherWorkingDir = path.join(path.dirname(saveDir), "working2");
+    await fs.mkdir(otherWorkingDir, { recursive: true });
+    const loadedNames = await copyEnvFilesForLoad(saveDir, otherWorkingDir);
+    expect(loadedNames).toContain(".python-version");
+    expect(await fs.readFile(path.join(otherWorkingDir, ".python-version"), "utf8")).toBe(
+      "3.12\n",
+    );
+  });
 });

--- a/electron/main/project-file-sync.ts
+++ b/electron/main/project-file-sync.ts
@@ -140,12 +140,18 @@ export async function copyFilesForLoad(
   return failedPaths;
 }
 
-/** uv environment files that travel between the save dir and working dir. */
-const ENV_FILES = ["pyproject.toml", "uv.lock"];
+/**
+ * uv environment files that travel between the save dir and working dir.
+ * `.python-version` is uv's native interpreter pin, written at project
+ * creation from the New Project dialog's version choice; carrying it here
+ * makes the pinned version survive save → open round-trips.
+ */
+const ENV_FILES = ["pyproject.toml", "uv.lock", ".python-version"];
 
 /**
- * Copy uv environment files (`pyproject.toml`, `uv.lock`) from the project
- * save directory into the kernel working directory.
+ * Copy uv environment files (`pyproject.toml`, `uv.lock`,
+ * `.python-version`) from the project save directory into the kernel
+ * working directory.
  *
  * Called for `mode: "uv"` projects before `uv sync` so the working directory
  * is a self-contained uv project (ARCHITECTURE.md §10.5.3, §10.5.9). Files
@@ -173,8 +179,9 @@ export async function copyEnvFilesForLoad(
 }
 
 /**
- * Copy uv environment files (`pyproject.toml`, `uv.lock`) from the kernel
- * working directory back into the project save directory (§10.5.10).
+ * Copy uv environment files (`pyproject.toml`, `uv.lock`,
+ * `.python-version`) from the kernel working directory back into the
+ * project save directory (§10.5.10).
  *
  * Only files present in the working directory are copied — a project whose
  * `uv sync` failed may have no `uv.lock`, and a missing working-dir file must

--- a/electron/main/project-manager.ts
+++ b/electron/main/project-manager.ts
@@ -819,6 +819,10 @@ export class ProjectManager {
    *
    * @param autosaveDir - The .autosave/ directory to write to (will be created).
    * @param codeCells - Current code-cell state from the renderer.
+   * @param opts - Optional overrides. ``timeoutMs`` bounds the kernel comm
+   *   request (default: the CommRouter's 30 s); the pre-restart snapshot
+   *   passes a short timeout so a wedged-but-alive kernel cannot stall the
+   *   restart.
    * @returns The kernel response (checksum, node count, module bundles), or
    *   null on error. ``moduleOwnedFiles`` and ``moduleManifests`` are
    *   forwarded so the autosave handler can mirror module state into the
@@ -827,6 +831,7 @@ export class ProjectManager {
   async autosave(
     autosaveDir: string,
     codeCells: CodeCellData,
+    opts?: { timeoutMs?: number },
   ): Promise<{
     checksum: string;
     nodeCount: number;
@@ -845,7 +850,7 @@ export class ProjectManager {
         save_dir: autosaveDir,
         is_autosave: true,
         clear_cache: clearCache,
-      }, { keepAlivePushType: PDVMessageType.PROGRESS });
+      }, { keepAlivePushType: PDVMessageType.PROGRESS, timeoutMs: opts?.timeoutMs });
 
       const payload = response.payload as unknown as PDVProjectSaveResponsePayload & {
         module_owned_files?: ModuleOwnedFile[];

--- a/electron/main/python-versions.ts
+++ b/electron/main/python-versions.ts
@@ -1,0 +1,48 @@
+/**
+ * python-versions.ts — Supported Python version range for PDV projects.
+ *
+ * Single source of truth for the CPython versions the New Project dialog
+ * offers and `kernels.start` accepts for uv-managed projects. The range must
+ * track `requires-python` in `pdv-python/pyproject.toml` (floor) and the
+ * newest CPython pdv-python is tested against (ceiling).
+ *
+ * This file does NOT probe interpreters or talk to uv — it is pure constants
+ * plus a version-string parser, safe to import from both the main process and
+ * the preload script (the constants are re-exposed to the renderer as static
+ * values under `window.pdv.system`).
+ */
+
+/**
+ * CPython minor versions supported for uv-managed PDV projects, oldest first.
+ * Keep in sync with `requires-python = ">=3.10"` in pdv-python/pyproject.toml.
+ */
+export const SUPPORTED_PYTHON_VERSIONS: readonly string[] = [
+  "3.10",
+  "3.11",
+  "3.12",
+  "3.13",
+  "3.14",
+];
+
+/**
+ * Default Python version preselected in the New Project dialog. One behind
+ * the newest supported release so the scientific stack's wheels are reliably
+ * available; users who want the newest pick it explicitly.
+ */
+export const DEFAULT_PYTHON_VERSION = "3.13";
+
+/**
+ * Parse a `python --version` style string down to its `major.minor` pair.
+ *
+ * Accepts the interpreter's stdout (e.g. `"Python 3.13.2"`) or a bare
+ * version string (e.g. `"3.10.5rc1"`); anything after the minor component
+ * is ignored.
+ *
+ * @param versionOutput - Raw version text to parse.
+ * @returns The `"major.minor"` string (e.g. `"3.13"`), or `undefined` when
+ *   no version number can be found.
+ */
+export function parseMajorMinor(versionOutput: string): string | undefined {
+  const match = /(\d+)\.(\d+)/.exec(versionOutput);
+  return match ? `${match[1]}.${match[2]}` : undefined;
+}

--- a/electron/main/query-socket-recovery.test.ts
+++ b/electron/main/query-socket-recovery.test.ts
@@ -1,0 +1,145 @@
+/**
+ * query-socket-recovery.test.ts — Query socket recovers after a timeout.
+ *
+ * Regression coverage for the query-channel wedge: a ZMQ REQ socket
+ * enforces a strict send → receive alternation, so after one timed-out
+ * ``receive()`` the outstanding request left every subsequent ``send()``
+ * failing — one slow query permanently degraded tree/namespace queries
+ * to the comm-router fallback until the Jupyter server was restarted.
+ * ``sendQueryRequest`` now replaces the socket after a failure.
+ *
+ * Uses real ZeroMQ sockets (no Python subprocess, unlike the @slow
+ * kernel-manager suites): the test binds a ROUTER peer that deliberately
+ * ignores the first request (forcing the client timeout) and answers
+ * later ones — which only ever reach it if the wedged socket was
+ * replaced.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import * as zmq from "zeromq";
+import { KernelManager } from "./kernel-manager";
+
+/** Minimal slice of ManagedKernel that the query path touches. */
+interface FakeManaged {
+  querySocket: zmq.Request;
+  queryQueue: Promise<unknown>;
+  shuttingDown: boolean;
+  connectionInfo: { transport: string; ip: string; query_port: number };
+}
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const fn of cleanups.splice(0)) {
+    try {
+      fn();
+    } catch {
+      /* already closed */
+    }
+  }
+});
+
+/** Bind a ROUTER that ignores the first request and echoes an ok-reply to the rest. */
+async function startRouterPeer(): Promise<{ port: number }> {
+  const router = new zmq.Router();
+  await router.bind("tcp://127.0.0.1:0");
+  cleanups.push(() => router.close());
+  const endpoint = router.lastEndpoint;
+  if (!endpoint) throw new Error("router did not report its endpoint");
+  const port = Number(endpoint.split(":").pop());
+
+  void (async () => {
+    let n = 0;
+    try {
+      for await (const frames of router) {
+        n += 1;
+        if (n === 1) continue; // stall: never answer the first request
+        const [identity, delimiter] = frames;
+        await router.send([
+          identity,
+          delimiter,
+          Buffer.from(JSON.stringify({ ok: true, request: n })),
+        ]);
+      }
+    } catch {
+      /* router closed at test teardown */
+    }
+  })();
+
+  return { port };
+}
+
+/** Wire a KernelManager with a forged managed entry pointing at `port`. */
+function makeManagerWithQuerySocket(port: number): {
+  manager: KernelManager;
+  managed: FakeManaged;
+} {
+  const manager = new KernelManager();
+  const querySocket = new zmq.Request();
+  querySocket.linger = 0;
+  // Short timeout so the wedge-inducing first request fails fast in-test.
+  (querySocket as unknown as { receiveTimeout: number }).receiveTimeout = 300;
+  querySocket.connect(`tcp://127.0.0.1:${port}`);
+  cleanups.push(() => querySocket.close());
+
+  const managed: FakeManaged = {
+    querySocket,
+    queryQueue: Promise.resolve(),
+    shuttingDown: false,
+    connectionInfo: { transport: "tcp", ip: "127.0.0.1", query_port: port },
+  };
+  (manager as unknown as { kernels: Map<string, FakeManaged> }).kernels.set(
+    "q1",
+    managed,
+  );
+  cleanups.push(() => managed.querySocket.close());
+  return { manager, managed };
+}
+
+describe("query socket recovery", () => {
+  it("demonstrates the wedge: a raw REQ socket cannot send again after a timeout", async () => {
+    const { port } = await startRouterPeer();
+    const req = new zmq.Request();
+    req.linger = 0;
+    (req as unknown as { receiveTimeout: number; sendTimeout: number }).receiveTimeout = 300;
+    (req as unknown as { receiveTimeout: number; sendTimeout: number }).sendTimeout = 300;
+    req.connect(`tcp://127.0.0.1:${port}`);
+    cleanups.push(() => req.close());
+
+    await req.send("first");
+    await expect(req.receive()).rejects.toThrow(); // times out
+    // The REQ state machine still has the first request outstanding.
+    await expect(req.send("second")).rejects.toThrow();
+  });
+
+  it("sendQueryRequest recovers after a timeout by replacing the socket (regression)", async () => {
+    const { port } = await startRouterPeer();
+    const { manager, managed } = makeManagerWithQuerySocket(port);
+    const originalSocket = managed.querySocket;
+
+    // First query: the peer stalls, so this rejects on the receive timeout.
+    await expect(
+      manager.sendQueryRequest("q1", { type: "ping", seq: 1 }),
+    ).rejects.toThrow();
+
+    // The wedged socket must have been swapped for a fresh one...
+    expect(managed.querySocket).not.toBe(originalSocket);
+
+    // ...and the next query must go through end-to-end. Without the
+    // replacement, this send() fails immediately (see the wedge test).
+    const reply = await manager.sendQueryRequest("q1", { type: "ping", seq: 2 });
+    expect(reply).toMatchObject({ ok: true });
+  });
+
+  it("does not replace the socket while the kernel is shutting down", async () => {
+    const { port } = await startRouterPeer();
+    const { manager, managed } = makeManagerWithQuerySocket(port);
+    managed.shuttingDown = true;
+    const originalSocket = managed.querySocket;
+
+    await expect(
+      manager.sendQueryRequest("q1", { type: "ping", seq: 1 }),
+    ).rejects.toThrow();
+    expect(managed.querySocket).toBe(originalSocket);
+  });
+});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -13,6 +13,10 @@
 
 import { contextBridge, ipcRenderer } from "electron";
 import { IPC, type PDVApi } from "./main/ipc";
+import {
+  DEFAULT_PYTHON_VERSION,
+  SUPPORTED_PYTHON_VERSIONS,
+} from "./main/python-versions";
 
 /**
  * Register an IPC push listener and return an unsubscribe callback.
@@ -125,6 +129,7 @@ const api: PDVApi = {
     addPackage: (specs) => ipcRenderer.invoke(IPC.environment.addPackage, specs),
     removePackage: (names) => ipcRenderer.invoke(IPC.environment.removePackage, names),
     upgradePackage: (names) => ipcRenderer.invoke(IPC.environment.upgradePackage, names),
+    activeInfo: () => ipcRenderer.invoke(IPC.environment.activeInfo),
   },
   modules: {
     listInstalled: () => ipcRenderer.invoke(IPC.modules.listInstalled),
@@ -243,6 +248,9 @@ const api: PDVApi = {
     // for the life of the process, so there is no point routing it through an
     // IPC channel — renderers read this synchronously from `window.pdv`.
     platform: process.platform,
+    // Compile-time constants from python-versions.ts; same rationale.
+    supportedPythonVersions: SUPPORTED_PYTHON_VERSIONS,
+    defaultPythonVersion: DEFAULT_PYTHON_VERSION,
   },
   launchers: {
     openAgent: () => ipcRenderer.invoke(IPC.launchers.openAgent),

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -481,7 +481,7 @@ const App: React.FC = () => {
   const [environmentMode, setEnvironmentMode] = useState<'uv' | 'shared'>('shared');
   const [uvSync, setUvSync] = useState<{ phase: 'idle' | 'syncing' | 'failed'; output: string; error?: string }>({ phase: 'idle', output: '' });
   const lastUvLaunchRef = useRef<import('../types').KernelUvContext | null>(null);
-  const { startKernel, handleEnvSave, lastErrorRef } = useKernelLifecycle({
+  const { startKernel, handleEnvSave, handleRestartKernel, lastErrorRef } = useKernelLifecycle({
     config,
     currentKernelId,
     setCurrentKernelId,
@@ -1865,6 +1865,7 @@ const App: React.FC = () => {
           lastDuration={lastDuration}
           progress={progress}
           onRuntimeClick={() => { setSettingsInitialTab('runtime'); setShowSettings(true); }}
+          onRestartSession={handleRestartKernel}
           lastChecksum={lastChecksum}
           checksumMismatch={checksumMismatch}
           savedPdvVersion={savedPdvVersion}

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -35,6 +35,7 @@ import { WriteTab } from '../components/WriteTab';
 import { SettingsDialog } from '../components/SettingsDialog';
 import { ImportModuleDialog } from '../components/ImportModuleDialog';
 import { SaveAsDialog } from '../components/SaveAsDialog';
+import { NewProjectDialog } from '../components/NewProjectDialog';
 import { UnsavedChangesDialog } from '../components/UnsavedChangesDialog';
 import { WelcomeScreen, type RecentProject, type RecoverableSession } from '../components/WelcomeScreen';
 import { EnvSyncModal } from '../components/EnvSyncModal';
@@ -173,6 +174,7 @@ const App: React.FC = () => {
   const [showSettings, setShowSettings] = useState(false);
   const [showImportModule, setShowImportModule] = useState(false);
   const [showSaveAsDialog, setShowSaveAsDialog] = useState(false);
+  const [showNewProjectDialog, setShowNewProjectDialog] = useState(false);
   const [currentProjectName, setCurrentProjectName] = useState<string | null>(null);
   const [chromeInfo, setChromeInfo] = useState<WindowChromeInfo | null>(null);
   const [menuModel, setMenuModel] = useState<AppMenuTopLevel[]>([]);
@@ -1300,15 +1302,42 @@ const App: React.FC = () => {
   }, [config, runningPdvVersion, startKernel, openEnvSettings, lastErrorRef]);
 
   const handleWelcomeNewProject = useCallback(async (language: 'python' | 'julia') => {
-    dismissWelcome();
     if (language === 'python') {
-      // New Python projects are uv projects (§10.5.8). The EnvSyncModal covers
-      // the venv build; ensureKernel's shared-env pre-flight does not apply.
-      await launchUvKernel({ newProject: true });
+      // New Python projects open the setup dialog first (§10.5.8); the
+      // welcome screen stays mounted underneath until Create/Cancel.
+      setShowNewProjectDialog(true);
       return;
     }
+    dismissWelcome();
     await ensureKernel(language);
-  }, [dismissWelcome, ensureKernel, launchUvKernel]);
+  }, [dismissWelcome, ensureKernel]);
+
+  /** Create a uv-managed project with the dialog's version/package choices. */
+  const handleNewProjectCreateUv = useCallback(async (opts: { pythonVersion: string; packages: string[] }) => {
+    setShowNewProjectDialog(false);
+    dismissWelcome();
+    // The EnvSyncModal covers the venv build (including a first-time
+    // interpreter download); ensureKernel's shared-env pre-flight does not apply.
+    await launchUvKernel({
+      newProject: true,
+      pythonVersion: opts.pythonVersion,
+      packages: opts.packages,
+    });
+  }, [dismissWelcome, launchUvKernel]);
+
+  /**
+   * Create a project on an existing (conda/system) interpreter chosen in the
+   * dialog's advanced expander. Session-scoped override — the global config
+   * is not touched; the choice reaches the manifest on first save (§10.5).
+   */
+  const handleNewProjectCreateShared = useCallback(async (pythonPath: string) => {
+    setShowNewProjectDialog(false);
+    dismissWelcome();
+    setActiveLanguage('python');
+    const overrideConfig: Config = { ...(config ?? {} as Config), pythonPath };
+    const ok = await startKernel(overrideConfig, 'python');
+    if (!ok) openEnvSettings(lastErrorRef.current ?? 'Kernel failed to start with the selected environment.');
+  }, [config, dismissWelcome, startKernel, openEnvSettings, lastErrorRef]);
 
   /**
    * Open a project from the welcome screen. Peeks at the manifest to detect
@@ -1866,6 +1895,7 @@ const App: React.FC = () => {
           progress={progress}
           onRuntimeClick={() => { setSettingsInitialTab('runtime'); setShowSettings(true); }}
           onRestartSession={handleRestartKernel}
+          canRestart={currentKernelId !== null}
           lastChecksum={lastChecksum}
           checksumMismatch={checksumMismatch}
           savedPdvVersion={savedPdvVersion}
@@ -1902,11 +1932,22 @@ const App: React.FC = () => {
          initialTab={settingsInitialTab}
          activeLanguage={activeLanguage}
          environmentMode={environmentMode}
+         kernelRunning={currentKernelId !== null && kernelStatus === 'ready'}
          config={config}
          shortcuts={shortcuts}
          onClose={() => setShowSettings(false)}
          onSave={handleSettingsSave}
          onEnvSave={(paths) => {
+           if (currentKernelId !== null && kernelStatus === 'ready') {
+             // A session is running: the selection only updates the global
+             // default runtime for future sessions (§10.5.19) — no kernel
+             // stop, no dirty guard, and the live project keeps its
+             // environment.
+             setInterpreterWarning(null);
+             setShowSettings(false);
+             void handleEnvSave(paths, { restart: false });
+             return;
+           }
            guardDirty('change the interpreter', () => {
              setShowSettings(false);
              setInterpreterWarning(null);
@@ -1937,6 +1978,16 @@ const App: React.FC = () => {
            onRecoverSession={handleRecoverSession}
            onDiscardSession={handleDiscardSession}
            onClearRecents={handleClearRecents}
+         />
+       )}
+
+       {showNewProjectDialog && (
+         <NewProjectDialog
+           defaultPackages={config?.defaultPackages ?? []}
+           currentPythonPath={config?.pythonPath}
+           onCreateUv={(opts) => void handleNewProjectCreateUv(opts)}
+           onCreateShared={(pythonPath) => void handleNewProjectCreateShared(pythonPath)}
+           onCancel={() => setShowNewProjectDialog(false)}
          />
        )}
 

--- a/electron/renderer/src/app/useKernelLifecycle.test.ts
+++ b/electron/renderer/src/app/useKernelLifecycle.test.ts
@@ -216,18 +216,61 @@ describe("useKernelLifecycle.handleEnvSave", () => {
     expect(pdv.kernels.start).toHaveBeenCalledTimes(1);
     expect(state.config?.pythonPath).toBe("/opt/python3.12");
   });
+
+  it("restart: false writes config without touching the running kernel (§10.5.19)", async () => {
+    // Guards the Default Runtime tab's future-sessions-only behavior: with a
+    // session up, selecting an environment must never stop/restart it (the
+    // old behavior silently demoted uv projects to shared mode).
+    const { state, setters } = createState();
+    state.currentKernelId = "k1";
+    const startMock = vi.fn();
+    const stopMock = vi.fn();
+    const { result, pdv } = renderHookWithPdv(
+      () =>
+        useKernelLifecycle({
+          config: state.config,
+          currentKernelId: state.currentKernelId,
+          ...setters,
+        }),
+      {
+        pdvOverrides: {
+          kernels: { start: startMock as never, stop: stopMock as never },
+          config: { set: vi.fn(async (cfg) => cfg as never) as never },
+        },
+      },
+    );
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.handleEnvSave(
+        { pythonPath: "/opt/conda/bin/python" },
+        { restart: false },
+      );
+    });
+
+    expect(ok).toBe(true);
+    expect(pdv.config.set).toHaveBeenCalledWith(
+      expect.objectContaining({ pythonPath: "/opt/conda/bin/python" }),
+    );
+    expect(state.config?.pythonPath).toBe("/opt/conda/bin/python");
+    expect(startMock).not.toHaveBeenCalled();
+    expect(stopMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("useKernelLifecycle.handleRestartKernel", () => {
-  it("calls pdv.kernels.restart, clears logs, bumps both refresh tokens", async () => {
+  it("calls pdv.kernels.restart, seeds a restored-state log entry, bumps both refresh tokens", async () => {
     const { state, setters } = createState();
     state.currentKernelId = "k1";
     state.logs = [{ executionId: "e1", chunks: [] } as never];
     const restartMock = vi.fn(async () => ({
-      id: "k2",
-      name: "python3",
-      language: "python" as const,
-      status: "idle" as const,
+      kernel: {
+        id: "k2",
+        name: "python3",
+        language: "python" as const,
+        status: "idle" as const,
+      },
+      restoredFromAutosave: true,
     }));
     const { result, pdv } = renderHookWithPdv(
       () =>
@@ -249,9 +292,46 @@ describe("useKernelLifecycle.handleRestartKernel", () => {
 
     expect(pdv.kernels.restart).toHaveBeenCalledWith("k1");
     expect(state.currentKernelId).toBe("k2");
-    expect(state.logs).toEqual([]);
+    // The log history is replaced with a single info entry saying what
+    // came back (restored vs fresh).
+    expect(state.logs).toHaveLength(1);
+    expect((state.logs[0] as { stdout?: string }).stdout).toMatch(/restored from the last autosave/i);
     expect(state.namespaceRefreshToken).toBe(1);
     expect(state.treeRefreshToken).toBe(1);
+  });
+
+  it("reports a fresh session when nothing was restored", async () => {
+    const { state, setters } = createState();
+    state.currentKernelId = "k1";
+    const restartMock = vi.fn(async () => ({
+      kernel: {
+        id: "k2",
+        name: "python3",
+        language: "python" as const,
+        status: "idle" as const,
+      },
+      restoredFromAutosave: false,
+    }));
+    const { result } = renderHookWithPdv(
+      () =>
+        useKernelLifecycle({
+          config: state.config,
+          currentKernelId: state.currentKernelId,
+          ...setters,
+        }),
+      {
+        pdvOverrides: {
+          kernels: { restart: restartMock as never },
+        },
+      },
+    );
+
+    await act(async () => {
+      await result.current.handleRestartKernel();
+    });
+
+    expect(state.logs).toHaveLength(1);
+    expect((state.logs[0] as { stdout?: string }).stdout).toMatch(/no autosave found/i);
   });
 
   it("no-op when there is no active kernel", async () => {

--- a/electron/renderer/src/app/useKernelLifecycle.ts
+++ b/electron/renderer/src/app/useKernelLifecycle.ts
@@ -131,7 +131,10 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
     });
   }, [doStartKernel]);
 
-  const handleEnvSave = useCallback(async (paths: { pythonPath?: string; juliaPath?: string }): Promise<boolean> => {
+  const handleEnvSave = useCallback(async (
+    paths: { pythonPath?: string; juliaPath?: string },
+    opts?: { restart?: boolean },
+  ): Promise<boolean> => {
     const language = paths.juliaPath && !paths.pythonPath ? 'julia' : 'python';
     const updatedConfig: Config = {
       kernelSpec: config?.kernelSpec ?? null,
@@ -146,6 +149,10 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
 
     await window.pdv.config.set(updatedConfig);
     setConfig(updatedConfig);
+    // restart: false — a session is already running; the selection only
+    // updates the global default runtime for future sessions. Never stop
+    // or demote the live session's environment (§10.5.19).
+    if (opts?.restart === false) return true;
     return startKernel(updatedConfig, language);
   }, [config, setConfig, startKernel]);
 
@@ -155,10 +162,20 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
     try {
       setKernelStatus('starting');
       setLastError(undefined);
-      const newKernel = await window.pdv.kernels.restart(currentKernelId);
-      setCurrentKernelId(newKernel.id);
+      const { kernel, restoredFromAutosave } =
+        await window.pdv.kernels.restart(currentKernelId);
+      setCurrentKernelId(kernel.id);
       setKernelStatus('ready');
-      setLogs([]);
+      // Replace the log history with a single entry saying what came back,
+      // so a crash-restart user knows whether their work was recovered.
+      setLogs([{
+        id: `restart-${Date.now()}`,
+        timestamp: Date.now(),
+        code: '',
+        stdout: restoredFromAutosave
+          ? 'Session restarted — restored from the last autosave.'
+          : 'Session restarted — no autosave found; starting fresh.',
+      }]);
       setNamespaceRefreshToken((prev) => prev + 1);
       setTreeRefreshToken((prev) => prev + 1);
     } catch (error) {

--- a/electron/renderer/src/components/EnvironmentSelector/index.tsx
+++ b/electron/renderer/src/components/EnvironmentSelector/index.tsx
@@ -15,6 +15,19 @@ import type { EnvironmentInfo, InstallOutputChunk } from '../../types';
 // Props
 // ---------------------------------------------------------------------------
 
+/**
+ * Imperative actions a host can drive when it owns the selector's buttons
+ * (see `hideConfirm`/`hideInstallButton`). Exposed via the `actionsRef` prop.
+ */
+export interface EnvironmentSelectorActions {
+  /**
+   * Install pdv-python into the currently selected environment — same flow
+   * as the inline install button (streaming output, post-install re-probe,
+   * badge refresh). Resolves `true` on success.
+   */
+  installPdv: () => Promise<boolean>;
+}
+
 interface EnvironmentSelectorProps {
   /** True when no interpreter has been configured yet. */
   isFirstRun: boolean;
@@ -28,6 +41,32 @@ interface EnvironmentSelectorProps {
   warning?: string | null;
   /** When true, renders inline (no modal overlay). Used in Settings → Runtime. */
   embedded?: boolean;
+  /**
+   * When true, the selector renders no confirm/cancel buttons of its own —
+   * the host owns the single confirm (e.g. the New Project dialog's Create
+   * button) and tracks the selection via `onSelectionChange`. Browse,
+   * Refresh, and the pdv-python install panel stay available.
+   */
+  hideConfirm?: boolean;
+  /**
+   * When true, the pdv-python install panel renders its message and
+   * streaming output but not its own install button — the host drives the
+   * install through `actionsRef.installPdv()` (e.g. the New Project
+   * dialog's footer button).
+   */
+  hideInstallButton?: boolean;
+  /**
+   * Receives the selector's imperative actions (install) so a host that
+   * hides the inline buttons can drive them from its own chrome.
+   */
+  actionsRef?: React.MutableRefObject<EnvironmentSelectorActions | null>;
+  /**
+   * Fires whenever the highlighted environment changes (row click, browse,
+   * refresh, post-install re-probe), with the freshest probe info — or null
+   * when the selection is cleared. Lets a host with `hideConfirm` gate its
+   * own confirm button on the selection's pdv status.
+   */
+  onSelectionChange?: (info: EnvironmentInfo | null) => void;
   /** Called when the user selects an environment. */
   onSelect: (config: { pythonPath?: string; juliaPath?: string }) => void;
   /** Called when the user cancels (not shown on first run). */
@@ -65,6 +104,10 @@ export const EnvironmentSelector: React.FC<EnvironmentSelectorProps> = ({
   currentJuliaPath,
   warning,
   embedded = false,
+  hideConfirm = false,
+  hideInstallButton = false,
+  actionsRef,
+  onSelectionChange,
   onSelect,
   onCancel,
 }) => {
@@ -89,6 +132,15 @@ export const EnvironmentSelector: React.FC<EnvironmentSelectorProps> = ({
 
   // -- Julia stub state ------------------------------------------------------
   const [juliaPath, setJuliaPath] = useState(currentJuliaPath || 'julia');
+
+  // Surface every selection change (row click, browse, refresh clear,
+  // post-install re-probe) to a host that owns the confirm button.
+  useEffect(() => {
+    onSelectionChange?.(selectedInfo);
+    // `onSelectionChange` is intentionally omitted: hosts pass inline
+    // closures, and re-firing on every parent render would loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedInfo]);
 
   // -- Load environments on mount --------------------------------------------
   const loadEnvironments = useCallback(async () => {
@@ -160,8 +212,8 @@ export const EnvironmentSelector: React.FC<EnvironmentSelectorProps> = ({
   }, []);
 
   // -- Install pdv-python ----------------------------------------------------
-  const handleInstall = useCallback(async () => {
-    if (!selectedPath) return;
+  const handleInstall = useCallback(async (): Promise<boolean> => {
+    if (!selectedPath) return false;
     setInstalling(true);
     setInstallOutput([]);
     setInstallResult(null);
@@ -185,16 +237,27 @@ export const EnvironmentSelector: React.FC<EnvironmentSelectorProps> = ({
           );
         }
       }
+      return result.success;
     } catch (err) {
       setInstallResult({
         success: false,
         output: err instanceof Error ? err.message : String(err),
       });
+      return false;
     } finally {
       unsubscribe();
       setInstalling(false);
     }
   }, [selectedPath]);
+
+  // Hand the imperative actions to a host that owns the buttons.
+  useEffect(() => {
+    if (!actionsRef) return;
+    actionsRef.current = { installPdv: handleInstall };
+    return () => {
+      actionsRef.current = null;
+    };
+  }, [actionsRef, handleInstall]);
 
   // Auto-scroll install output
   useEffect(() => {
@@ -360,18 +423,20 @@ export const EnvironmentSelector: React.FC<EnvironmentSelectorProps> = ({
               ? `pdv-python ${selectedInfo.pdvVersion} installed — v${appVersion ?? 'latest'} required.`
               : 'pdv-python is not installed in this environment.'}
           </div>
-          <button
-            className="btn btn-primary"
-            onClick={handleInstall}
-            disabled={installing}
-            type="button"
-          >
-            {installing
-              ? 'Installing...'
-              : selectedInfo.pdvVersionMismatch
-                ? `Install pdv-python ${appVersion ?? 'latest'}`
-                : 'Install pdv-python'}
-          </button>
+          {!hideInstallButton && (
+            <button
+              className="btn btn-primary"
+              onClick={() => void handleInstall()}
+              disabled={installing}
+              type="button"
+            >
+              {installing
+                ? 'Installing...'
+                : selectedInfo.pdvVersionMismatch
+                  ? `Install pdv-python ${appVersion ?? 'latest'}`
+                  : 'Install pdv-python'}
+            </button>
+          )}
 
           {/* Streaming output */}
           {(installOutput.length > 0 || installResult) && (
@@ -393,23 +458,26 @@ export const EnvironmentSelector: React.FC<EnvironmentSelectorProps> = ({
         </div>
       )}
 
-      {/* Confirm / Cancel */}
-      <div className="button-group">
-        <button
-          className="btn btn-primary"
-          onClick={handleConfirm}
-          disabled={!canConfirm}
-          type="button"
-          title={canConfirm ? undefined : 'Install pdv-python first'}
-        >
-          Select Environment
-        </button>
-        {!isFirstRun && onCancel && (
-          <button className="btn btn-secondary" onClick={onCancel} type="button">
-            Cancel
+      {/* Confirm / Cancel — suppressed when the host owns the confirm
+          (e.g. the New Project dialog's single Create button). */}
+      {!hideConfirm && (
+        <div className="button-group">
+          <button
+            className="btn btn-primary"
+            onClick={handleConfirm}
+            disabled={!canConfirm}
+            type="button"
+            title={canConfirm ? undefined : 'Install pdv-python first'}
+          >
+            Select Environment
           </button>
-        )}
-      </div>
+          {!isFirstRun && onCancel && (
+            <button className="btn btn-secondary" onClick={onCancel} type="button">
+              Cancel
+            </button>
+          )}
+        </div>
+      )}
     </>
   );
 

--- a/electron/renderer/src/components/NewProjectDialog/index.test.tsx
+++ b/electron/renderer/src/components/NewProjectDialog/index.test.tsx
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EnvironmentInfo, PDVApi } from '../../types/pdv';
+import { installPdvMock } from '../../test-fixtures/pdv-mock';
+import { NewProjectDialog } from './index';
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderDialog(overrides: Partial<Parameters<typeof NewProjectDialog>[0]> = {}) {
+  installPdvMock();
+  const handlers = {
+    onCreateUv: vi.fn(),
+    onCreateShared: vi.fn(),
+    onCancel: vi.fn(),
+  };
+  render(
+    <NewProjectDialog
+      defaultPackages={['numpy', 'matplotlib']}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+  return handlers;
+}
+
+describe('NewProjectDialog', () => {
+  it('renders the supported versions with the default preselected and packages prefilled', () => {
+    renderDialog();
+    const select = screen.getByTestId('new-project-python-version') as HTMLSelectElement;
+    expect(select.value).toBe('3.13');
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toEqual(['3.10', '3.11', '3.12', '3.13', '3.14']);
+    const packages = screen.getByTestId('new-project-packages') as HTMLInputElement;
+    expect(packages.value).toBe('numpy, matplotlib');
+  });
+
+  it('Create passes the chosen version and parsed packages to onCreateUv', async () => {
+    const { onCreateUv } = renderDialog();
+    const user = userEvent.setup();
+    await user.selectOptions(screen.getByTestId('new-project-python-version'), '3.11');
+    const packages = screen.getByTestId('new-project-packages');
+    await user.clear(packages);
+    await user.type(packages, 'scipy>=1.10,  xarray numpy');
+    await user.click(screen.getByTestId('new-project-create'));
+    expect(onCreateUv).toHaveBeenCalledWith({
+      pythonVersion: '3.11',
+      packages: ['scipy>=1.10', 'xarray', 'numpy'],
+    });
+  });
+
+  it('an empty packages field creates with no packages', async () => {
+    const { onCreateUv } = renderDialog();
+    const user = userEvent.setup();
+    await user.clear(screen.getByTestId('new-project-packages'));
+    await user.click(screen.getByTestId('new-project-create'));
+    expect(onCreateUv).toHaveBeenCalledWith({ pythonVersion: '3.13', packages: [] });
+  });
+
+  it('Escape in the packages field cancels; Enter creates', async () => {
+    const { onCancel, onCreateUv } = renderDialog();
+    const user = userEvent.setup();
+    const packages = screen.getByTestId('new-project-packages');
+    await user.click(packages);
+    await user.keyboard('{Escape}');
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    await user.click(packages);
+    await user.keyboard('{Enter}');
+    expect(onCreateUv).toHaveBeenCalledTimes(1);
+  });
+
+  describe('existing-environment mode', () => {
+    function installEnvListMock(env: Partial<EnvironmentInfo> = {}) {
+      return installPdvMock({
+        environment: {
+          list: vi.fn<PDVApi['environment']['list']>(async () => [
+            {
+              kind: 'conda',
+              pythonPath: '/opt/conda/envs/mpi/bin/python',
+              label: 'conda: mpi (3.12.4)',
+              pythonVersion: '3.12.4',
+              pdvInstalled: true,
+              pdvVersion: '0.2.0',
+              pdvCompatible: true,
+              pdvVersionMismatch: false,
+              ipykernelInstalled: true,
+              isFreeThreaded: false,
+              ...env,
+            } as EnvironmentInfo,
+          ]),
+          // Row clicks re-probe via check(); return null to keep the list info.
+          check: vi.fn<PDVApi['environment']['check']>(async () => null),
+        },
+      });
+    }
+
+    function renderAdvanced() {
+      const handlers = {
+        onCreateUv: vi.fn(),
+        onCreateShared: vi.fn(),
+        onCancel: vi.fn(),
+      };
+      render(<NewProjectDialog defaultPackages={[]} {...handlers} />);
+      return handlers;
+    }
+
+    it('opening Advanced hides the uv fields and disables Create until a selection exists', async () => {
+      installEnvListMock();
+      renderAdvanced();
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId('new-project-advanced-toggle'));
+      // uv fields are gone — the two paths are mutually exclusive.
+      expect(screen.queryByTestId('new-project-python-version')).toBeNull();
+      expect(screen.queryByTestId('new-project-packages')).toBeNull();
+      // The selector's own confirm button is suppressed; the footer Create
+      // is the single confirm, disabled with no selection.
+      expect(screen.queryByRole('button', { name: /select environment/i })).toBeNull();
+      const create = screen.getByTestId('new-project-create') as HTMLButtonElement;
+      expect(create.textContent).toMatch(/selected environment/i);
+      expect(create.disabled).toBe(true);
+    });
+
+    it('Create confirms the selected usable environment via onCreateShared', async () => {
+      installEnvListMock();
+      const handlers = renderAdvanced();
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId('new-project-advanced-toggle'));
+      await user.click(await screen.findByText(/conda: mpi/));
+      const create = screen.getByTestId('new-project-create') as HTMLButtonElement;
+      await waitFor(() => expect(create.disabled).toBe(false));
+      await user.click(create);
+      expect(handlers.onCreateShared).toHaveBeenCalledWith('/opt/conda/envs/mpi/bin/python');
+      expect(handlers.onCreateUv).not.toHaveBeenCalled();
+    });
+
+    it('selecting an environment without pdv-python swaps the footer button to Install', async () => {
+      installEnvListMock({ pdvInstalled: false, pdvVersion: null, pdvCompatible: false });
+      const handlers = renderAdvanced();
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId('new-project-advanced-toggle'));
+      await user.click(await screen.findByText(/conda: mpi/));
+      // The required next step IS the footer button — no scrolling to a
+      // buried inline install button, and no way to "Create" past it.
+      await waitFor(() =>
+        expect(screen.getByTestId('new-project-install-pdv')).toBeTruthy(),
+      );
+      expect(screen.queryByTestId('new-project-create')).toBeNull();
+      // The selector's own inline install button is suppressed too — the
+      // footer button is the only install affordance.
+      expect(screen.queryByRole('button', { name: /^install pdv-python$/i })).toBe(
+        screen.getByTestId('new-project-install-pdv'),
+      );
+      expect(handlers.onCreateShared).not.toHaveBeenCalled();
+    });
+
+    it('footer Install runs the install and flips to an enabled Create on success', async () => {
+      const usableEnv = {
+        kind: 'conda',
+        pythonPath: '/opt/conda/envs/mpi/bin/python',
+        label: 'conda: mpi (3.12.4)',
+        pythonVersion: '3.12.4',
+        pdvInstalled: true,
+        pdvVersion: '0.2.0',
+        pdvCompatible: true,
+        pdvVersionMismatch: false,
+        ipykernelInstalled: true,
+        isFreeThreaded: false,
+      } as EnvironmentInfo;
+      installPdvMock({
+        environment: {
+          list: vi.fn<PDVApi['environment']['list']>(async () => [
+            { ...usableEnv, pdvInstalled: false, pdvVersion: null, pdvCompatible: false },
+          ]),
+          // First check (row-click re-probe) still reports pdv missing; the
+          // post-install re-probe reports it usable.
+          check: vi
+            .fn<PDVApi['environment']['check']>()
+            .mockResolvedValueOnce({
+              ...usableEnv,
+              pdvInstalled: false,
+              pdvVersion: null,
+              pdvCompatible: false,
+            })
+            .mockResolvedValue(usableEnv),
+          install: vi.fn<PDVApi['environment']['install']>(async () => ({
+            success: true,
+            output: 'installed',
+          })),
+        },
+      });
+      const handlers = {
+        onCreateUv: vi.fn(),
+        onCreateShared: vi.fn(),
+        onCancel: vi.fn(),
+      };
+      render(<NewProjectDialog defaultPackages={[]} {...handlers} />);
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId('new-project-advanced-toggle'));
+      await user.click(await screen.findByText(/conda: mpi/));
+      await user.click(await screen.findByTestId('new-project-install-pdv'));
+      // Post-install re-probe flips the selection to usable → Create appears.
+      const create = (await screen.findByTestId('new-project-create')) as HTMLButtonElement;
+      expect(create.disabled).toBe(false);
+      await user.click(create);
+      expect(handlers.onCreateShared).toHaveBeenCalledWith('/opt/conda/envs/mpi/bin/python');
+    });
+
+    it('toggling back to uv mode restores the fields and the plain Create', async () => {
+      installEnvListMock();
+      const handlers = renderAdvanced();
+      const user = userEvent.setup();
+      const toggle = screen.getByTestId('new-project-advanced-toggle');
+      await user.click(toggle);
+      await user.click(toggle);
+      expect(screen.getByTestId('new-project-python-version')).toBeTruthy();
+      const create = screen.getByTestId('new-project-create') as HTMLButtonElement;
+      expect(create.disabled).toBe(false);
+      await user.click(create);
+      expect(handlers.onCreateUv).toHaveBeenCalledTimes(1);
+      expect(handlers.onCreateShared).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/electron/renderer/src/components/NewProjectDialog/index.tsx
+++ b/electron/renderer/src/components/NewProjectDialog/index.tsx
@@ -1,0 +1,234 @@
+/**
+ * NewProjectDialog — creation-time environment setup for a new Python project.
+ *
+ * Shown when the user clicks "New Python Project" on the welcome screen.
+ * Two mutually exclusive modes with a single Create button in the footer:
+ *
+ * - **uv-managed** (default): Python version (from the supported range) and
+ *   the initial package list (prefilled from the user's default packages).
+ * - **existing environment** (behind the "Advanced" toggle): run on a
+ *   conda/system interpreter instead. Opening it hides the uv fields — the
+ *   two paths can't be half-selected — and the footer's primary button is
+ *   the single action, always visible: **Create** when the highlighted
+ *   environment can run PDV, **Install pdv-python** when that is the
+ *   required next step (driving the selector's install flow via
+ *   `actionsRef`), and disabled-with-reason otherwise. The embedded
+ *   selector's own confirm/install buttons are suppressed.
+ *
+ * The project itself stays unsaved until the first explicit Save; this
+ * dialog configures only the environment.
+ *
+ * Follows the standard modal-overlay pattern (SaveAsDialog, CreateScriptDialog).
+ */
+
+import React, { useRef, useState } from 'react';
+import type { EnvironmentInfo } from '../../types';
+import { useModalKeyboard } from '../../hooks/useModalKeyboard';
+import {
+  EnvironmentSelector,
+  type EnvironmentSelectorActions,
+} from '../EnvironmentSelector';
+
+interface NewProjectDialogProps {
+  /** Packages prefilled into the packages field (the user's defaults). */
+  defaultPackages: string[];
+  /** Currently configured Python path (highlighted in the advanced selector). */
+  currentPythonPath?: string;
+  /** Create a uv-managed project with the chosen version and packages. */
+  onCreateUv: (opts: { pythonVersion: string; packages: string[] }) => void;
+  /** Create a project on an existing (conda/system) interpreter. */
+  onCreateShared: (pythonPath: string) => void;
+  /** Called when the user cancels (Escape, ×, backdrop, Cancel). */
+  onCancel: () => void;
+}
+
+/** Split a comma/whitespace-separated package string into PEP 508 specs. */
+function parsePackages(raw: string): string[] {
+  return raw
+    .split(/[,\s]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export const NewProjectDialog: React.FC<NewProjectDialogProps> = ({
+  defaultPackages,
+  currentPythonPath,
+  onCreateUv,
+  onCreateShared,
+  onCancel,
+}) => {
+  const supportedVersions = window.pdv.system.supportedPythonVersions;
+  const [pythonVersion, setPythonVersion] = useState(
+    window.pdv.system.defaultPythonVersion
+  );
+  const [packagesText, setPackagesText] = useState(defaultPackages.join(', '));
+  const [mode, setMode] = useState<'uv' | 'existing'>('uv');
+  const [selectedEnv, setSelectedEnv] = useState<EnvironmentInfo | null>(null);
+  const [installing, setInstalling] = useState(false);
+  const selectorActions = useRef<EnvironmentSelectorActions | null>(null);
+
+  // Mirrors the environment selector's own confirm gate: the chosen
+  // interpreter must have a compatible pdv-python and not be free-threaded.
+  const envUsable =
+    !!selectedEnv?.pdvInstalled &&
+    !!selectedEnv?.pdvCompatible &&
+    !selectedEnv?.isFreeThreaded;
+
+  // A selected env that merely lacks (or has the wrong) pdv-python is one
+  // click away from usable — the footer's primary button becomes the install
+  // action so the required next step is never hidden behind a scroll.
+  const needsInstall =
+    !!selectedEnv &&
+    !selectedEnv.isFreeThreaded &&
+    (!selectedEnv.pdvInstalled || !!selectedEnv.pdvVersionMismatch || !selectedEnv.pdvCompatible);
+
+  const canCreate = mode === 'uv' || envUsable;
+  const disabledReason = !selectedEnv
+    ? 'Select an environment from the list first'
+    : selectedEnv.isFreeThreaded
+      ? 'Free-threaded (no-GIL) Python builds cannot run PDV'
+      : 'Install pdv-python into the selected environment first';
+
+  const handleCreate = () => {
+    if (mode === 'existing') {
+      if (envUsable && selectedEnv) onCreateShared(selectedEnv.pythonPath);
+      return;
+    }
+    onCreateUv({ pythonVersion, packages: parsePackages(packagesText) });
+  };
+
+  // Footer install action: drives the selector's install flow (streaming
+  // output, post-install re-probe). On success the re-probe flips the
+  // selection to usable and this button becomes Create.
+  const handleInstall = async () => {
+    if (!selectorActions.current) return;
+    setInstalling(true);
+    try {
+      await selectorActions.current.installPdv();
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const handleKeyDown = useModalKeyboard({ onSubmit: handleCreate, onCancel });
+
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div
+        className="new-project-dialog"
+        data-testid="new-project-dialog"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="dialog-header">
+          <h3>New Python Project</h3>
+          <button className="close-btn" onClick={onCancel} aria-label="Close dialog">
+            &times;
+          </button>
+        </div>
+
+        <div className="dialog-body">
+          {mode === 'uv' && (
+            <>
+              <label className="new-project-field">
+                Python version
+                <select
+                  value={pythonVersion}
+                  onChange={(e) => setPythonVersion(e.target.value)}
+                  data-testid="new-project-python-version"
+                >
+                  {supportedVersions.map((v) => (
+                    <option key={v} value={v}>
+                      {v}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="new-project-hint">
+                Downloaded automatically if not already installed.
+              </div>
+
+              <label className="new-project-field">
+                Initial packages
+                <input
+                  type="text"
+                  value={packagesText}
+                  onChange={(e) => setPackagesText(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="numpy, matplotlib"
+                  data-testid="new-project-packages"
+                />
+              </label>
+              <div className="new-project-hint">
+                Comma-separated; version specifiers welcome (e.g. <code>scipy&gt;=1.10</code>).
+                More can be added later in Settings.
+              </div>
+            </>
+          )}
+
+          <button
+            type="button"
+            className="new-project-advanced-toggle"
+            onClick={() => {
+              setMode((m) => (m === 'uv' ? 'existing' : 'uv'));
+            }}
+            data-testid="new-project-advanced-toggle"
+            aria-expanded={mode === 'existing'}
+          >
+            {mode === 'existing'
+              ? '▾ Using an existing environment — click to switch back to a PDV-managed project'
+              : '▸ Advanced: use an existing environment'}
+          </button>
+
+          {mode === 'existing' && (
+            <div className="new-project-advanced">
+              <div className="new-project-hint">
+                Run this project on an environment you manage yourself (e.g. a
+                conda env with cluster-specific libraries). The project will
+                not be self-contained or shareable — the environment must
+                exist wherever the project is opened. Select an environment
+                below, then press Create.
+              </div>
+              <EnvironmentSelector
+                isFirstRun={false}
+                activeLanguage="python"
+                currentPythonPath={currentPythonPath}
+                embedded
+                hideConfirm
+                hideInstallButton
+                actionsRef={selectorActions}
+                onSelectionChange={setSelectedEnv}
+                onSelect={() => undefined}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="dialog-footer">
+          <button className="btn btn-secondary" onClick={onCancel} disabled={installing}>
+            Cancel
+          </button>
+          {mode === 'existing' && needsInstall ? (
+            <button
+              className="btn btn-primary"
+              onClick={() => void handleInstall()}
+              disabled={installing}
+              data-testid="new-project-install-pdv"
+            >
+              {installing ? 'Installing…' : 'Install pdv-python'}
+            </button>
+          ) : (
+            <button
+              className="btn btn-primary"
+              onClick={handleCreate}
+              disabled={!canCreate}
+              title={canCreate ? undefined : disabledReason}
+              data-testid="new-project-create"
+            >
+              {mode === 'existing' ? 'Create with Selected Environment' : 'Create'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/electron/renderer/src/components/SettingsDialog/PackagesTab.tsx
+++ b/electron/renderer/src/components/SettingsDialog/PackagesTab.tsx
@@ -1,19 +1,21 @@
 /**
- * PackagesTab — Per-project dependency management for uv-mode projects.
+ * PackagesTab — the "Project Environment" settings tab.
  *
- * Lists declared dependencies from `pyproject.toml` paired with the version
- * actually installed in the venv (via `uv pip list`), and exposes add /
- * remove / upgrade actions that go through `uv add` / `uv remove` /
+ * Shows the active session's environment (mode badge, interpreter path,
+ * Python version, via `environment.activeInfo`), and for uv-mode projects
+ * lists declared dependencies from `pyproject.toml` paired with the version
+ * actually installed in the venv (via `uv pip list`), with add / remove /
+ * upgrade actions that go through `uv add` / `uv remove` /
  * `uv lock --upgrade-package` in the main process. Streams uv output via
  * the existing `envActivity` push channel.
  *
  * See Also
  * --------
- * ARCHITECTURE.md §10.5.13 (Package Management UI)
+ * ARCHITECTURE.md §10.5.13 (Package Management UI), §10.5.19
  */
 
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import type { EnvironmentInstallResult, ProjectPackage } from '../../types';
+import type { ActiveEnvironmentInfo, EnvironmentInstallResult, ProjectPackage } from '../../types';
 
 /** Props for {@link PackagesTab}. */
 interface PackagesTabProps {
@@ -21,14 +23,26 @@ interface PackagesTabProps {
   environmentMode?: 'uv' | 'shared';
 }
 
-/** Settings tab body for per-project package management. */
+/** Settings tab body for the project environment (info header + packages). */
 export const PackagesTab: React.FC<PackagesTabProps> = ({ environmentMode }) => {
   const [packages, setPackages] = useState<ProjectPackage[]>([]);
+  const [envInfo, setEnvInfo] = useState<ActiveEnvironmentInfo | null>(null);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
   const [addInput, setAddInput] = useState('');
   const [output, setOutput] = useState('');
   const outputRef = useRef<HTMLPreElement>(null);
+
+  // Fetch the active session's environment metadata for the header.
+  useEffect(() => {
+    let cancelled = false;
+    void window.pdv.environment.activeInfo().then((info) => {
+      if (!cancelled) setEnvInfo(info);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [environmentMode]);
 
   // Auto-scroll the streaming output pane to the latest line.
   useLayoutEffect(() => {
@@ -88,14 +102,37 @@ export const PackagesTab: React.FC<PackagesTabProps> = ({ environmentMode }) => 
     void runMutation(() => window.pdv.environment.addPackage([spec]));
   }, [addInput, runMutation]);
 
+  // Environment info header shared by both modes (§10.5.19). Falls back to
+  // the mode prop when the metadata fetch hasn't resolved yet.
+  const mode = envInfo?.mode ?? environmentMode;
+  const envHeader = (
+    <div className="settings-env-header" data-testid="project-env-header">
+      <span
+        className={`settings-env-badge ${mode === 'uv' ? 'settings-env-badge-uv' : 'settings-env-badge-shared'}`}
+      >
+        {mode === 'uv' ? 'uv-managed · shareable' : 'external environment'}
+      </span>
+      {envInfo?.pythonVersion && (
+        <span className="settings-env-version">Python {envInfo.pythonVersion}</span>
+      )}
+      {envInfo?.interpreterPath && (
+        <div className="settings-env-interpreter" title={envInfo.interpreterPath}>
+          <code>{envInfo.interpreterPath}</code>
+        </div>
+      )}
+    </div>
+  );
+
   if (environmentMode !== 'uv') {
     return (
       <div className="settings-packages">
+        {envHeader}
         <p className="settings-packages-hint">
-          Project package management is available only for uv-managed projects.
-          This project uses the shared environment selected in the Runtime tab —
-          use that environment&rsquo;s own package manager (pip / conda) to
-          install packages.
+          This project runs on an environment managed outside PDV (e.g. conda),
+          chosen when the project was created. Use that environment&rsquo;s own
+          package manager (pip / conda) to install packages. Changing an
+          existing project&rsquo;s environment isn&rsquo;t supported yet
+          (planned as a dedicated action).
         </p>
       </div>
     );
@@ -103,6 +140,7 @@ export const PackagesTab: React.FC<PackagesTabProps> = ({ environmentMode }) => 
 
   return (
     <div className="settings-packages">
+      {envHeader}
       <h4 className="settings-general-section">Project Dependencies</h4>
       <p className="settings-packages-hint">
         Packages declared in this project&rsquo;s <code>pyproject.toml</code>,

--- a/electron/renderer/src/components/SettingsDialog/index.tsx
+++ b/electron/renderer/src/components/SettingsDialog/index.tsx
@@ -64,8 +64,14 @@ interface SettingsDialogProps {
    *  caller can prompt about unsaved changes before the app restarts. */
   onInstallUpdate?: () => void;
   envWarning?: string | null;
-  /** Active environment mode — drives the Packages tab content (§10.5.13). */
+  /** Active environment mode — drives the Project Environment tab content (§10.5.13). */
   environmentMode?: 'uv' | 'shared';
+  /**
+   * True when a kernel session is up (`ready`). Gates the Runtime tab into
+   * default-runtime-only mode: selections update the global config for
+   * future sessions but never stop or demote the live session (§10.5.19).
+   */
+  kernelRunning?: boolean;
 }
 
 /** Top-level settings modal used by the App shell. */
@@ -81,6 +87,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
   onInstallUpdate,
   envWarning,
   environmentMode,
+  kernelRunning = false,
 }) => {
   const [activeTab, setActiveTab] = useState<SettingsTab>(initialTab);
   const [editedShortcuts, setEditedShortcuts] = useState<Shortcuts>(shortcuts);
@@ -474,8 +481,8 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
           <button className={`tab ${activeTab === 'shortcuts' ? 'active' : ''}`} onClick={() => setActiveTab('shortcuts')}>Keyboard Shortcuts</button>
           <button className={`tab ${activeTab === 'appearance' ? 'active' : ''}`} onClick={() => setActiveTab('appearance')}>Appearance</button>
           <button className={`tab ${activeTab === 'agents' ? 'active' : ''}`} onClick={() => setActiveTab('agents')}>Agents</button>
-          <button className={`tab ${activeTab === 'runtime' ? 'active' : ''}`} onClick={() => setActiveTab('runtime')}>Runtime</button>
-          <button className={`tab ${activeTab === 'packages' ? 'active' : ''}`} onClick={() => setActiveTab('packages')}>Packages</button>
+          <button className={`tab ${activeTab === 'runtime' ? 'active' : ''}`} onClick={() => setActiveTab('runtime')}>Default Runtime</button>
+          <button className={`tab ${activeTab === 'packages' ? 'active' : ''}`} onClick={() => setActiveTab('packages')}>Project Environment</button>
           <button className={`tab ${activeTab === 'about' ? 'active' : ''}`} onClick={() => setActiveTab('about')}>About</button>
         </div>
         <div className="dialog-body">
@@ -722,15 +729,29 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
           ) : activeTab === 'agents' ? (
             <AgentsTab />
           ) : activeTab === 'runtime' ? (
-            <EnvironmentSelector
-              embedded
-              isFirstRun={activeLanguage === 'julia' ? !config?.juliaPath : !config?.pythonPath}
-              activeLanguage={activeLanguage}
-              currentPythonPath={config?.pythonPath}
-              currentJuliaPath={config?.juliaPath}
-              warning={envWarning}
-              onSelect={onEnvSave}
-            />
+            <div className="settings-runtime">
+              <p className="settings-general-hint">
+                The default runtime is used for the first run, sessions on an
+                existing environment, and Julia. New Python projects manage
+                their own environment (see the New Project dialog).
+              </p>
+              {kernelRunning && (
+                <p className="settings-runtime-note" data-testid="runtime-future-note">
+                  A session is running. Selections here become the default for
+                  future sessions and do not change the current project&rsquo;s
+                  environment.
+                </p>
+              )}
+              <EnvironmentSelector
+                embedded
+                isFirstRun={activeLanguage === 'julia' ? !config?.juliaPath : !config?.pythonPath}
+                activeLanguage={activeLanguage}
+                currentPythonPath={config?.pythonPath}
+                currentJuliaPath={config?.juliaPath}
+                warning={envWarning}
+                onSelect={onEnvSave}
+              />
+            </div>
           ) : activeTab === 'packages' ? (
             <PackagesTab environmentMode={environmentMode} />
           ) : activeTab === 'about' ? (

--- a/electron/renderer/src/components/StatusBar/StatusBar.test.tsx
+++ b/electron/renderer/src/components/StatusBar/StatusBar.test.tsx
@@ -4,9 +4,9 @@
  * StatusBar.test.tsx — Renderer tests for the bottom status bar.
  *
  * Covers the MCP connection-indicator dot wired in for Phase 3 of the MCP
- * server work: the indicator should render only when `mcpClientAttached` is
- * true, and use the `mcp-attached` status-dot modifier so the
- * `--mcp-dot-attached` theme token drives the color.
+ * server work, and the restart-affordance visibility matrix (§11.6): the
+ * ⟳ Restart item must render while connected AND after a crash when a
+ * restartable session exists (`canRestart`), but never for a failed start.
  */
 
 import { cleanup, render, screen } from "@testing-library/react";
@@ -18,7 +18,14 @@ afterEach(() => {
   cleanup();
 });
 
-function renderStatusBar(overrides: { mcpClientAttached?: boolean } = {}): void {
+function renderStatusBar(
+  overrides: {
+    mcpClientAttached?: boolean;
+    kernelStatus?: "idle" | "starting" | "ready" | "error";
+    canRestart?: boolean;
+    onRestartSession?: () => void;
+  } = {},
+): void {
   render(
     <StatusBar
       isExecuting={false}
@@ -27,10 +34,12 @@ function renderStatusBar(overrides: { mcpClientAttached?: boolean } = {}): void 
       juliaPath={undefined}
       kernelSpec={undefined}
       currentProjectDir={null}
-      kernelStatus="idle"
+      kernelStatus={overrides.kernelStatus ?? "idle"}
       lastDuration={null}
       progress={null}
       onRuntimeClick={vi.fn()}
+      onRestartSession={overrides.onRestartSession}
+      canRestart={overrides.canRestart}
       lastChecksum={null}
       checksumMismatch={false}
       savedPdvVersion={null}
@@ -57,5 +66,34 @@ describe("StatusBar MCP connection indicator", () => {
   it("hides the indicator when no MCP agent is attached", () => {
     renderStatusBar({ mcpClientAttached: false });
     expect(screen.queryByTestId("mcp-client-indicator")).toBeNull();
+  });
+});
+
+describe("StatusBar restart affordance (§11.6)", () => {
+  const onRestartSession = vi.fn();
+
+  it("renders while connected", () => {
+    renderStatusBar({ kernelStatus: "ready", onRestartSession });
+    expect(screen.getByTestId("restart-session")).toBeTruthy();
+  });
+
+  it("renders after a crash when a restartable session exists", () => {
+    renderStatusBar({ kernelStatus: "error", canRestart: true, onRestartSession });
+    const item = screen.getByTestId("restart-session");
+    expect(item).toBeTruthy();
+    // Crash-specific tooltip tells the user what a restart will recover.
+    expect(item.getAttribute("title")).toMatch(/crashed/i);
+  });
+
+  it("hidden in the error state when there is nothing to restart (failed start)", () => {
+    renderStatusBar({ kernelStatus: "error", canRestart: false, onRestartSession });
+    expect(screen.queryByTestId("restart-session")).toBeNull();
+  });
+
+  it("hidden while starting and when no handler is wired", () => {
+    renderStatusBar({ kernelStatus: "starting", canRestart: true, onRestartSession });
+    expect(screen.queryByTestId("restart-session")).toBeNull();
+    renderStatusBar({ kernelStatus: "ready" });
+    expect(screen.queryByTestId("restart-session")).toBeNull();
   });
 });

--- a/electron/renderer/src/components/StatusBar/index.tsx
+++ b/electron/renderer/src/components/StatusBar/index.tsx
@@ -21,9 +21,15 @@ interface StatusBarProps {
   lastDuration: number | null;
   progress: ProgressPayload | null;
   onRuntimeClick: () => void;
-  /** Restart the active session. Rendered only while connected; the tree
-   *  is snapshotted before teardown and restored afterwards. */
+  /** Restart the active session. Rendered while connected, and after a
+   *  crash when a restartable session exists (`canRestart`); the tree is
+   *  snapshotted before teardown (or recovered from the last autosave
+   *  after a crash) and restored afterwards. */
   onRestartSession?: () => void;
+  /** True when a session exists to restart (a kernel id is known). Gates
+   *  the restart affordance in the `error` state — a crashed session can
+   *  be restarted, a failed start cannot. */
+  canRestart?: boolean;
   lastChecksum: string | null;
   checksumMismatch: boolean;
   savedPdvVersion: string | null;
@@ -68,6 +74,7 @@ export const StatusBar: React.FC<StatusBarProps> = ({
   progress,
   onRuntimeClick,
   onRestartSession,
+  canRestart = false,
   lastChecksum,
   checksumMismatch,
   savedPdvVersion,
@@ -156,6 +163,7 @@ export const StatusBar: React.FC<StatusBarProps> = ({
           className="status-item status-clickable"
           onClick={onRuntimeClick}
           title={runtimeTitle}
+          data-testid="runtime-chip"
         >
           {runtimeLabel}
         </span>
@@ -185,11 +193,16 @@ export const StatusBar: React.FC<StatusBarProps> = ({
         <span className="status-item">
           Last: {lastDuration !== null ? `${Math.round(lastDuration)}ms` : '--'}
         </span>
-        {kernelStatus === 'ready' && onRestartSession && (
+        {(kernelStatus === 'ready' || (kernelStatus === 'error' && canRestart)) &&
+          onRestartSession && (
           <span
             className="status-item status-clickable"
             onClick={onRestartSession}
-            title="Restart the session — the tree is snapshotted and restored automatically"
+            title={
+              kernelStatus === 'error'
+                ? 'The session crashed — restart it. Work is restored from the last autosave when available.'
+                : 'Restart the session — the tree is snapshotted and restored automatically'
+            }
             data-testid="restart-session"
           >
             ⟳ Restart

--- a/electron/renderer/src/components/StatusBar/index.tsx
+++ b/electron/renderer/src/components/StatusBar/index.tsx
@@ -21,6 +21,9 @@ interface StatusBarProps {
   lastDuration: number | null;
   progress: ProgressPayload | null;
   onRuntimeClick: () => void;
+  /** Restart the active session. Rendered only while connected; the tree
+   *  is snapshotted before teardown and restored afterwards. */
+  onRestartSession?: () => void;
   lastChecksum: string | null;
   checksumMismatch: boolean;
   savedPdvVersion: string | null;
@@ -64,6 +67,7 @@ export const StatusBar: React.FC<StatusBarProps> = ({
   lastDuration,
   progress,
   onRuntimeClick,
+  onRestartSession,
   lastChecksum,
   checksumMismatch,
   savedPdvVersion,
@@ -181,6 +185,16 @@ export const StatusBar: React.FC<StatusBarProps> = ({
         <span className="status-item">
           Last: {lastDuration !== null ? `${Math.round(lastDuration)}ms` : '--'}
         </span>
+        {kernelStatus === 'ready' && onRestartSession && (
+          <span
+            className="status-item status-clickable"
+            onClick={onRestartSession}
+            title="Restart the session — the tree is snapshotted and restored automatically"
+            data-testid="restart-session"
+          >
+            ⟳ Restart
+          </span>
+        )}
         <span
           className={`status-item ${kernelStatus === 'ready' ? 'status-connected' : kernelStatus === 'error' ? 'status-error' : ''}`}
           data-testid="kernel-status"

--- a/electron/renderer/src/styles/dialogs.css
+++ b/electron/renderer/src/styles/dialogs.css
@@ -1452,3 +1452,142 @@
   color: var(--text-primary);
   line-height: 1.5;
 }
+
+/* ===== NEW PROJECT DIALOG ===== */
+
+.new-project-dialog {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  width: 560px;
+  max-width: 90%;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.new-project-dialog .dialog-body {
+  overflow-y: auto;
+}
+
+.new-project-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.new-project-field input[type="text"],
+.new-project-field select {
+  padding: 8px 12px;
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.new-project-field input[type="text"]:focus,
+.new-project-field select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.new-project-hint {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+  line-height: 1.4;
+}
+
+.new-project-hint code {
+  font-family: var(--font-mono);
+  background: var(--bg-tertiary);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.new-project-advanced-toggle {
+  background: none;
+  border: none;
+  padding: 4px 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-align: left;
+}
+
+.new-project-advanced-toggle:hover {
+  color: var(--text-primary);
+}
+
+.new-project-advanced {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-color);
+}
+
+/* ===== PROJECT ENVIRONMENT TAB (settings) ===== */
+
+.settings-env-header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.settings-env-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+}
+
+.settings-env-badge-uv {
+  color: var(--text-on-accent);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.settings-env-badge-shared {
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+}
+
+.settings-env-version {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.settings-env-interpreter {
+  flex-basis: 100%;
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.settings-env-interpreter code {
+  font-family: var(--font-mono);
+}
+
+.settings-runtime-note {
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 8px 12px;
+  margin: 0 0 12px;
+  line-height: 1.4;
+}

--- a/electron/renderer/src/test-fixtures/pdv-mock.ts
+++ b/electron/renderer/src/test-fixtures/pdv-mock.ts
@@ -103,6 +103,7 @@ function buildBase() {
       addPackage: stub<PDVApi["environment"]["addPackage"]>(async () => ({ success: true, output: "" })),
       removePackage: stub<PDVApi["environment"]["removePackage"]>(async () => ({ success: true, output: "" })),
       upgradePackage: stub<PDVApi["environment"]["upgradePackage"]>(async () => ({ success: true, output: "" })),
+      activeInfo: stub<PDVApi["environment"]["activeInfo"]>(async () => null),
     },
     modules: {
       listInstalled: stub<PDVApi["modules"]["listInstalled"]>(async () => []),
@@ -218,6 +219,8 @@ function buildBase() {
       // Tests run under Node (process.platform is set); mirror it so platform-
       // sensitive renderer code under test sees the same value as in prod.
       platform: process.platform,
+      supportedPythonVersions: ["3.10", "3.11", "3.12", "3.13", "3.14"],
+      defaultPythonVersion: "3.13",
     },
     launchers: {
       openAgent: stub<PDVApi["launchers"]["openAgent"]>(async () => ({ success: true })),

--- a/electron/renderer/src/types/index.ts
+++ b/electron/renderer/src/types/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+  ActiveEnvironmentInfo,
   AgentLauncherConfig,
   Config,
   EditorLauncherConfig,
@@ -16,6 +17,7 @@ import type {
   KernelExecutionError,
   KernelExecutionOrigin,
   KernelExecuteResult,
+  KernelRestartResult,
   KernelSpec,
   KernelUvContext,
   ProjectPackage,
@@ -54,6 +56,7 @@ import type {
 
 /** Re-export core preload API contract types for renderer imports. */
 export type {
+  ActiveEnvironmentInfo,
   AgentLauncherConfig,
   Config,
   EditorLauncherConfig,
@@ -63,6 +66,7 @@ export type {
   KernelExecutionError,
   KernelExecutionOrigin,
   KernelExecuteResult,
+  KernelRestartResult,
   KernelSpec,
   KernelUvContext,
   ProjectPackage,

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -281,6 +281,40 @@ export interface KernelUvContext {
   saveDir?: string;
   /** Creating a brand-new uv project (seed from default packages, §10.5.8). */
   newProject?: boolean;
+  /**
+   * Python version for a new project's venv (e.g. `"3.13"`), chosen in the
+   * New Project dialog. Only meaningful with `newProject`.
+   */
+  pythonVersion?: string;
+  /**
+   * Initial PEP 508 dependency specs for a new project's `pyproject.toml`.
+   * Only meaningful with `newProject`; defaults to the global default
+   * packages when absent.
+   */
+  packages?: string[];
+}
+
+/**
+ * Result of `kernels.restart`: the freshly started kernel plus whether
+ * project state was restored from a pre-restart autosave snapshot.
+ */
+export interface KernelRestartResult {
+  /** Metadata of the newly started kernel. */
+  kernel: KernelInfo;
+  /** True when tree/cell state was reloaded from an autosave snapshot. */
+  restoredFromAutosave: boolean;
+}
+
+/**
+ * Environment metadata for the active kernel (Project Environment tab).
+ */
+export interface ActiveEnvironmentInfo {
+  /** Whether the session runs in a uv-managed project venv or a shared env. */
+  mode: 'uv' | 'shared';
+  /** Interpreter the kernel actually spawned on (venv python for uv mode). */
+  interpreterPath?: string;
+  /** Resolved `major.minor` Python version of that interpreter. */
+  pythonVersion?: string;
 }
 
 /**
@@ -839,7 +873,7 @@ export interface PDVApi {
     stop(kernelId: string): Promise<boolean>;
     execute(kernelId: string, request: KernelExecuteRequest): Promise<KernelExecuteResult>;
     interrupt(kernelId: string): Promise<boolean>;
-    restart(kernelId: string): Promise<KernelInfo>;
+    restart(kernelId: string): Promise<KernelRestartResult>;
     complete(
       kernelId: string,
       code: string,
@@ -961,6 +995,8 @@ export interface PDVApi {
     removePackage(names: string[]): Promise<EnvironmentInstallResult>;
     /** Upgrade packages within their declared constraints (`uv lock --upgrade-package` + sync). */
     upgradePackage(names: string[]): Promise<EnvironmentInstallResult>;
+    /** Active kernel's environment metadata, or null when no kernel is active. */
+    activeInfo(): Promise<ActiveEnvironmentInfo | null>;
   };
   modules: {
     listInstalled(): Promise<ModuleDescriptor[]>;
@@ -1118,6 +1154,10 @@ export interface PDVApi {
   system: {
     /** Node.js platform identifier of the main process. */
     platform: NodeJS.Platform;
+    /** CPython minor versions offered by the New Project dialog, oldest first. */
+    supportedPythonVersions: readonly string[];
+    /** Version preselected in the New Project dialog (e.g. `"3.13"`). */
+    defaultPythonVersion: string;
   };
   /** External-app launchers driven by the action bar. */
   launchers: {


### PR DESCRIPTION
## Summary

Two thrusts on one branch:

1. **Batch 2 of the audit follow-ups** — robustness fixes to the Electron main process, plus restart-preserves-the-tree.
2. **New-project environment UX** — a creation-time environment dialog, per-project environment recording in the manifest, a settings rescope that kills the uv→shared demotion trap, and crash-safe restart.

**No `pdv-python` changes**, so no dependency sweep needed. Follow-up issue filed: #335 (deliberate "Change project environment…" action).

---

## Part 1 — Lifecycle robustness (commit `9dbc45f`)

### Robustness (items 1–6)

- **IPC channel registry** — new `ipc-registry.ts` (`handleIpc`/`removeAllIpcHandlers`) records channels as they register and derives teardown from the actual registrations, replacing the hand-maintained `REGISTERED_CHANNELS` list that had drifted (17 channels missing → macOS window-reopen threw "second handler"; 4 stale entries). All `ipcMain.handle` sites now route through `handleIpc`.
- **Atomic writes** — `preferences.json` (new `atomicWriteFileSync`), `module-index.json`, and gui-editor `.gui.json` saves write via tmp+rename. A torn `preferences.json` was previously backed up and reset, silently dropping all settings.
- **Listener leaks** — tracked `kernel:memoryRss` listener with a remover; `before-quit` guard detached on window `closed`; window chrome-state listeners scoped to the window.
- **Session start/stop/restart lock** — `withStartLock` does the synchronous swap-before-await (mirroring `ProjectManager.runWithSaveLock`) so concurrent operations can't both proceed.
- **Query-socket recovery** — a ZMQ REQ socket wedges after one timed-out receive; `sendQueryRequest` now recreates the socket after a failure.
- **Module reinstall** — a duplicate install no longer overwrites installed files when reporting `up_to_date`.

### Restart preserves the tree (item 7)

Restart snapshots the tree into `.autosave` while the old session is still alive and restores it into the new one — saved projects via the project-open overlay recipe, unsaved sessions via the welcome-screen Recover routine. Wired the StatusBar **⟳ Restart** control. ARCHITECTURE.md §8.4.

---

## Part 2 — New-project environment UX (commit `0910e6d`)

Principle: **the environment is a property of the project, not the app** (ARCHITECTURE.md §10.5.8, §10.5.19, §11.6).

### New Project dialog

- "New Python Project" opens a setup dialog: Python version dropdown (3.10–3.14 via new `main/python-versions.ts`, default 3.13; uv downloads missing interpreters), initial packages prefilled from `defaultPackages`, and an **Advanced** mode toggle for running on an existing (conda/system) environment — the cluster/MPI case.
- The two paths are mutually exclusive with a **single always-visible footer action**: Create for a usable selection, **Install pdv-python** when that is the required next step (the embedded selector's own confirm/install buttons are suppressed via new `hideConfirm`/`hideInstallButton`/`actionsRef` props), disabled-with-reason otherwise. Nothing actionable ever sits below the scroll.
- uv path: `KernelUvContext` gains `{pythonVersion, packages}`; new projects get `uv sync --python` plus a `.python-version` pin that rides `ENV_FILES` through save/open/restart. Project stays unsaved until first Save.

### Per-project environment recording

- New `kernelEnvMeta` map records mode + actual interpreter + resolved Python version per kernel.
- Saves record `environment.python_version` (uv) or an **authoritative** `interpreter_path` (shared — the interpreter the kernel actually spawned on, not the global config value); shared mode is now recorded explicitly. Reopen probes the recorded interpreter with the existing missing-env fallback.
- New `environment:activeInfo` IPC channel.

### Settings rescope

- Packages tab → **Project Environment**: mode badge ("uv-managed · shareable" / "external environment") + interpreter + Python version header above the package manager.
- Runtime tab → **Default Runtime**: with a session ready, selections update the global default **for future sessions only** — the old path (write global config, stop the kernel, silently demote a uv project to shared mode) is removed. First-run / start-failure / missing-interpreter flows keep their save-and-start behavior.

### Crash-safe restart

- `onCrash` no longer deletes the working dir — it was destroying the uv env spec and any unsaved `.autosave`, so a crashed uv project restarted in shared mode with data loss.
- The pre-restart snapshot gates on **process liveness** (not the stale-idle `executionState`, which survives a crash) with a 5 s comm bound, falling back to the last timer autosave.
- **⟳ Restart now renders in the `error` state** (it used to disappear exactly when needed); `kernels.restart` returns `{kernel, restoredFromAutosave}` and the console reports what came back. Restart also rebuilds the uv env from the save dir if the working dir is gone.

## Test plan

- [x] Electron unit suite: **682 passed**, typecheck clean, lint at baseline. New coverage: `NewProjectDialog` (9 tests incl. the Install↔Create footer swap), StatusBar restart-visibility matrix, env-recording in project save, new-project uv plumbing (`--python`, packages, pin), crash-handler dir preservation, restart return shape, `handleEnvSave {restart:false}`, `.python-version` ENV_FILES round-trip.
- [x] Full Playwright e2e: **22 passed** against a real kernel, including new `new-project-dialog.spec.ts` (dialog → uv project → manifest records `mode`/`python_version`/pin) and `crash-restart.spec.ts` (SIGKILL the kernel → Restart appears → tree restored from autosave), plus the Default Runtime future-sessions note. Existing specs migrated to a `createNewPythonProject` helper.
- [x] Docs: ARCHITECTURE.md §8.4, §10.5.3/.5/.8/.10/.13/.15, new §10.5.19, §11.2, §11.6.
- [x] No `pdv-python` changes → dependency sweep not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)