### PR TITLE
Renderer state refactor (#233) + kernel tree-version channel — remote-mode Phase 1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -812,7 +812,7 @@ The file layout mirrors `pdv-python` one-to-one (`tree.jl`, `serialization.jl`, 
 | Runtime version acquisition | bundled uv downloads interpreters on demand (`uv python install`, §10.5.7) | the *user's* juliaup, never bundled (§10.7.5): selector-driven `juliaup add`, one-click juliaup bootstrap via the official script, and a load-time `Manifest.toml` version check with a `juliaup add` offer |
 | Query server | ZMQ REP on a daemon thread (GIL makes concurrent dict reads safe) | ZMQ REP on a **spare interactive-pool** OS thread when one exists (the app spawns Julia with `--threads=auto,2`: the main task holds one interactive thread, the query loop the other). The pool choice is load-bearing — `@threads :static` pins one task per *default*-pool thread, so a resident loop on a default thread would deadlock every `:static` loop in the session; interactive tids are never pinned. The loop never touches libuv (a blocked `ZMQ.recv` starves while the main thread computes) — it polls `sock.events` + `Libc.systemsleep` with a `yield()` per tick (so it can never starve the sticky root task if scheduled onto tid 1), and answers `pdv.tree.list` from a lock-guarded listings snapshot rebuilt on the main thread (debounce flush, postexecute hook, project load) so it never reads live tree values cross-thread. Other query types reply `query.kernel_busy`, which the app converts into a comm-channel fallback. Without a spare interactive thread it degrades to the original cooperative async-task loop |
 | Save-walker rescue | any error → pickle fallback; a value even pickle refuses (lambda, open handle) is skipped and reported in `failed_nodes` | same contract: any error → jls fallback; a value even jls refuses (running `Task`, ...) is skipped and reported in `failed_nodes`. `Serialization` refuses more values than pickle, so this path is far more reachable on Julia |
-| Change debounce | `threading.Timer` (fires mid-execution) | libuv `Timer` (fires at yield points; the renderer's 1 Hz poll is the safety net during tight loops) |
+| Change debounce | `threading.Timer` (fires mid-execution) | libuv `Timer` (fires at yield points; the renderer's version-check poll (§7.4.3) is the safety net during tight loops) |
 
 Because saved data formats differ (`pickle` vs `jls`), projects are per-language: `project.json`'s `language` field selects the kernel at open time, and the Julia loader rejects `pickle`-format nodes with a clear "open with a Python session" error (and vice-versa — the Python loader does not know `jls`).
 
@@ -1333,7 +1333,7 @@ Additional fields present at top level for specific types:
 
 ### 7.4 Tree-Update Propagation
 
-Tree changes propagate to the renderer by two complementary mechanisms — push notifications for snappy live updates, and a 1 Hz poll as a safety net for mutations that bypass push.
+Tree changes propagate to the renderer by three complementary mechanisms — push notifications for snappy live updates, a post-execute structural fingerprint that catches silent mutations at the source, and a low-frequency version-check poll as the last-resort safety net.
 
 #### 7.4.1 Push (primary)
 
@@ -1352,14 +1352,20 @@ Whenever the tree structure changes — a node is added, deleted, or its value u
 
 Mutations on the **root** `PDVTree` emit precise paths via the per-instance debounced queue (§7.1.2). Mutations on **any other** `PDVTree` (intermediate sub-trees, scratch instances) emit `change_type: "unknown"` with empty `changed_paths` via a class-level global channel — local paths can't be reconciled with the renderer's absolute view, so the renderer responds with a full refresh-with-expansion. Both channels share the 100 ms debounce.
 
-#### 7.4.2 Poll (safety net)
+#### 7.4.2 Post-execute fingerprint (silent-mutation detection)
 
-The renderer also polls. Every second, the Tree component fetches fresh `pdv.tree.list` results for the root and every currently expanded subtree, structurally compares each child list against the rendered state (path / key / type / hasChildren / preview), and — when it detects drift — patches just the drifted path in place, merging the fresh children with the existing ones so surviving nodes keep their expansion state (no full-depth refetch, no loading flash). Most ticks find no change and are effectively free, since `pdv.tree.list` is served by the kernel's dedicated read-only thread (`pdv.query_server`, §3.1) and doesn't block on user-code execution. The next tick is scheduled only after the previous walk completes, so a slow walk over a large expanded tree never overlaps itself.
+Push cannot see mutations of plain-`dict` values stored in the tree (`pdv_tree['data']['x'] = 1` where `data` is a plain dict) — they have no emission machinery. Both kernels therefore compare a cheap structural fingerprint of the root tree after every execution (IPython `post_execute` event / IJulia postexecute hook). The fingerprint covers what listings display — keys, value type names, scalar values (previews show them), and shape/length for sized containers — and never touches array contents, with a node budget and depth cap bounding pathological trees. When the fingerprint drifts and no precise notification already covered the execution, the kernel bumps its **tree version counter** and emits a coarse `change_type: "unknown"` ping so the renderer refreshes immediately.
 
-The poll exists to catch mutations that push cannot see — primarily plain-`dict` values stored in the tree, which have no emission machinery. The user-facing contract is therefore:
+The version counter (`PDVTree._tree_version` / `PDVKernel._TREE_VERSION`) is a monotonic integer bumped by every mutation notification and by fingerprint drift. It is served by the read-only query server as `pdv.tree.version` → `{ "version": n }`, answerable mid-execution (in Julia's threaded query mode it is answered off-thread directly, since it reads only a lock-guarded counter).
 
-- Mutations on `PDVTree` values are reflected in the tree panel within ~100 ms.
-- Mutations on plain `dict` values stored in the tree are reflected within ~1 s.
+#### 7.4.3 Poll (safety net)
+
+The renderer also polls, as a last resort for mutations neither push nor the fingerprint sees (e.g. a background thread in user code mutating between executions). Every 2 s — and only when no `pdv.tree.changed` push arrived in the last 2 s, since a live push stream proves the pipeline works — the Tree issues **one** `pdv.tree.version` query and compares the counter. On change, it invalidates the React Query tree cache; the root and every expanded listing then refetch **in parallel** (≈1 round trip of wall-clock) and structural sharing keeps unchanged listings identity-stable, so no-op refreshes render nothing. Kernels that predate the version channel are feature-detected once (the query returns null) and polled by listing instead: the same parallel revalidation of root + expanded paths through the query cache.
+
+The user-facing contract:
+
+- Mutations on `PDVTree` values are reflected in the tree panel within ~100 ms (push).
+- Mutations on plain `dict` values stored in the tree are reflected at the end of the execution that made them (fingerprint ping), or within ~2–4 s in the worst case (version poll).
 
 This is the trade we accept to avoid silently coercing user-supplied `dict` values into `PDVTree` at assignment time, which would change the type of stored values out from under the user.
 
@@ -1999,8 +2005,11 @@ useEffect(() => {
 useEffect(() => {
   if (!currentKernelId) return;
 
-  const unsubTree = window.pdv.tree.onChanged(_payload => {
-    setTreeRefreshToken(t => t + 1);
+  const unsubTree = window.pdv.tree.onChanged(payload => {
+    // Targeted React Query invalidation (queries/invalidation.ts):
+    // removals patch the parent listing in place; adds/updates invalidate
+    // only the changed parents; "unknown" invalidates every listing.
+    applyTreeChange(currentKernelId, payload);
   });
 
   const unsubProject = window.pdv.project.onLoaded(payload => {
@@ -2038,10 +2047,10 @@ useEffect(() => {
 ```
 
 Rules:
-- **One owner (main window)**: Within the main window, only `App` (via its hooks) directly registers push subscriptions. Child components receive state/refresh tokens as props. Module popup windows are independent roots and manage their own subscriptions.
-- **Kernel-scoped cleanup**: `tree.onChanged`, `project.onLoaded`, `kernels.onKernelStatus`, `project.onReloading`, and `progress.onProgress` are torn down/re-registered whenever kernel identity changes.
+- **One owner (main window)**: Within the main window, only `App` (via its hooks) directly registers push subscriptions. Handlers translate pushes into React Query invalidations (`renderer/src/queries/invalidation.ts`) and Zustand store updates; components read server state through query hooks (`renderer/src/queries/`) and shared UI state through `useStore` selectors — never via refresh-token props, and never by subscribing to `window.pdv` push channels themselves. Module popup windows are independent roots and manage their own subscriptions.
+- **Kernel-scoped cleanup**: `tree.onChanged`, `project.onLoaded`, `kernels.onKernelStatus`, `project.onReloading`, and `progress.onProgress` are torn down/re-registered whenever kernel identity changes. Kernel-scoped query caches are removed on kernel switch (`invalidateAllKernelState`).
 - **App-scoped cleanup**: `kernels.onOutput`, `menu.onAction`, and `chrome.onStateChanged` are registered once and cleaned up on unmount.
-- **No polling**: Tree/project updates are push-driven; renderer does not poll these domains.
+- **Round-trip discipline**: Server state is cached by React Query and refreshed by push-driven invalidation; common interactions cost at most one round trip, and idle traffic is O(1) per tick (the §7.4.3 version-check poll), never proportional to how much of the tree is expanded. No new refresh tokens or ad-hoc polling.
 - **Hook composition**: See `electron/renderer/src/app/HOOKS.md` for the full hook dependency graph and data flow documentation.
 
 ### 11.5 Custom Title Bar and Window Chrome

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Renderer (React) ──window.pdv──► Preload ──ipcRenderer──► Ma
 
 6. **`kernels.start()` encapsulates the full handshake.** The `pdv.ready → pdv.init → pdv.init.response` sequence is entirely inside the main process's `kernels.start()` handler. The renderer only `await`s it.
 
-7. **Push subscriptions are owned by `App`, keyed on `currentKernelId`.** One `useEffect` in `app/index.tsx` subscribes to `tree.onChanged` and `project.onLoaded`, and tears them down on cleanup. Child components receive refresh tokens as props; they do not subscribe directly.
+7. **Push subscriptions are owned by `App`'s `useKernelSubscriptions`, keyed on `currentKernelId`; they write to the shared stores, not to props.** Handlers translate pushes into React Query invalidations (`renderer/src/queries/invalidation.ts`) and Zustand store updates (`renderer/src/store/`). Components never subscribe to `window.pdv` push channels directly and never receive refresh tokens; server state is read via query hooks in `renderer/src/queries/`, shared UI state via `useStore` selectors. Shared state goes in the store; local component state stays `useState`. No new refresh tokens or ad-hoc polling — the latency budget is: common interactions ≤1 round trip, idle traffic O(1) per tick.
 
 8. **Scripts follow a fixed structure.** Every PDV script defines `run(pdv_tree: dict, **user_params) -> dict`. The `pdv_tree` argument is always injected by `PDVScript.run()` and is never supplied by the user — it is present in the signature so language servers don't flag tree references as errors.
 
@@ -165,3 +165,4 @@ When reviewing a pull request (including via `/review`), check every item below 
 - [ ] **JSDoc coverage** — New or modified exports in `electron/main/` have JSDoc with `@param`, `@returns`, `@throws`. No unguarded `any` types introduced.
 - [ ] **Documentation updated** — If the PR changes architecture, adds new IPC channels, modifies the comm protocol, introduces new tree node types, or alters any behavior described in `ARCHITECTURE.md` or `PLANNED_FEATURES.md`, those documents have been updated to match.
 - [ ] **Dependency sweep passed** — If the PR touches `pdv-python/` (source or `pyproject.toml`), `pdv-python/scripts/sweep-deps.sh` was run locally and exited green. Result is recorded in the PR description's "Test plan".
+- [ ] **Round-trip discipline** — No new refresh tokens or ad-hoc polling in the renderer; server state goes through `renderer/src/queries/` (React Query) with push-driven invalidation, shared UI state through `renderer/src/store/`. Common interactions cost ≤1 round trip; idle traffic is O(1) per tick.

--- a/electron/e2e/round-trip-budget.spec.ts
+++ b/electron/e2e/round-trip-budget.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * round-trip-budget.spec.ts — the renderer's latency discipline, executable.
+ *
+ * Remote mode turns every `window.pdv` invoke into a network round trip, so
+ * the renderer must never be chatty: idle traffic is O(1) per poll tick
+ * (one `tree:getVersion`, never per-expanded-level listings), and a cell
+ * run costs the execute plus one parallel revalidation wave. This spec
+ * counts real IPC invokes (per-channel counters recorded by the preload
+ * under PDV_E2E=1) and fails if the budget regresses — e.g. if someone
+ * reintroduces a listing-based poll or an ad-hoc refetch loop.
+ *
+ * Budgets are deliberately generous enough to absorb timing jitter (an
+ * extra poll tick landing inside the window) while remaining far below the
+ * old behavior they guard against (the pre-#233 poll issued
+ * (1 + expanded) serial listings every second — ~15+ listings per 5 s
+ * window where this spec allows zero).
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { expectKernelReady } from "./helpers/kernel-status";
+import { launchPDV, type LaunchedApp } from "./helpers/launch";
+import { createNewPythonProject } from "./helpers/new-project";
+
+let launched: LaunchedApp;
+
+test.beforeAll(async () => {
+  launched = await launchPDV();
+  await createNewPythonProject(launched.window);
+  await expectKernelReady(launched.window);
+});
+
+test.afterAll(async () => {
+  await launched?.cleanup();
+});
+
+async function invokeCounts(window: Page): Promise<Record<string, number>> {
+  return window.evaluate(() =>
+    (window as unknown as { pdv: { system: { getInvokeCounts(): Record<string, number> } } })
+      .pdv.system.getInvokeCounts(),
+  );
+}
+
+function delta(
+  before: Record<string, number>,
+  after: Record<string, number>,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [channel, count] of Object.entries(after)) {
+    const diff = count - (before[channel] ?? 0);
+    if (diff > 0) out[channel] = diff;
+  }
+  return out;
+}
+
+const sum = (counts: Record<string, number>): number =>
+  Object.values(counts).reduce((a, b) => a + b, 0);
+
+test("idle app with expanded tree costs one version check per tick, no listings", async () => {
+  test.setTimeout(120_000);
+  const { window } = launched;
+
+  // Seed a two-level tree and expand both levels, so the old
+  // per-expanded-level poll would be maximally visible.
+  const editor = window.getByRole("textbox", { name: "Editor content" });
+  await editor.focus();
+  await window.keyboard.type(
+    "pdv_tree['grp'] = {'inner': {'leaf': 1}, 'x': 2}",
+  );
+  await window.getByRole("button", { name: "Execute" }).click();
+  const grpRow = window.locator(".tree-row", { hasText: "grp" }).first();
+  await expect(grpRow).toBeVisible({ timeout: 30_000 });
+  await grpRow.getByRole("button", { name: /Expand/ }).click();
+  const innerRow = window.locator(".tree-row", { hasText: "inner" }).first();
+  await expect(innerRow).toBeVisible({ timeout: 15_000 });
+  await innerRow.getByRole("button", { name: /Expand/ }).click();
+  await expect(window.locator(".tree-row", { hasText: "leaf" })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Let post-execution invalidation and push suppression settle.
+  await window.waitForTimeout(4_000);
+
+  const before = await invokeCounts(window);
+  await window.waitForTimeout(5_000); // ~2–3 poll ticks
+  const idle = delta(before, await invokeCounts(window));
+
+  // The whole idle window: version checks only. Zero listings, zero
+  // namespace traffic, and O(1) total regardless of expansion depth.
+  expect(idle["tree:list"] ?? 0).toBe(0);
+  expect(idle["namespace:query"] ?? 0).toBe(0);
+  expect(idle["tree:getVersion"] ?? 0).toBeLessThanOrEqual(4);
+  expect(sum(idle)).toBeLessThanOrEqual(5);
+});
+
+test("a cell run costs the execute plus one bounded revalidation wave", async () => {
+  test.setTimeout(120_000);
+  const { window } = launched;
+  const editor = window.getByRole("textbox", { name: "Editor content" });
+
+  const before = await invokeCounts(window);
+
+  await editor.focus();
+  await window.keyboard.press(
+    process.platform === "darwin" ? "Meta+a" : "Control+a",
+  );
+  await window.keyboard.type("x_budget = 1");
+  await window.getByRole("button", { name: "Execute" }).click();
+  await expect(window.locator(".log-entry", { hasText: "x_budget" })).toBeVisible({
+    timeout: 30_000,
+  });
+  // Allow the post-run invalidation wave (and any fingerprint ping) to land.
+  await window.waitForTimeout(2_500);
+
+  const run = delta(before, await invokeCounts(window));
+
+  expect(run["kernels:execute"] ?? 0).toBe(1);
+  // Revalidation: root + 2 expanded levels, in parallel — allow slack for a
+  // push-driven wave on top, but nothing like a per-level serial reload.
+  expect(run["tree:list"] ?? 0).toBeLessThanOrEqual(6);
+  // Namespace panel is hidden: its queries are inactive and must not fetch.
+  expect(run["namespace:query"] ?? 0).toBe(0);
+  // Total budget for one trivial run, including poll ticks in the window.
+  expect(sum(run)).toBeLessThanOrEqual(12);
+});

--- a/electron/main/ipc-register-tree-namespace-script.ts
+++ b/electron/main/ipc-register-tree-namespace-script.ts
@@ -238,6 +238,23 @@ export function registerTreeNamespaceScriptIpcHandlers(
     return response.payload;
   });
 
+  handleIpc(IPC.tree.getVersion, async (_event, kernelId: string) => {
+    if (!kernelManager.getKernel(kernelId) || !queryRouter.isAttached()) {
+      return null;
+    }
+    // Query socket only, no comm fallback: a kernel that predates the
+    // version channel rejects it instantly there (query.not_allowed), while
+    // a comm fallback would hang until timeout. Callers treat null as
+    // "unsupported" and poll by listing instead.
+    try {
+      const response = await queryRouter.request(PDVMessageType.TREE_VERSION, {});
+      const version = (response.payload as { version?: unknown }).version;
+      return typeof version === "number" ? version : null;
+    } catch {
+      return null;
+    }
+  });
+
   handleIpc(
     IPC.tree.createScript,
     async (

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -93,6 +93,7 @@ export const IPC = {
   tree: {
     list: "tree:list",
     get: "tree:get",
+    getVersion: "tree:getVersion",
     createScript: "tree:createScript",
     createNote: "tree:createNote",
     addFile: "tree:addFile",
@@ -1959,6 +1960,15 @@ export interface PDVApi {
      */
     get(kernelId: string, path: string): Promise<Record<string, unknown>>;
     /**
+     * Fetch the kernel's monotonic tree-version counter (query socket only —
+     * one cheap round trip regardless of tree size).
+     *
+     * @param kernelId - Target kernel ID.
+     * @returns The current version, or null when the kernel predates the
+     *   version channel (callers fall back to listing-based polling).
+     */
+    getVersion(kernelId: string): Promise<number | null>;
+    /**
      * Create and register a new script node.
      *
      * @param kernelId - Target kernel ID.
@@ -2993,6 +3003,12 @@ export interface PDVApi {
     supportedJuliaVersions: readonly string[];
     /** Fallback preselected Julia version when no juliaup default applies. */
     defaultJuliaVersion: string;
+    /**
+     * E2E-only diagnostics: snapshot of per-channel invoke counts (empty
+     * outside `PDV_E2E=1`). Read by the round-trip-budget spec to assert
+     * the renderer's latency discipline.
+     */
+    getInvokeCounts(): Record<string, number>;
   };
 
   /** External-app launchers driven by the action bar. */

--- a/electron/main/pdv-protocol.ts
+++ b/electron/main/pdv-protocol.ts
@@ -152,6 +152,17 @@ export const PDVMessageType = {
   /** Kernel → app. Returns node value. */
   TREE_GET_RESPONSE: "pdv.tree.get.response",
   /**
+   * App → kernel. Request the tree's monotonic version counter — bumped on
+   * every PDVTree mutation and by the post-execute structural fingerprint
+   * (which catches plain-dict mutations that emit no change push). Served by
+   * the read-only query server, so it answers mid-execution. The renderer's
+   * safety-net poll costs one round trip regardless of tree size by asking
+   * for this instead of re-listing every expanded level.
+   */
+  TREE_VERSION: "pdv.tree.version",
+  /** Kernel → app. Returns `{ version: number }`. */
+  TREE_VERSION_RESPONSE: "pdv.tree.version.response",
+  /**
    * App → kernel. Resolve a file-backed tree node to its absolute path.
    *
    * Used internally by main-process handlers (e.g.
@@ -408,6 +419,12 @@ export interface PDVProjectSaveResponsePayload {
 export interface PDVTreeListPayload {
   /** Dot-separated path to list, or "" / null for root. */
   path?: string | null;
+}
+
+/** Payload for pdv.tree.version.response (kernel → app). */
+export interface PDVTreeVersionPayload {
+  /** Monotonic mutation counter for the kernel's tree. */
+  version: number;
 }
 
 /** Payload for pdv.tree.get (app → kernel). */

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "physics-data-viewer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "physics-data-viewer",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@monaco-editor/react": "^4.6.0",
+        "@tanstack/react-query": "^5.101.2",
         "ansi-to-html": "^0.7.2",
         "electron-updater": "^6.8.9",
         "katex": "^0.17.0",
@@ -21,7 +22,8 @@
         "react-window": "^2.2.7",
         "smol-toml": "^1.7.0",
         "zeromq": "^6.5.0",
-        "zod": "^4.4.3"
+        "zod": "^4.4.3",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2516,6 +2518,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -2708,14 +2736,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4321,7 +4349,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -10015,6 +10043,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "physics-data-viewer",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "physics-data-viewer",
-      "version": "0.2.1",
+      "version": "0.2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@monaco-editor/react": "^4.6.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "physics-data-viewer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "uvVersion": "0.11.6",
   "private": true,
   "author": {
@@ -71,6 +71,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
     "@monaco-editor/react": "^4.6.0",
+    "@tanstack/react-query": "^5.101.2",
     "ansi-to-html": "^0.7.2",
     "electron-updater": "^6.8.9",
     "katex": "^0.17.0",
@@ -82,6 +83,7 @@
     "react-window": "^2.2.7",
     "smol-toml": "^1.7.0",
     "zeromq": "^6.5.0",
-    "zod": "^4.4.3"
+    "zod": "^4.4.3",
+    "zustand": "^5.0.14"
   }
 }

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "physics-data-viewer",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "uvVersion": "0.11.6",
   "private": true,
   "author": {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -57,7 +57,20 @@ function onPush<TPayload>(
  * @returns The handler's result.
  * @throws {Error} The handler's failure, with the Electron prefix removed.
  */
+/**
+ * Per-channel invoke counters, populated only under E2E (`PDV_E2E=1`).
+ * The round-trip-budget spec reads these to assert the renderer's latency
+ * discipline — idle traffic O(1) per tick, ≤1 round trip per interaction —
+ * which is what keeps PDV usable when every invoke is a network hop in
+ * remote mode.
+ */
+const invokeCounts: Record<string, number> = {};
+const COUNT_INVOKES = process.env.PDV_E2E === "1";
+
 async function invoke<TResult>(channel: string, ...args: unknown[]): Promise<TResult> {
+  if (COUNT_INVOKES) {
+    invokeCounts[channel] = (invokeCounts[channel] ?? 0) + 1;
+  }
   try {
     return (await ipcRenderer.invoke(channel, ...args)) as TResult;
   } catch (err) {
@@ -101,6 +114,8 @@ const api: PDVApi = {
       invoke(IPC.tree.list, kernelId, nodePath),
     get: (kernelId, nodePath) =>
       invoke(IPC.tree.get, kernelId, nodePath),
+    getVersion: (kernelId) =>
+      invoke(IPC.tree.getVersion, kernelId),
     createScript: (kernelId, targetPath, scriptName) =>
       invoke(IPC.tree.createScript, kernelId, targetPath, scriptName),
     createNote: (kernelId, targetPath, noteName) =>
@@ -298,6 +313,9 @@ const api: PDVApi = {
     // Julia siblings from julia-versions.ts (§10.6.5).
     supportedJuliaVersions: SUPPORTED_JULIA_VERSIONS,
     defaultJuliaVersion: DEFAULT_JULIA_VERSION,
+    // E2E-only diagnostics: per-channel invoke counts for the
+    // round-trip-budget spec. Returns a snapshot copy; empty outside E2E.
+    getInvokeCounts: () => ({ ...invokeCounts }),
   },
   launchers: {
     openAgent: () => invoke(IPC.launchers.openAgent),

--- a/electron/renderer/src/app/HOOKS.md
+++ b/electron/renderer/src/app/HOOKS.md
@@ -30,16 +30,16 @@ App's 39 `useState` calls are organized into these logical groups:
 | Group | States | Primary Consumers |
 |-------|--------|--------------------|
 | **Code editor** | `cellTabs`, `activeCellTab` | CodeCell, useCodeCellsPersistence, useKeyboardShortcuts, useProjectWorkflow |
-| **Console** | `logs` | Console, useKernelSubscriptions, useKernelLifecycle |
+| **Console** | `logs` (Zustand `consoleSlice` — Console subscribes directly) | Console, useKernelSubscriptions, useKernelLifecycle |
 | **Kernel** | `currentKernelId`, `kernelStatus`, `isExecuting`, `lastError`, `codeCellExecutionError`, `lastDuration` | useKernelLifecycle, useKernelSubscriptions, CodeCell, Tree, status bar |
 | **Config** | `config` | useThemeManager, useKernelLifecycle, useProjectWorkflow, CodeCell, ModulesPanel |
 | **Project** | `currentProjectDir` | useProjectWorkflow, title bar |
-| **Refresh tokens** | `treeRefreshToken`, `namespaceRefreshToken`, `modulesRefreshToken`, `autoRefreshNamespace` | Tree, NamespaceView, ModulesPanel |
+| **Refresh tokens** | `modulesRefreshToken` (last survivor — modules queries not yet migrated), `autoRefreshNamespace` | ModulesPanel |
 | **Dialogs** | `showEnvSelector`, `scriptDialog`, `createScriptTarget`, `showSettings`, `settingsInitialTab` | EnvironmentSelector, ScriptDialog, CreateScriptDialog, SettingsDialog |
 
-### Refresh Token Pattern
+### Server-State Pattern (React Query)
 
-Several hooks bump integer "refresh tokens" (e.g. `setTreeRefreshToken(t => t + 1)`) to signal child components that they should refetch data. This avoids passing full data objects through the component tree — children own their own fetch logic and simply re-run it when their token prop changes.
+Tree and namespace data live in the React Query cache (`renderer/src/queries/`), keyed per kernel and parent path/expression. Push events translate into targeted invalidations (`queries/invalidation.ts`); components mount query hooks and re-render only when data actually changes. The old integer "refresh token" pattern survives only for the modules listings (`modulesRefreshToken`), pending their query migration.
 
 ---
 
@@ -87,10 +87,10 @@ Several hooks bump integer "refresh tokens" (e.g. `setTreeRefreshToken(t => t + 
 
 **Purpose**: Registers and tears down three push subscriptions keyed on `currentKernelId`:
 - `window.pdv.kernels.onOutput()` → appends stdout/stderr/images to console logs
-- `window.pdv.tree.onChanged()` → bumps tree and modules refresh tokens
+- `window.pdv.tree.onChanged()` → applies targeted React Query invalidations (applyTreeChange) and bumps the modules refresh token
 - `window.pdv.project.onLoaded()` → restores code cell tabs from project snapshot
 
-**Takes**: `currentKernelId`, `loadedProjectTabsRef`, and setters for logs, cellTabs, activeCellTab, treeRefreshToken, modulesRefreshToken.
+**Takes**: `currentKernelId`, `loadedProjectTabsRef`, and setters for logs, cellTabs, activeCellTab, modulesRefreshToken.
 
 **Returns**: Nothing (void). Subscriptions are cleaned up on kernel change or unmount.
 
@@ -102,12 +102,12 @@ Several hooks bump integer "refresh tokens" (e.g. `setTreeRefreshToken(t => t + 
 
 **Purpose**: Provides callbacks for starting, restarting, and reconfiguring the kernel.
 
-**Takes**: Config, current kernel ID, and setters for kernel status, error state, env selector visibility, logs, and refresh tokens.
+**Takes**: Config, current kernel ID, and setters for kernel status, error state, env selector visibility, and logs.
 
 **Returns**:
 - `startKernel(cfg)` — stops any existing kernel, starts a new one with the given config
 - `handleEnvSave(paths)` — saves new environment paths to config and calls `startKernel`
-- `handleRestartKernel()` — restarts the current kernel (clears logs, bumps refresh tokens)
+- `handleRestartKernel()` — restarts the current kernel (clears logs, purges kernel-scoped query caches)
 
 **Dependencies**: Uses `currentKernelId` to know which kernel to stop/restart.
 
@@ -195,7 +195,7 @@ Several hooks bump integer "refresh tokens" (e.g. `setTreeRefreshToken(t => t + 
                     └──────────────────────┘
 
                     ┌──────────────────────┐
-  currentKernelId ─►│useKernelSubscriptions │──► setLogs, setTreeRefreshToken,
+  currentKernelId ─►│useKernelSubscriptions │──► setLogs, query invalidations,
                     │                      │    setModulesRefreshToken,
                     │                      │    setCellTabs (on project load)
                     └──────────────────────┘
@@ -222,7 +222,7 @@ Several hooks bump integer "refresh tokens" (e.g. `setTreeRefreshToken(t => t + 
 
 1. **No circular dependencies** — hooks receive state as props and only call provided setters; they never import or call each other.
 2. **One subscription owner** — only `useKernelSubscriptions` registers push subscriptions. Other hooks read state but don't subscribe.
-3. **Refresh tokens as triggers** — child components (Tree, NamespaceView, ModulesPanel) receive token props and refetch when they change. They don't subscribe to push events directly. Incrementing a token (e.g. `setTreeRefreshToken(t => t + 1)`) causes any `useEffect` that lists it as a dependency to re-run, acting as a lightweight pub/sub without a state-management library.
+3. **Query invalidation as triggers** — Tree and NamespaceView mount React Query hooks and refetch when their keys are invalidated by push handlers (`queries/invalidation.ts`); they don't subscribe to push events directly. ModulesPanel still uses the legacy `modulesRefreshToken` prop pending its query migration.
 4. **Ref-based stability** — `useKeyboardShortcuts` stores frequently-changing values in refs to avoid re-registering the global listener on every render.
 
 ---

--- a/electron/renderer/src/app/app-utils.test.ts
+++ b/electron/renderer/src/app/app-utils.test.ts
@@ -4,12 +4,14 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  appendLogEntry,
   mergeConfigUpdate,
   normalizeLoadedCodeCells,
   normalizeRecentProjects,
 } from "./app-utils";
-import { MAX_RECENT_PROJECTS } from "./constants";
+import { MAX_IMAGE_LOG_ENTRIES, MAX_LOG_ENTRIES, MAX_RECENT_PROJECTS } from "./constants";
 import type { Config } from "../types/pdv";
+import type { LogEntry } from "../types";
 
 describe("normalizeLoadedCodeCells", () => {
   it("returns a single empty tab when input is invalid (null / non-object / empty)", () => {
@@ -146,5 +148,48 @@ describe("mergeConfigUpdate", () => {
     } as unknown as Config;
     const merged = mergeConfigUpdate(base, { theme: 'dark' });
     expect(merged.launchers?.agent?.command).toBe('claude');
+  });
+});
+
+describe("appendLogEntry", () => {
+  const entry = (id: number, withImage = false): LogEntry => ({
+    id: `e${id}`,
+    timestamp: id,
+    code: "",
+    ...(withImage ? { images: [{ mime: "image/png", data: "AAA" }] } : {}),
+  });
+
+  it("appends and enforces the total-entry cap", () => {
+    let logs: LogEntry[] = [];
+    for (let i = 0; i < MAX_LOG_ENTRIES + 5; i++) {
+      logs = appendLogEntry(logs, entry(i));
+    }
+    expect(logs).toHaveLength(MAX_LOG_ENTRIES);
+    expect(logs[0].id).toBe("e5");
+  });
+
+  it("strips images from entries older than the image window, keeping a count", () => {
+    let logs: LogEntry[] = [];
+    for (let i = 0; i < MAX_IMAGE_LOG_ENTRIES + 3; i++) {
+      logs = appendLogEntry(logs, entry(i, true));
+    }
+    // The three oldest entries fell out of the image window.
+    for (let i = 0; i < 3; i++) {
+      expect(logs[i].images).toBeUndefined();
+      expect(logs[i].imagesDropped).toBe(1);
+    }
+    // Everything inside the window keeps its image.
+    expect(logs[3].images).toHaveLength(1);
+    expect(logs.at(-1)?.images).toHaveLength(1);
+  });
+
+  it("preserves identity of untouched entries", () => {
+    let logs: LogEntry[] = [];
+    for (let i = 0; i < 10; i++) {
+      logs = appendLogEntry(logs, entry(i, true));
+    }
+    const before = logs[4];
+    const next = appendLogEntry(logs, entry(99));
+    expect(next[4]).toBe(before);
   });
 });

--- a/electron/renderer/src/app/app-utils.ts
+++ b/electron/renderer/src/app/app-utils.ts
@@ -5,8 +5,40 @@
  * config merge helpers. These are side-effect-free and have no React dependency.
  */
 
-import type { CellTab, Config } from '../types';
-import { MAX_RECENT_PROJECTS } from './constants';
+import type { CellTab, Config, LogEntry } from '../types';
+import { MAX_IMAGE_LOG_ENTRIES, MAX_LOG_ENTRIES, MAX_RECENT_PROJECTS } from './constants';
+
+/**
+ * Append a console log entry, enforcing both retention caps: total entries
+ * (`MAX_LOG_ENTRIES`) and how many recent entries keep their inline images
+ * (`MAX_IMAGE_LOG_ENTRIES`). Entries pushed past the image window have their
+ * base64 images replaced by an `imagesDropped` count; untouched entries keep
+ * their identity so memoized rows don't re-render.
+ *
+ * @param prev - Current log entries (not mutated).
+ * @param entry - The new entry to append.
+ * @returns The capped log list.
+ */
+export function appendLogEntry(prev: LogEntry[], entry: LogEntry): LogEntry[] {
+  let next = [...prev, entry];
+  if (next.length > MAX_LOG_ENTRIES) {
+    next = next.slice(next.length - MAX_LOG_ENTRIES);
+  }
+  const imageCutoff = next.length - MAX_IMAGE_LOG_ENTRIES;
+  if (imageCutoff > 0) {
+    for (let i = 0; i < imageCutoff; i++) {
+      const old = next[i];
+      if (old.images && old.images.length > 0) {
+        next[i] = {
+          ...old,
+          images: undefined,
+          imagesDropped: (old.imagesDropped ?? 0) + old.images.length,
+        };
+      }
+    }
+  }
+  return next;
+}
 
 /**
  * Generate an execution ID for correlating a kernel run with its console

--- a/electron/renderer/src/app/constants.ts
+++ b/electron/renderer/src/app/constants.ts
@@ -10,14 +10,27 @@ export const CELL_UNDO_LIMIT = 20;
 /** Debounce delay (ms) for code-cell persistence writes. */
 export const CODE_CELL_SAVE_DEBOUNCE_MS = 500;
 
-/** Default namespace auto-refresh interval (ms). */
-export const NAMESPACE_REFRESH_INTERVAL_MS = 2000;
+/**
+ * Opt-in namespace auto-refresh interval (ms). Refresh is primarily
+ * event-driven (execution-finish invalidates the namespace queries); this
+ * interval is a coarse catch-all for out-of-band kernel mutations, so it can
+ * be slow — each tick refetches the top-level query plus every expanded
+ * inspection, which matters once those are network round trips.
+ */
+export const NAMESPACE_REFRESH_INTERVAL_MS = 5000;
 
 /** Maximum recent projects to retain. */
 export const MAX_RECENT_PROJECTS = 10;
 
 /** Maximum console log entries before oldest are dropped. */
 export const MAX_LOG_ENTRIES = 2000;
+
+/**
+ * How many of the newest console entries keep their inline images. Base64
+ * plots are megabytes each; a long plotting session would otherwise retain
+ * gigabytes across 2000 entries. Older entries show an "image expired" note.
+ */
+export const MAX_IMAGE_LOG_ENTRIES = 200;
 
 /**
  * Fallback autosave interval (s) when no config value is present. Should

--- a/electron/renderer/src/app/index.tsx
+++ b/electron/renderer/src/app/index.tsx
@@ -43,13 +43,13 @@ import type {
   KernelExecutionOrigin,
   LogEntry,
   ScriptRunResult,
-  TreeChangeInfo,
   TreeNodeData,
   WindowChromeInfo,
 } from '../types';
+import { invalidateTree, invalidateNamespace, invalidateCompletions } from '../queries/invalidation';
 import { resolveShortcuts } from '../shortcuts';
-import { newExecutionId, normalizeLoadedCodeCells, normalizeRecentProjects, mergeConfigUpdate } from './app-utils';
-import { CELL_UNDO_LIMIT, MAX_LOG_ENTRIES, NAMESPACE_REFRESH_INTERVAL_MS } from './constants';
+import { appendLogEntry, newExecutionId, normalizeLoadedCodeCells, normalizeRecentProjects, mergeConfigUpdate } from './app-utils';
+import { CELL_UNDO_LIMIT, NAMESPACE_REFRESH_INTERVAL_MS } from './constants';
 import { useCodeCellsPersistence } from './useCodeCellsPersistence';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 import { useKernelLaunch } from './useKernelLaunch';
@@ -61,6 +61,7 @@ import { useKernelSubscriptions } from './useKernelSubscriptions';
 import { useWelcomeState } from './useWelcomeState';
 import { useThemeManager } from './useThemeManager';
 import { useTreeAction } from '../hooks/useTreeAction';
+import { useStore } from '../store';
 
 type KernelStatus = 'idle' | 'starting' | 'ready' | 'error';
 type CodeCellExecutionError = {
@@ -68,37 +69,6 @@ type CodeCellExecutionError = {
   message: string;
   location?: { line?: number; column?: number };
 };
-
-/**
- * The app-level modal currently open, or `null` for none. A discriminated
- * union instead of one boolean/target per dialog: only one modal can be up
- * at a time, so a single state slot makes "open X" implicitly close
- * everything else and lets Escape close whatever is active without a
- * priority chain.
- */
-type ActiveDialog =
-  | { kind: 'script'; node: TreeNodeData }
-  | { kind: 'rename'; path: string; nodeKey: string }
-  | { kind: 'move'; path: string; nodeType: string }
-  | { kind: 'duplicate'; path: string; nodeType: string }
-  | { kind: 'createNode'; parentPath: string }
-  | { kind: 'createScript'; parentPath: string }
-  | { kind: 'createNote'; parentPath: string }
-  | { kind: 'createGui'; parentPath: string }
-  | { kind: 'createLib'; parentPath: string }
-  | { kind: 'newModule' }
-  | {
-      kind: 'moduleMetadata';
-      alias: string;
-      name: string;
-      version: string;
-      description?: string;
-      language?: 'python' | 'julia';
-    }
-  | { kind: 'importModule' }
-  | { kind: 'saveAs' }
-  | { kind: 'newProject' }
-  | { kind: 'newJuliaProject' };
 
 
 /** Root PDV application component rendered in the Electron renderer process. */
@@ -126,7 +96,11 @@ const App: React.FC = () => {
   cellTabsRef.current = cellTabs;
   const activeCellTabRef = useRef(activeCellTab);
   activeCellTabRef.current = activeCellTab;
-  const [logs, setLogs] = useState<LogEntry[]>([]);
+  // Console logs live in the store so only the Console panel re-renders on
+  // streamed output. App subscribes to emptiness only (for the pristine
+  // check), never to the entries themselves.
+  const setLogs = useStore((s) => s.setLogs);
+  const logsEmpty = useStore((s) => s.logs.length === 0);
 
   // -- Kernel state ---------------------------------------------------------
   const [activeLanguage, setActiveLanguage] = useState<'python' | 'julia'>('python');
@@ -181,15 +155,13 @@ const App: React.FC = () => {
   /**
    * Refresh tokens — integer counters bumped to signal child components to re-fetch data.
    * Incrementing a token causes any useEffect that lists it as a dependency to re-run.
-   * This is the renderer's lightweight alternative to a pub/sub or state-management library.
+   * Tree state has moved to React Query (see `queries/`); these remaining
+   * tokens migrate there in later steps of the #233 refactor.
    */
   const [autoRefreshNamespace, setAutoRefreshNamespace] = useState(false);
-  const [namespaceRefreshToken, setNamespaceRefreshToken] = useState(0);
-  const [treeRefreshToken, setTreeRefreshToken] = useState(0);
-  const [pendingTreeChanges, setPendingTreeChanges] = useState<TreeChangeInfo[]>([]);
   const [modulesRefreshToken, setModulesRefreshToken] = useState(0);
 
-  const runTreeAction = useTreeAction({ setLastError, setTreeRefreshToken });
+  const runTreeAction = useTreeAction({ setLastError, kernelId: currentKernelId });
 
   // -- Welcome screen state ---------------------------------------------------
   // Visibility flags, recent projects, and recoverable orphaned sessions all
@@ -208,14 +180,15 @@ const App: React.FC = () => {
 
   // -- Dialog visibility state ----------------------------------------------
 
-  // One modal at a time: every app-level dialog is a variant of this union,
-  // so opening one implicitly closes the previous and Escape/close logic
-  // needs no priority chain. SettingsDialog stays outside (it suppresses
-  // Escape while recording shortcuts), as do the welcome overlay and the
-  // unsaved-changes confirm.
-  const [activeDialog, setActiveDialog] = useState<ActiveDialog | null>(null);
-  const closeDialog = useCallback(() => setActiveDialog(null), []);
-  const [showSettings, setShowSettings] = useState(false);
+  // Modal state lives in the store's dialog slice (one modal at a time via
+  // the ActiveDialog union; Escape priority in closeTopmost). Store actions
+  // are identity-stable, so they slot in where the old setters were used.
+  const activeDialog = useStore((s) => s.activeDialog);
+  const setActiveDialog = useStore((s) => s.setActiveDialog);
+  const closeDialog = useStore((s) => s.closeDialog);
+  const showSettings = useStore((s) => s.showSettings);
+  const setShowSettings = useStore((s) => s.setShowSettings);
+  const openSettings = useStore((s) => s.openSettings);
   const [currentProjectName, setCurrentProjectName] = useState<string | null>(null);
   const [chromeInfo, setChromeInfo] = useState<WindowChromeInfo | null>(null);
   const [menuModel, setMenuModel] = useState<AppMenuTopLevel[]>([]);
@@ -236,7 +209,7 @@ const App: React.FC = () => {
     handleNoteCloseTab,
     flushDirtyNotes,
   } = useNoteTabs({ currentKernelId, setLogs, setLastError });
-  const [settingsInitialTab, setSettingsInitialTab] = useState<'general' | 'shortcuts' | 'appearance' | 'runtime' | 'about'>('general');
+  const settingsInitialTab = useStore((s) => s.settingsInitialTab);
 
   // -- Project reloading state (kernel restart with active project) ----------
   const [projectReloading, setProjectReloading] = useState(false);
@@ -248,9 +221,8 @@ const App: React.FC = () => {
   // `guardDirty` helper, so a future PR can refine the heuristic by changing
   // only where/how `setProjectDirty` is called.
   const [projectDirty, setProjectDirty] = useState(false);
-  const [pendingDirtyAction, setPendingDirtyAction] = useState<
-    { label: string; run: () => void } | null
-  >(null);
+  const pendingDirtyAction = useStore((s) => s.pendingDirtyAction);
+  const setPendingDirtyAction = useStore((s) => s.setPendingDirtyAction);
 
   // -- Save/load progress state -----------------------------------------------
   const [progress, setProgress] = useState<import('../types/pdv').ProgressPayload | null>(null);
@@ -412,8 +384,7 @@ const App: React.FC = () => {
       } else if (payload.action === 'modules:newEmpty') {
         setActiveDialog({ kind: 'newModule' });
       } else if (payload.action === 'settings:open') {
-        setSettingsInitialTab('general');
-        setShowSettings(true);
+        openSettings('general');
       } else if (payload.action === 'project:new') {
         guardDirtyRef.current('start a new project', () => {
           // Reset renderer-side project state so the workspace behind the
@@ -514,31 +485,16 @@ const App: React.FC = () => {
     setPendingDirtyAction({ label, run: action });
   }, [projectDirty]);
 
-  const handleTreeChanged = useCallback((info: TreeChangeInfo) => {
-    setPendingTreeChanges((prev) => [...prev, info]);
-  }, []);
-
-  const handleTreeChangesConsumed = useCallback((consumed: TreeChangeInfo[]) => {
-    setPendingTreeChanges((prev) => {
-      // Drop only the consumed snapshot; a push that landed between render
-      // and the Tree's consume effect stays queued.
-      const consumedSet = new Set(consumed);
-      return prev.filter((c) => !consumedSet.has(c));
-    });
-  }, []);
-
   useKernelSubscriptions({
     currentKernelId,
     loadedProjectTabsRef,
     setCellTabs,
     setActiveCellTab,
     setLogs,
-    setTreeRefreshToken,
     setModulesRefreshToken,
     setProjectReloading,
     setProgress,
     onKernelCrash: handleKernelCrash,
-    onTreeChanged: handleTreeChanged,
     setKernelMemoryRss,
   });
 
@@ -551,8 +507,6 @@ const App: React.FC = () => {
     setLastError,
     setConfig,
     setLogs,
-    setNamespaceRefreshToken,
-    setTreeRefreshToken,
     setEnvironmentMode,
   });
 
@@ -647,7 +601,7 @@ const App: React.FC = () => {
   useEffect(() => {
     if (!activeDialog) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setActiveDialog(null);
+      if (e.key === 'Escape' && useStore.getState().closeTopmost()) e.preventDefault();
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
@@ -820,17 +774,14 @@ const App: React.FC = () => {
       duration: result.duration,
       images: result.images,
     };
-    setLogs((prev) => {
-      const next = [...prev, logEntry];
-      return next.length > MAX_LOG_ENTRIES ? next.slice(next.length - MAX_LOG_ENTRIES) : next;
-    });
+    setLogs((prev) => appendLogEntry(prev, logEntry));
     if (result.error) {
       setLastError(result.error);
     }
     if (typeof result.duration === 'number') {
       setLastDuration(result.duration);
     }
-    setNamespaceRefreshToken((prev) => prev + 1);
+    if (currentKernelId) invalidateNamespace(currentKernelId);
     setActiveDialog((prev) => (prev?.kind === 'script' ? null : prev));
   };
 
@@ -863,13 +814,7 @@ const App: React.FC = () => {
     };
 
     // Create the log entry immediately so output appears as it streams in.
-    setLogs((prev) => {
-      const next = [
-        ...prev,
-        { id: executionId, timestamp: Date.now(), code, origin },
-      ];
-      return next.length > MAX_LOG_ENTRIES ? next.slice(next.length - MAX_LOG_ENTRIES) : next;
-    });
+    setLogs((prev) => appendLogEntry(prev, { id: executionId, timestamp: Date.now(), code, origin }));
 
     try {
       const result = await window.pdv.kernels.execute(currentKernelId, {
@@ -919,13 +864,16 @@ const App: React.FC = () => {
       setCodeCellExecutionError(undefined);
     } finally {
       setIsExecuting(false);
-      setNamespaceRefreshToken((prev) => prev + 1);
+      invalidateNamespace(currentKernelId);
+      // Execution can define/rebind anything: cached Monaco completions and
+      // hovers are stale now.
+      invalidateCompletions(currentKernelId);
       // Defense in depth: a script that mutates a sub-PDVTree directly
       // (e.g. `pdv_tree['big']['x'] = ...`) doesn't fire `pdv.tree.changed`
-      // because sub-trees don't carry _send_fn. Refetching the tree after
-      // execution catches those silent mutations even before that's fixed
-      // properly upstream, and is cheap (a single tree.list query).
-      setTreeRefreshToken((prev) => prev + 1);
+      // because sub-trees don't carry _send_fn. Invalidating after execution
+      // catches those silent mutations; visible listings refetch in
+      // parallel, unexpanded ones lazily on expansion.
+      invalidateTree(currentKernelId);
     }
   }, [currentKernelId, kernelStatus]);
 
@@ -1096,7 +1044,7 @@ const App: React.FC = () => {
   // Whether the session has no user work (no project, no code, no logs, no notes).
   const isPristine = currentProjectDir === null
     && cellTabs.every((t) => !t.code.trim())
-    && logs.length === 0
+    && logsEmpty
     && noteTabs.length === 0;
 
   const {
@@ -1113,7 +1061,7 @@ const App: React.FC = () => {
     setCellTabs,
     setActiveCellTab,
     setModulesRefreshToken,
-    setNamespaceRefreshToken,
+    currentKernelId,
     setProgress,
     setLastError,
     setLogs,
@@ -1154,8 +1102,7 @@ const App: React.FC = () => {
    */
   const openEnvSettings = useCallback((warning?: string) => {
     if (warning) setInterpreterWarning(warning);
-    setSettingsInitialTab('runtime');
-    setShowSettings(true);
+    openSettings('runtime');
   }, []);
 
   // --- session launch overlay ---------------------------------------------
@@ -1373,7 +1320,7 @@ const App: React.FC = () => {
       setCurrentProjectDir(null);
       setCurrentProjectName(null);
       setModulesRefreshToken((prev) => prev + 1);
-      setNamespaceRefreshToken((prev) => prev + 1);
+      if (currentKernelId) invalidateNamespace(currentKernelId);
 
       const missingWarn = result.missingFiles?.length
         ? `\nWarning: ${result.missingFiles.length} file(s) could not be copied:\n  ${result.missingFiles.join('\n  ')}`
@@ -1396,7 +1343,7 @@ const App: React.FC = () => {
     setCurrentProjectDir,
     setCurrentProjectName,
     setModulesRefreshToken,
-    setNamespaceRefreshToken,
+    currentKernelId,
     setLogs,
     setLastError,
     refreshRecoverableSessions,
@@ -1531,7 +1478,7 @@ const App: React.FC = () => {
           leftSidebarOpen={leftSidebarOpen}
           leftPanel={leftPanel}
           onActivityBarClick={handleActivityBarClick}
-          onSettingsClick={() => { setSettingsInitialTab('general'); setShowSettings(true); }}
+          onSettingsClick={() => openSettings('general')}
           onAgentClick={handleOpenAgent}
           onOpenWorkingDir={handleOpenWorkingDir}
           guiModules={importedGuiModules}
@@ -1557,13 +1504,9 @@ const App: React.FC = () => {
                   <Tree
                     kernelId={currentKernelId}
                     disabled={kernelStatus !== 'ready'}
-                    refreshToken={treeRefreshToken}
-                    pendingChanges={pendingTreeChanges}
-                    onChangesConsumed={handleTreeChangesConsumed}
                     onAction={handleTreeAction}
                     shortcuts={shortcuts}
                     projectKey={currentProjectDir}
-
                   />
                 )}
                 {leftPanel === 'namespace' && (
@@ -1571,7 +1514,6 @@ const App: React.FC = () => {
                     kernelId={currentKernelId}
                     disabled={kernelStatus !== 'ready'}
                     autoRefresh={autoRefreshNamespace}
-                    refreshToken={namespaceRefreshToken}
                     refreshInterval={NAMESPACE_REFRESH_INTERVAL_MS}
                     onToggleAutoRefresh={(next) => {
                       setAutoRefreshNamespace(next);
@@ -1613,7 +1555,6 @@ const App: React.FC = () => {
             <>
               <div className="console-wrapper">
                 <Console
-                  logs={logs}
                   onClear={handleClearConsole}
                   // Reactive install works where an in-kernel installer exists:
                   // uv-mode Python projects (pdv.install → uv add) and every
@@ -1759,7 +1700,7 @@ const App: React.FC = () => {
               if (!result.success) {
                 setLastError(result.error);
               } else if (result.treePath) {
-                setTreeRefreshToken((t) => t + 1);
+                if (currentKernelId) invalidateTree(currentKernelId);
                 await window.pdv.script.edit(currentKernelId, result.treePath);
               }
             } catch (error) {
@@ -1782,7 +1723,7 @@ const App: React.FC = () => {
               if (!result.success) {
                 setLastError(result.error);
               } else if (result.treePath) {
-                setTreeRefreshToken((t) => t + 1);
+                if (currentKernelId) invalidateTree(currentKernelId);
                 const noteNode: TreeNodeData = {
                   id: result.treePath,
                   key: name,
@@ -1814,7 +1755,7 @@ const App: React.FC = () => {
               if (!result.success) {
                 setLastError(result.error);
               } else if (result.treePath) {
-                setTreeRefreshToken((t) => t + 1);
+                if (currentKernelId) invalidateTree(currentKernelId);
                 void window.pdv.guiEditor.open({ treePath: result.treePath, kernelId: currentKernelId });
               }
             } catch (error) {
@@ -1838,7 +1779,7 @@ const App: React.FC = () => {
               if (!result.success) {
                 setLastError(result.error);
               } else if (result.treePath) {
-                setTreeRefreshToken((t) => t + 1);
+                if (currentKernelId) invalidateTree(currentKernelId);
                 await window.pdv.script.edit(currentKernelId, result.treePath);
               }
             } catch (error) {
@@ -1856,7 +1797,7 @@ const App: React.FC = () => {
         onCancel={closeDialog}
         onCreated={() => {
           closeDialog();
-          setTreeRefreshToken((t) => t + 1);
+          if (currentKernelId) invalidateTree(currentKernelId);
         }}
       />
 
@@ -1873,7 +1814,7 @@ const App: React.FC = () => {
           onCancel={closeDialog}
           onSaved={() => {
             closeDialog();
-            setTreeRefreshToken((t) => t + 1);
+            if (currentKernelId) invalidateTree(currentKernelId);
           }}
         />
       )}
@@ -1890,7 +1831,7 @@ const App: React.FC = () => {
           kernelStatus={kernelStatus}
           lastDuration={lastDuration}
           progress={progress}
-          onRuntimeClick={() => { setSettingsInitialTab('runtime'); setShowSettings(true); }}
+          onRuntimeClick={() => openSettings('runtime')}
           onRestartSession={handleRestartKernel}
           canRestart={currentKernelId !== null}
           lastChecksum={lastChecksum}
@@ -1900,7 +1841,7 @@ const App: React.FC = () => {
           lastAutosaveAt={lastAutosaveAt}
           kernelMemoryRss={kernelMemoryRss}
           updateStatus={updateStatus}
-          onUpdateClick={() => { setSettingsInitialTab('about'); setShowSettings(true); }}
+          onUpdateClick={() => openSettings('about')}
           mcpClientAttached={mcpClientAttached}
         />
 

--- a/electron/renderer/src/app/useKernelLifecycle.test.ts
+++ b/electron/renderer/src/app/useKernelLifecycle.test.ts
@@ -6,7 +6,7 @@
  * Covers: startKernel happy path with state transitions, error path,
  * concurrent-call queuing (only the latest queued call resolves true),
  * handleEnvSave config-then-start chain, handleRestartKernel clearing logs
- * and bumping refresh tokens.
+ * and dropping kernel-scoped query caches.
  */
 
 import { act } from "@testing-library/react";
@@ -15,6 +15,11 @@ import { renderHookWithPdv } from "../test-fixtures/hook-helpers";
 import type { Config, KernelInfo } from "../types/pdv";
 import type { LogEntry } from "../types";
 import { useKernelLifecycle } from "./useKernelLifecycle";
+import { invalidateAllKernelState } from "../queries/invalidation";
+
+vi.mock("../queries/invalidation", () => ({
+  invalidateAllKernelState: vi.fn(),
+}));
 
 type KernelStatus = "idle" | "starting" | "ready" | "error";
 
@@ -24,8 +29,6 @@ interface State {
   lastError: string | undefined;
   config: Config | null;
   logs: LogEntry[];
-  namespaceRefreshToken: number;
-  treeRefreshToken: number;
 }
 
 interface Setters {
@@ -34,8 +37,6 @@ interface Setters {
   setLastError: (v: string | undefined | ((prev: string | undefined) => string | undefined)) => void;
   setConfig: (v: Config | null | ((prev: Config | null) => Config | null)) => void;
   setLogs: (v: LogEntry[] | ((prev: LogEntry[]) => LogEntry[])) => void;
-  setNamespaceRefreshToken: (v: number | ((prev: number) => number)) => void;
-  setTreeRefreshToken: (v: number | ((prev: number) => number)) => void;
   setEnvironmentMode: (v: 'uv' | 'shared' | 'pkg' | ((prev: 'uv' | 'shared' | 'pkg') => 'uv' | 'shared' | 'pkg')) => void;
 }
 
@@ -46,8 +47,6 @@ function createState(): { state: State; setters: Setters } {
     lastError: undefined,
     config: { pythonPath: "/usr/bin/python3" } as Config,
     logs: [],
-    namespaceRefreshToken: 0,
-    treeRefreshToken: 0,
   };
   const apply = <K extends keyof State>(key: K, v: State[K] | ((prev: State[K]) => State[K])): void => {
     state[key] = typeof v === "function" ? (v as (prev: State[K]) => State[K])(state[key]) : v;
@@ -58,8 +57,6 @@ function createState(): { state: State; setters: Setters } {
     setLastError: (v) => apply("lastError", v as never),
     setConfig: (v) => apply("config", v as never),
     setLogs: (v) => apply("logs", v as never),
-    setNamespaceRefreshToken: (v) => apply("namespaceRefreshToken", v as never),
-    setTreeRefreshToken: (v) => apply("treeRefreshToken", v as never),
     setEnvironmentMode: () => {},
   };
   return { state, setters };
@@ -74,7 +71,7 @@ afterEach(() => {
 });
 
 describe("useKernelLifecycle.startKernel", () => {
-  it("happy path: status idle → starting → ready, sets kernel id, bumps tokens", async () => {
+  it("happy path: status idle → starting → ready, sets kernel id, clears kernel cache", async () => {
     const { state, setters } = createState();
     const kernelInfo: KernelInfo = {
       id: "k1",
@@ -107,8 +104,8 @@ describe("useKernelLifecycle.startKernel", () => {
     expect(state.currentKernelId).toBe("k1");
     expect(state.kernelStatus).toBe("ready");
     expect(state.lastError).toBeUndefined();
-    expect(state.namespaceRefreshToken).toBe(1);
-    expect(state.treeRefreshToken).toBe(1);
+    // Fresh kernel id — cache cleared for it in case the id was reused.
+    expect(invalidateAllKernelState).toHaveBeenCalledWith("k1", "kernel-switch");
   });
 
   it("failure path: sets status error and lastError, leaves currentKernelId null", async () => {
@@ -259,7 +256,7 @@ describe("useKernelLifecycle.handleEnvSave", () => {
 });
 
 describe("useKernelLifecycle.handleRestartKernel", () => {
-  it("calls pdv.kernels.restart, seeds a restored-state log entry, bumps both refresh tokens", async () => {
+  it("calls pdv.kernels.restart, seeds a restored-state log entry, purges kernel caches", async () => {
     const { state, setters } = createState();
     state.currentKernelId = "k1";
     state.logs = [{ executionId: "e1", chunks: [] } as never];
@@ -296,8 +293,9 @@ describe("useKernelLifecycle.handleRestartKernel", () => {
     // came back (restored vs fresh).
     expect(state.logs).toHaveLength(1);
     expect((state.logs[0] as { stdout?: string }).stdout).toMatch(/restored from the last autosave/i);
-    expect(state.namespaceRefreshToken).toBe(1);
-    expect(state.treeRefreshToken).toBe(1);
+    // Both the pre-restart and post-restart kernel ids are purged.
+    expect(invalidateAllKernelState).toHaveBeenCalledWith("k1", "kernel-switch");
+    expect(invalidateAllKernelState).toHaveBeenCalledWith("k2", "kernel-switch");
   });
 
   it("reports a fresh session when nothing was restored", async () => {

--- a/electron/renderer/src/app/useKernelLifecycle.ts
+++ b/electron/renderer/src/app/useKernelLifecycle.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, type Dispatch, type SetStateAction } from 'react';
 import type { Config, LogEntry } from '../types';
+import { invalidateAllKernelState } from '../queries/invalidation';
 
 type KernelStatus = 'idle' | 'starting' | 'ready' | 'error';
 
@@ -19,10 +20,6 @@ interface UseKernelLifecycleOptions {
   setConfig: Dispatch<SetStateAction<Config | null>>;
   /** Clears the console log entries on kernel restart. */
   setLogs: Dispatch<SetStateAction<LogEntry[]>>;
-  /** Bumps the token to trigger a NamespaceView refetch. */
-  setNamespaceRefreshToken: Dispatch<SetStateAction<number>>;
-  /** Bumps the token to trigger a Tree panel refetch. */
-  setTreeRefreshToken: Dispatch<SetStateAction<number>>;
   /** Setter for the active environment mode ("uv" project venv vs shared). */
   setEnvironmentMode: Dispatch<SetStateAction<'uv' | 'shared' | 'pkg'>>;
 }
@@ -36,8 +33,6 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
     setLastError,
     setConfig,
     setLogs,
-    setNamespaceRefreshToken,
-    setTreeRefreshToken,
     setEnvironmentMode,
   } = options;
 
@@ -59,6 +54,10 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
     try {
       if (currentKernelId) {
         await window.pdv.kernels.stop(currentKernelId);
+        // Drop the dead kernel's cached queries outright — no refetch storm
+        // for a kernel that no longer exists. The new kernel's queries start
+        // cold and fetch on mount.
+        invalidateAllKernelState(currentKernelId, 'kernel-switch');
       }
 
       let spec: import('../types').KernelSpec;
@@ -81,8 +80,8 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
       // launches; its presence is the authoritative signal that this kernel
       // runs in a project env — uv for Python (§10.5), pkg for Julia (§10.6).
       setEnvironmentMode(uvContext ? (language === 'julia' ? 'pkg' : 'uv') : 'shared');
-      setTreeRefreshToken((prev) => prev + 1);
-      setNamespaceRefreshToken((prev) => prev + 1);
+      // In case the kernel id was reused, make sure nothing stale survives.
+      invalidateAllKernelState(kernel.id, 'kernel-switch');
       setKernelStatus('ready');
       return true;
     } catch (error) {
@@ -99,8 +98,6 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
     setCurrentKernelId,
     setKernelStatus,
     setLastError,
-    setNamespaceRefreshToken,
-    setTreeRefreshToken,
     setEnvironmentMode,
   ]);
 
@@ -177,8 +174,10 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
           ? 'Session restarted — restored from the last autosave.'
           : 'Session restarted — no autosave found; starting fresh.',
       }]);
-      setNamespaceRefreshToken((prev) => prev + 1);
-      setTreeRefreshToken((prev) => prev + 1);
+      // The restarted kernel starts from autosave (or fresh): every cached
+      // listing is suspect. Remove the old and (possibly reused) new ids.
+      invalidateAllKernelState(currentKernelId, 'kernel-switch');
+      invalidateAllKernelState(kernel.id, 'kernel-switch');
     } catch (error) {
       console.error('[App] Failed to restart kernel:', error);
       setKernelStatus('error');
@@ -190,8 +189,6 @@ export function useKernelLifecycle(options: UseKernelLifecycleOptions) {
     setKernelStatus,
     setLastError,
     setLogs,
-    setNamespaceRefreshToken,
-    setTreeRefreshToken,
   ]);
 
   return {

--- a/electron/renderer/src/app/useKernelSubscriptions.test.ts
+++ b/electron/renderer/src/app/useKernelSubscriptions.test.ts
@@ -14,29 +14,40 @@ import { renderHookWithPdv } from "../test-fixtures/hook-helpers";
 import type { LogEntry } from "../types";
 import type { ExecuteOutputChunk } from "../types/pdv";
 import { useKernelSubscriptions } from "./useKernelSubscriptions";
+import { applyTreeChange, invalidateTree } from "../queries/invalidation";
+
+vi.mock("../queries/invalidation", () => ({
+  applyTreeChange: vi.fn(),
+  invalidateTree: vi.fn(),
+}));
+
+type TreeChangedPayload = {
+  changed_paths: string[];
+  change_type: "added" | "removed" | "updated" | "batch" | "unknown";
+};
 
 type LogsUpdate = LogEntry[] | ((prev: LogEntry[]) => LogEntry[]);
 
-function renderSubscriptions(initialLogs: LogEntry[]) {
+function renderSubscriptions(initialLogs: LogEntry[], kernelId: string | null = null) {
   let logs = initialLogs;
   const setLogs = vi.fn((update: LogsUpdate) => {
     logs = typeof update === "function" ? update(logs) : update;
   });
+  const setModulesRefreshToken = vi.fn();
   let outputCallback: ((chunk: ExecuteOutputChunk) => void) | undefined;
+  let treeChangedCallback: ((payload: TreeChangedPayload) => void) | undefined;
   const rendered = renderHookWithPdv(
     () =>
       useKernelSubscriptions({
-        currentKernelId: null,
+        currentKernelId: kernelId,
         loadedProjectTabsRef: { current: null },
         setCellTabs: vi.fn(),
         setActiveCellTab: vi.fn(),
         setLogs,
-        setTreeRefreshToken: vi.fn(),
-        setModulesRefreshToken: vi.fn(),
+        setModulesRefreshToken,
         setProjectReloading: vi.fn(),
         setProgress: vi.fn(),
         onKernelCrash: vi.fn(),
-        onTreeChanged: vi.fn(),
         setKernelMemoryRss: vi.fn(),
       }),
     {
@@ -47,18 +58,27 @@ function renderSubscriptions(initialLogs: LogEntry[]) {
             return () => {};
           }),
         },
+        tree: {
+          onChanged: vi.fn((cb: (payload: TreeChangedPayload) => void) => {
+            treeChangedCallback = cb;
+            return () => {};
+          }),
+        },
       },
     },
   );
   return {
     ...rendered,
     setLogs,
+    setModulesRefreshToken,
     getLogs: () => logs,
     emitChunk: (chunk: ExecuteOutputChunk) => outputCallback?.(chunk),
+    emitTreeChange: (payload: TreeChangedPayload) => treeChangedCallback?.(payload),
   };
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   vi.useFakeTimers();
 });
 
@@ -129,5 +149,72 @@ describe("useKernelSubscriptions output coalescing", () => {
     expect(getLogs()).toEqual([
       { ...seedEntry, images: [{ mime: "image/png", data: "AAA" }], result: 42 },
     ]);
+  });
+});
+
+describe("useKernelSubscriptions tree-change mapping", () => {
+  it("routes every tree.onChanged payload through applyTreeChange for the active kernel", () => {
+    const { emitTreeChange, setModulesRefreshToken } = renderSubscriptions([], "k1");
+
+    const payload: TreeChangedPayload = { changed_paths: ["a.b"], change_type: "updated" };
+    act(() => {
+      emitTreeChange(payload);
+    });
+
+    expect(applyTreeChange).toHaveBeenCalledTimes(1);
+    expect(applyTreeChange).toHaveBeenCalledWith("k1", payload);
+    expect(setModulesRefreshToken).toHaveBeenCalled();
+  });
+
+  it("removes top-level module imports when their root node is removed", () => {
+    const removeImport = vi.fn(async () => ({ success: true }));
+    const rendered = renderHookWithPdv(
+      () =>
+        useKernelSubscriptions({
+          currentKernelId: "k1",
+          loadedProjectTabsRef: { current: null },
+          setCellTabs: vi.fn(),
+          setActiveCellTab: vi.fn(),
+          setLogs: vi.fn(),
+          setModulesRefreshToken: vi.fn(),
+          setProjectReloading: vi.fn(),
+          setProgress: vi.fn(),
+          onKernelCrash: vi.fn(),
+          setKernelMemoryRss: vi.fn(),
+        }),
+      {
+        pdvOverrides: {
+          tree: {
+            onChanged: vi.fn((cb: (payload: TreeChangedPayload) => void) => {
+              queueMicrotask(() =>
+                cb({ changed_paths: ["mymodule", "keep.child"], change_type: "removed" }),
+              );
+              return () => {};
+            }),
+          },
+          modules: { removeImport },
+        },
+      },
+    );
+
+    return act(async () => {
+      await Promise.resolve();
+      expect(applyTreeChange).toHaveBeenCalledWith("k1", {
+        changed_paths: ["mymodule", "keep.child"],
+        change_type: "removed",
+      });
+      expect(removeImport).toHaveBeenCalledTimes(1);
+      expect(removeImport).toHaveBeenCalledWith("mymodule");
+      rendered.unmount();
+    });
+  });
+
+  it("does not subscribe to tree changes without a kernel", () => {
+    const { emitTreeChange } = renderSubscriptions([], null);
+    act(() => {
+      emitTreeChange({ changed_paths: ["a"], change_type: "added" });
+    });
+    expect(applyTreeChange).not.toHaveBeenCalled();
+    expect(invalidateTree).not.toHaveBeenCalled();
   });
 });

--- a/electron/renderer/src/app/useKernelSubscriptions.ts
+++ b/electron/renderer/src/app/useKernelSubscriptions.ts
@@ -1,7 +1,13 @@
 import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
-import type { CellTab, LogEntry, TreeChangeInfo } from '../types';
+import type { CellTab, LogEntry } from '../types';
 import type { ExecuteOutputChunk, ProgressPayload } from '../types/pdv';
-import { MAX_LOG_ENTRIES } from './constants';
+import { appendLogEntry } from './app-utils';
+import {
+  applyTreeChange,
+  invalidateCompletions,
+  invalidateNamespace,
+  invalidateTree,
+} from '../queries/invalidation';
 
 /**
  * How long buffered output chunks may sit before being applied to the log
@@ -39,8 +45,6 @@ interface UseKernelSubscriptionsOptions {
   setActiveCellTab: Dispatch<SetStateAction<number>>;
   /** Appends streamed execution output (stdout, stderr, images) to console logs. */
   setLogs: Dispatch<SetStateAction<LogEntry[]>>;
-  /** Bumps the token to trigger Tree panel full refetch (project load, reload, etc.). */
-  setTreeRefreshToken: Dispatch<SetStateAction<number>>;
   /** Bumps the token to trigger ModulesPanel refetch on tree changes. */
   setModulesRefreshToken: Dispatch<SetStateAction<number>>;
   /** Controls the project-reloading overlay shown during kernel restart with active project. */
@@ -49,8 +53,6 @@ interface UseKernelSubscriptionsOptions {
   setProgress: Dispatch<SetStateAction<ProgressPayload | null>>;
   /** Called when a kernel crash is detected via the push channel. */
   onKernelCrash: (kernelId: string) => void;
-  /** Called on incremental tree changes so the Tree can update selectively. */
-  onTreeChanged: (info: TreeChangeInfo) => void;
   /** Setter for the latest kernel-process RSS in bytes (null when unknown). */
   setKernelMemoryRss: Dispatch<SetStateAction<number | null>>;
 }
@@ -61,12 +63,10 @@ export function useKernelSubscriptions({
   setCellTabs,
   setActiveCellTab,
   setLogs,
-  setTreeRefreshToken,
   setModulesRefreshToken,
   setProjectReloading,
   setProgress,
   onKernelCrash,
-  onTreeChanged,
   setKernelMemoryRss,
 }: UseKernelSubscriptionsOptions): void {
   useEffect(() => {
@@ -107,18 +107,12 @@ export function useKernelSubscriptions({
     const offBegin = window.pdv.kernels.onExecuteBegin((payload) => {
       setLogs((prev) => {
         if (prev.some((l) => l.id === payload.executionId)) return prev;
-        const next: LogEntry[] = [
-          ...prev,
-          {
-            id: payload.executionId,
-            timestamp: payload.timestamp,
-            code: payload.code,
-            origin: payload.origin,
-          },
-        ];
-        return next.length > MAX_LOG_ENTRIES
-          ? next.slice(next.length - MAX_LOG_ENTRIES)
-          : next;
+        return appendLogEntry(prev, {
+          id: payload.executionId,
+          timestamp: payload.timestamp,
+          code: payload.code,
+          origin: payload.origin,
+        });
       });
     });
     const offFinish = window.pdv.kernels.onExecuteFinish((payload) => {
@@ -134,12 +128,20 @@ export function useKernelSubscriptions({
             : l,
         ),
       );
+      // Agent-driven runs mutate kernel state just like renderer runs do,
+      // but never pass through executeImmediate's finally block — refresh
+      // the same caches here.
+      if (currentKernelId) {
+        invalidateTree(currentKernelId);
+        invalidateNamespace(currentKernelId);
+        invalidateCompletions(currentKernelId);
+      }
     });
     return () => {
       offBegin();
       offFinish();
     };
-  }, [setLogs]);
+  }, [setLogs, currentKernelId]);
 
   useEffect(() => {
     if (!currentKernelId) {
@@ -147,17 +149,12 @@ export function useKernelSubscriptions({
     }
 
     const unsubscribeTree = window.pdv.tree.onChanged((payload) => {
-      // "unknown" comes from non-root PDVTree mutations (intermediate
-      // sub-trees, scratch trees) where the local path can't be mapped to
-      // the renderer's absolute view. Trigger a full refresh-with-expansion
-      // instead of trying to reconcile changed_paths.
-      if (payload.change_type === "unknown") {
-        setTreeRefreshToken((prev) => prev + 1);
-        setModulesRefreshToken((prev) => prev + 1);
-        return;
-      }
-      // Notify Tree for selective (incremental) update instead of a full reload.
-      onTreeChanged({
+      // Targeted cache surgery: removals patch the parent listing in place
+      // (0 round trips); adds/updates invalidate only the changed parents;
+      // "unknown" (non-root PDVTree mutations whose local path can't be
+      // mapped to the renderer's absolute view) invalidates every listing,
+      // refetching visible levels in parallel.
+      applyTreeChange(currentKernelId, {
         changed_paths: payload.changed_paths,
         change_type: payload.change_type,
       });
@@ -180,7 +177,7 @@ export function useKernelSubscriptions({
         setCellTabs(loaded.tabs);
         setActiveCellTab(loaded.activeTabId);
       }
-      setTreeRefreshToken((prev) => prev + 1);
+      invalidateTree(currentKernelId);
     });
 
     const unsubscribeKernelCrashed = window.pdv.kernels.onKernelCrashed((payload) => {
@@ -201,13 +198,13 @@ export function useKernelSubscriptions({
         setProjectReloading(true);
       } else if (payload.status === 'ready') {
         setProjectReloading(false);
-        setTreeRefreshToken((prev) => prev + 1);
+        invalidateTree(currentKernelId);
         setModulesRefreshToken((prev) => prev + 1);
       }
     });
 
     const unsubscribeReconnected = window.pdv.kernels.onReconnected(() => {
-      setTreeRefreshToken((prev) => prev + 1);
+      invalidateTree(currentKernelId);
       setModulesRefreshToken((prev) => prev + 1);
     });
 
@@ -236,8 +233,6 @@ export function useKernelSubscriptions({
     setModulesRefreshToken,
     setProgress,
     setProjectReloading,
-    setTreeRefreshToken,
-    onTreeChanged,
     setKernelMemoryRss,
   ]);
 }

--- a/electron/renderer/src/app/useProjectWorkflow.test.ts
+++ b/electron/renderer/src/app/useProjectWorkflow.test.ts
@@ -34,7 +34,6 @@ interface State {
   config: Config | null;
   logs: LogEntry[];
   modulesRefreshToken: number;
-  namespaceRefreshToken: number;
   progress: ProgressPayload | null;
   lastError: string | undefined;
   lastChecksum: string | null;
@@ -57,7 +56,6 @@ function createState(overrides: Partial<State> = {}): {
     config: { recentProjects: [] } as Config,
     logs: [],
     modulesRefreshToken: 0,
-    namespaceRefreshToken: 0,
     progress: null,
     lastError: undefined,
     lastChecksum: null,
@@ -88,7 +86,7 @@ function createState(overrides: Partial<State> = {}): {
     setCellTabs: ((v: unknown) => apply("cellTabs", v as never)) as never,
     setActiveCellTab: ((v: unknown) => apply("activeCellTab", v as never)) as never,
     setModulesRefreshToken: ((v: unknown) => apply("modulesRefreshToken", v as never)) as never,
-    setNamespaceRefreshToken: ((v: unknown) => apply("namespaceRefreshToken", v as never)) as never,
+    currentKernelId: "k1",
     setProgress: ((v: unknown) => apply("progress", v as never)) as never,
     setLastError: ((v: unknown) => apply("lastError", v as never)) as never,
     setLogs: ((v: unknown) => apply("logs", v as never)) as never,

--- a/electron/renderer/src/app/useProjectWorkflow.ts
+++ b/electron/renderer/src/app/useProjectWorkflow.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
+import { invalidateNamespace } from '../queries/invalidation';
 import type { CellTab, Config, LogEntry, MenuActionPayload } from '../types';
 import type { ProgressPayload } from '../types/pdv';
 import { normalizeRecentProjects } from './app-utils';
@@ -26,8 +27,8 @@ interface UseProjectWorkflowOptions {
   setActiveCellTab: Dispatch<SetStateAction<number>>;
   /** Bumps to trigger ModulesPanel refetch after project load. */
   setModulesRefreshToken: Dispatch<SetStateAction<number>>;
-  /** Bumps to trigger NamespaceView refetch after project load. */
-  setNamespaceRefreshToken: Dispatch<SetStateAction<number>>;
+  /** Active kernel id — used to invalidate namespace queries after load. */
+  currentKernelId: string | null;
   /** Clears or updates save/load progress state. */
   setProgress: Dispatch<SetStateAction<ProgressPayload | null>>;
   /** Sets error message if save/load fails. */
@@ -64,7 +65,7 @@ export function useProjectWorkflow(options: UseProjectWorkflowOptions) {
     setCellTabs,
     setActiveCellTab,
     setModulesRefreshToken,
-    setNamespaceRefreshToken,
+    currentKernelId,
     setProgress,
     setLastError,
     setLogs,
@@ -223,7 +224,7 @@ export function useProjectWorkflow(options: UseProjectWorkflowOptions) {
       setCurrentProjectName(result.projectName ?? null);
       setModulesRefreshToken((prev) => prev + 1);
       await rememberRecentProject(saveDir);
-      setNamespaceRefreshToken((prev) => prev + 1);
+      if (currentKernelId) invalidateNamespace(currentKernelId);
       setLastChecksum(result.checksum ? result.checksum.slice(0, 6) : null);
       setChecksumMismatch(result.checksumValid === false);
       setSavedPdvVersion(result.savedPdvVersion ?? null);
@@ -324,7 +325,7 @@ export function useProjectWorkflow(options: UseProjectWorkflowOptions) {
     setLastError,
     setLogs,
     setModulesRefreshToken,
-    setNamespaceRefreshToken,
+    currentKernelId,
   ]);
 
   useEffect(() => {

--- a/electron/renderer/src/components/CodeCell/CodeCell.test.tsx
+++ b/electron/renderer/src/components/CodeCell/CodeCell.test.tsx
@@ -169,11 +169,21 @@ describe('CodeCell completion provider', () => {
       { lineNumber: 1, column: 8 }
     );
 
-    expect(complete).toHaveBeenCalledWith('kernel-1', 'os.path.', 7);
+    // The request is issued at the START of the current word ('path' → 3),
+    // so the kernel returns all candidates for the context and Monaco
+    // filters the typed prefix client-side.
+    expect(complete).toHaveBeenCalledWith('kernel-1', 'os.path.', 3);
     expect(result.suggestions.map((s) => s.label)).toEqual(['join', 'exists']);
     expect(result.suggestions[0].insertText).toBe('join');
     expect(result.suggestions[0].kind).toBe(1);
     expect(result.suggestions[1].kind).toBe(7);
+
+    // A repeat trigger for the same word context is a cache hit.
+    await completionProvider!.provideCompletionItems(
+      makeModel('os.path.'),
+      { lineNumber: 1, column: 8 }
+    );
+    expect(complete).toHaveBeenCalledTimes(1);
   });
 
   it('adds pdv_tree fallback for pdv* prefix completions', async () => {

--- a/electron/renderer/src/components/CodeCell/monaco-providers.ts
+++ b/electron/renderer/src/components/CodeCell/monaco-providers.ts
@@ -8,11 +8,25 @@
  *
  * Providers are registered globally (Monaco providers are page-singletons)
  * but read current kernel/tab state through refs passed at registration time.
+ *
+ * Round-trip discipline: every kernel call here happens while the user
+ * types, so results are cached through React Query — tree-path completions
+ * share the Tree panel's cache (a level already visible in the Tree costs 0
+ * round trips), kernel completions are keyed on the code up to the current
+ * word (so typing within a word never re-queries), and hovers are keyed on
+ * code+position with a short delay so drive-by mouse movement fires nothing.
+ * Execution-finish invalidates the completion/hover caches (namespace
+ * changed → candidates changed) via `queries/invalidation.ts`.
  */
 
 import type * as monaco from 'monaco-editor';
 import type React from 'react';
-import { treeService } from '../../services/tree';
+import { queryClient, STALE_TIMES } from '../../queries/client';
+import { keys, stableHash } from '../../queries/keys';
+import { fetchTreeChildren } from '../../queries/tree';
+
+/** How long the mouse must rest before a hover inspect request fires. */
+const HOVER_DELAY_MS = 200;
 
 // Registration guards — Monaco providers are page-level singletons.
 let completionProviderRegistered = false;
@@ -87,7 +101,9 @@ async function getTreePathSuggestions(
   const keyPrefix = typedParts[typedParts.length - 1] ?? '';
   const parentSegments = [...context.ancestorSegments, ...extraParentSegments];
   const parentPath = parentSegments.join('.');
-  const nodes = await treeService.listByPath(kernelId, parentPath);
+  // Shares the Tree panel's query cache: a level the Tree already shows (or
+  // that was completed moments ago) resolves without a kernel round trip.
+  const nodes = await fetchTreeChildren(kernelId, parentPath, STALE_TIMES.treeCompletion);
   return nodes
     .filter((node) => node.key.startsWith(keyPrefix))
     .map((node) => ({
@@ -188,10 +204,24 @@ export function registerKernelCompletionProvider(
       try {
         const prefix = buildContextPrefix();
         const prefixedCode = prefix + code;
-        const prefixedOffset = prefix.length + offset;
-        const result = await window.pdv.kernels.complete(kernelId, prefixedCode, prefixedOffset);
         const textBeforeCursor = code.slice(0, offset);
         const namePrefix = textBeforeCursor.match(/[A-Za-z_][A-Za-z0-9_]*$/)?.[0] ?? '';
+        // Complete at the START of the current word, not the cursor: the
+        // kernel then returns every candidate for the context, Monaco
+        // filters them client-side as the user types, and the cache key is
+        // stable for the whole word — one round trip per context instead of
+        // one per keystroke.
+        const wordStartOffset = offset - namePrefix.length;
+        const prefixedWordStart = prefix.length + wordStartOffset;
+        const result = await queryClient.fetchQuery({
+          queryKey: keys.completion(
+            kernelId,
+            stableHash(prefixedCode.slice(0, prefixedWordStart)),
+          ),
+          queryFn: () =>
+            window.pdv.kernels.complete(kernelId, prefixedCode, prefixedWordStart),
+          staleTime: STALE_TIMES.complete,
+        });
         const mergedMatches = [...result.matches];
         // ipykernel completion can omit protected PDV locals from top-level name
         // completion; ensure the two built-ins are always discoverable.
@@ -202,10 +232,15 @@ export function registerKernelCompletionProvider(
             }
           }
         }
-        const adjustedStart = Math.max(0, result.cursor_start - prefix.length);
-        const adjustedEnd = Math.max(0, result.cursor_end - prefix.length);
+        // Replace from where the kernel says the completion starts (usually
+        // the word start) through the cursor, so accepting a suggestion
+        // swallows the prefix the user already typed.
+        const adjustedStart = Math.min(
+          Math.max(0, result.cursor_start - prefix.length),
+          wordStartOffset,
+        );
         const startPosition = model.getPositionAt(adjustedStart);
-        const endPosition = model.getPositionAt(adjustedEnd);
+        const endPosition = model.getPositionAt(offset);
         const range = new monacoInstance.Range(
           startPosition.lineNumber,
           startPosition.column,
@@ -266,15 +301,28 @@ export function registerKernelHoverProvider(
   hoverProviderRegistered = true;
 
   monacoInstance.languages.registerHoverProvider('python', {
-    async provideHover(model, position) {
+    async provideHover(model, position, token) {
       const kernelId = activeKernelIdRef?.current ?? null;
       if (!kernelId) return null;
+
+      // Let the mouse rest before firing: drive-by movement across symbols
+      // cancels here and costs zero round trips.
+      await new Promise((resolve) => setTimeout(resolve, HOVER_DELAY_MS));
+      if (token.isCancellationRequested) return null;
 
       try {
         const code = model.getValue();
         const prefix = buildContextPrefix();
         const offset = prefix.length + model.getOffsetAt(position);
-        const result = await window.pdv.kernels.inspect(kernelId, prefix + code, offset);
+        const prefixedCode = prefix + code;
+        const result = await queryClient.fetchQuery({
+          queryKey: keys.inspectHover(
+            kernelId,
+            stableHash(`${offset} ${prefixedCode}`),
+          ),
+          queryFn: () => window.pdv.kernels.inspect(kernelId, prefixedCode, offset),
+          staleTime: STALE_TIMES.inspectHover,
+        });
         const rawDoc = result.data?.['text/plain'];
         if (!result.found || typeof rawDoc !== 'string' || !rawDoc.trim()) {
           return null;

--- a/electron/renderer/src/components/Console/Console.test.tsx
+++ b/electron/renderer/src/components/Console/Console.test.tsx
@@ -1,9 +1,14 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LogEntry } from '../../types';
+import { useStore } from '../../store';
 import { Console } from './index';
+
+beforeEach(() => {
+  useStore.setState({ logs: [] });
+});
 
 afterEach(() => {
   cleanup();
@@ -26,6 +31,15 @@ function makeLog(overrides: Partial<LogEntry> = {}): LogEntry {
   };
 }
 
+/** Seed the store's console slice and render the (store-subscribing) panel. */
+function renderConsole(
+  logs: LogEntry[],
+  props: Partial<React.ComponentProps<typeof Console>> = {},
+) {
+  useStore.setState({ logs });
+  return render(<Console onClear={props.onClear ?? vi.fn()} onInstallPackage={props.onInstallPackage} />);
+}
+
 // Empty-state rendering, stdout/stderr/result/image rendering, and the Clear
 // button are exercised by `code-cell.spec.ts` (which actually drives stdout
 // and result through a real kernel). The unit tests below pin the smaller
@@ -33,38 +47,28 @@ function makeLog(overrides: Partial<LogEntry> = {}): LogEntry {
 // non-error-source-header layout and the literal-null result rendering.
 describe('Console', () => {
   it('shows source in header without bottom context for non-error logs', () => {
-    const { container } = render(
-      <Console
-        logs={[
-          makeLog({
-            origin: { kind: 'code-cell', label: 'Tab 1', tabId: 1 },
-            stdout: 'ok',
-          }),
-        ]}
-        onClear={vi.fn()}
-      />
-    );
+    const { container } = renderConsole([
+      makeLog({
+        origin: { kind: 'code-cell', label: 'Tab 1', tabId: 1 },
+        stdout: 'ok',
+      }),
+    ]);
     expect(container.querySelector('.log-source')?.textContent).toBe('Cell 1');
     expect(container.querySelector('.log-error-context')).toBeNull();
   });
 
   it('renders null result string', () => {
-    const { container } = render(<Console logs={[makeLog({ id: 'n', result: null })]} onClear={vi.fn()} />);
+    const { container } = renderConsole([makeLog({ id: 'n', result: null })]);
     expect(container.querySelector('.log-result')?.textContent).toBe('null');
   });
 
   it('tags an agent-origin entry with the log-entry-agent modifier class', () => {
-    const { container } = render(
-      <Console
-        logs={[
-          makeLog({
-            id: 'agent-1',
-            origin: { kind: 'agent', agentTool: 'pdv_run' },
-          }),
-        ]}
-        onClear={vi.fn()}
-      />
-    );
+    const { container } = renderConsole([
+      makeLog({
+        id: 'agent-1',
+        origin: { kind: 'agent', agentTool: 'pdv_run' },
+      }),
+    ]);
     const entry = container.querySelector('.log-entry');
     expect(entry).not.toBeNull();
     expect(entry?.classList.contains('log-entry-agent')).toBe(true);
@@ -72,12 +76,9 @@ describe('Console', () => {
   });
 
   it('does not tag a code-cell entry with the agent class', () => {
-    const { container } = render(
-      <Console
-        logs={[makeLog({ id: 'cell-1', origin: { kind: 'code-cell', tabId: 2 } })]}
-        onClear={vi.fn()}
-      />
-    );
+    const { container } = renderConsole([
+      makeLog({ id: 'cell-1', origin: { kind: 'code-cell', tabId: 2 } }),
+    ]);
     const entry = container.querySelector('.log-entry');
     expect(entry?.classList.contains('log-entry-agent')).toBe(false);
   });
@@ -95,35 +96,31 @@ describe('Console', () => {
 
   it('offers pdv.install for a ModuleNotFoundError when onInstallPackage is provided', () => {
     const onInstallPackage = vi.fn();
-    const { getByRole } = render(
-      <Console logs={[moduleNotFoundLog()]} onClear={vi.fn()} onInstallPackage={onInstallPackage} />
-    );
+    const { getByRole } = renderConsole([moduleNotFoundLog()], { onInstallPackage });
     const btn = getByRole('button', { name: /pdv\.install\("xarray"\)/ });
     btn.click();
     expect(onInstallPackage).toHaveBeenCalledWith('xarray');
   });
 
   it('hides the install affordance in shared mode (no onInstallPackage)', () => {
-    const { container } = render(<Console logs={[moduleNotFoundLog()]} onClear={vi.fn()} />);
+    const { container } = renderConsole([moduleNotFoundLog()]);
     expect(container.querySelector('.log-install-action')).toBeNull();
   });
 
   it('does not re-parse ANSI for entries whose object identity is unchanged', () => {
     const stable = makeLog({ id: 'stable', stdout: 'first entry output' });
     const growing = makeLog({ id: 'growing', stdout: 'chunk-1' });
-    const onClear = vi.fn();
-    const { rerender } = render(<Console logs={[stable, growing]} onClear={onClear} />);
+    renderConsole([stable, growing]);
     ansiSpy.mockClear();
 
     // Streamed output replaces only the affected entry object (see
     // useKernelSubscriptions); the other entry keeps identity and its
     // memoized HTML.
-    rerender(
-      <Console
-        logs={[stable, { ...growing, stdout: growing.stdout + 'chunk-2' }]}
-        onClear={onClear}
-      />
-    );
+    act(() => {
+      useStore.setState({
+        logs: [stable, { ...growing, stdout: growing.stdout + 'chunk-2' }],
+      });
+    });
 
     expect(ansiSpy).toHaveBeenCalledTimes(1);
     expect(ansiSpy).toHaveBeenCalledWith('chunk-1chunk-2');

--- a/electron/renderer/src/components/Console/index.tsx
+++ b/electron/renderer/src/components/Console/index.tsx
@@ -2,16 +2,18 @@
  * Console panel for execution history and streamed output rendering.
  *
  * Displays code, stdout/stderr, rich display images, and execution metadata
- * emitted from kernel executions coordinated by `App`.
+ * emitted from kernel executions coordinated by `App`. Subscribes to the
+ * store's console slice directly, so streamed-output flushes re-render this
+ * panel only — not the whole app.
  */
 
 import React, { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import type { LogEntry } from '../../types';
+import { useStore } from '../../store';
 import { ansiToHtml } from './ansi';
 
 /** Props for the execution console panel. */
 interface ConsoleProps {
-  logs: LogEntry[];
   onClear: () => void;
   /**
    * Run `pdv.install("<name>")` for a missing module. Provided only for uv
@@ -54,7 +56,8 @@ function missingModuleName(log: LogEntry): { name: string; installer: string } |
 const PIN_THRESHOLD_PX = 4;
 
 /** Execution console component. */
-export const Console: React.FC<ConsoleProps> = ({ logs, onClear, onInstallPackage }) => {
+export const Console: React.FC<ConsoleProps> = ({ onClear, onInstallPackage }) => {
+  const logs = useStore((s) => s.logs);
   const contentRef = useRef<HTMLDivElement>(null);
   // True when the viewport is at (or within PIN_THRESHOLD_PX of) the
   // bottom. Initialized true so the first batch of output scrolls into
@@ -207,6 +210,11 @@ const LogEntryView: React.FC<{
               alt={`Plot ${index}.${idx + 1}`}
             />
           ))}
+        </div>
+      )}
+      {!hasImages && (log.imagesDropped ?? 0) > 0 && (
+        <div className="log-images-expired">
+          [{log.imagesDropped === 1 ? 'image expired' : `${log.imagesDropped} images expired`} — re-run to regenerate]
         </div>
       )}
     </div>

--- a/electron/renderer/src/components/NamespaceView/NamespaceView.test.tsx
+++ b/electron/renderer/src/components/NamespaceView/NamespaceView.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
 
+import React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NamespaceInspectorNode, NamespaceVariable } from '../../types';
 import type { PDVApi } from '../../types/pdv';
 import { installPdvMock, type PdvMock } from '../../test-fixtures/pdv-mock';
+import { queryClient } from '../../queries/client';
+import { invalidateNamespace } from '../../queries/invalidation';
 import { NamespaceView } from './index';
 
 function makeVars(): NamespaceVariable[] {
@@ -59,7 +63,22 @@ function makeChildren(): NamespaceInspectorNode[] {
 
 let pdv: PdvMock;
 
+function renderNamespaceView(props: React.ComponentProps<typeof NamespaceView>) {
+  const wrap = (p: React.ComponentProps<typeof NamespaceView>) => (
+    <QueryClientProvider client={queryClient}>
+      <NamespaceView {...p} />
+    </QueryClientProvider>
+  );
+  const rendered = render(wrap(props));
+  return {
+    ...rendered,
+    rerender: (nextProps: React.ComponentProps<typeof NamespaceView>) =>
+      rendered.rerender(wrap(nextProps)),
+  };
+}
+
 beforeEach(() => {
+  queryClient.clear();
   pdv = installPdvMock({
     namespace: {
       query: vi.fn<PDVApi['namespace']['query']>(async () => makeVars()),
@@ -79,12 +98,12 @@ afterEach(() => {
 // and lazy-expand are all covered indirectly when a real kernel runs against
 // NamespaceView in the larger E2E flow. The unit tests retained here pin the
 // mapping between UI controls and the request shape sent to
-// `namespace.query`/`inspect`, plus the polling cadence — both of which are
-// hard to verify with on/off-only observability.
+// `namespace.query`/`inspect`, plus the invalidation-driven refresh flow —
+// both of which are hard to verify with on/off-only observability.
 describe('NamespaceView', () => {
   it('applies filter toggles to subsequent API requests', async () => {
     const query = pdv.namespace.query;
-    render(<NamespaceView kernelId="k1" />);
+    renderNamespaceView({ kernelId: 'k1' });
     await waitFor(() => expect(query).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByRole('checkbox', { name: /Private/i }));
@@ -102,9 +121,9 @@ describe('NamespaceView', () => {
     );
   });
 
-  it('sorts top-level rows by column header clicks and reacts to refreshToken changes', async () => {
+  it('sorts top-level rows by column header clicks and refetches on invalidation', async () => {
     const query = pdv.namespace.query;
-    const { rerender } = render(<NamespaceView kernelId="k1" refreshToken={0} />);
+    renderNamespaceView({ kernelId: 'k1' });
     await waitFor(() => {
       expect(screen.getByText('alpha')).toBeTruthy();
     });
@@ -113,20 +132,20 @@ describe('NamespaceView', () => {
     const rows = document.querySelectorAll('.namespace-row');
     expect(rows[0]?.textContent).toContain('beta');
 
-    rerender(<NamespaceView kernelId="k1" refreshToken={1} />);
+    invalidateNamespace('k1');
     await waitFor(() => expect(query.mock.calls.length).toBeGreaterThanOrEqual(2));
   });
 
   it('auto-refresh triggers interval-based re-queries', async () => {
     const query = pdv.namespace.query;
-    render(<NamespaceView kernelId="k1" autoRefresh refreshInterval={20} />);
+    renderNamespaceView({ kernelId: 'k1', autoRefresh: true, refreshInterval: 20 });
     await waitFor(() => expect(query.mock.calls.length).toBeGreaterThanOrEqual(3), { timeout: 2000 });
   });
 
   it('keeps expanded nodes open (with refreshed children) across auto-refresh ticks', async () => {
     const query = pdv.namespace.query;
     const inspect = pdv.namespace.inspect;
-    render(<NamespaceView kernelId="k1" autoRefresh refreshInterval={20} />);
+    renderNamespaceView({ kernelId: 'k1', autoRefresh: true, refreshInterval: 20 });
     await waitFor(() => expect(screen.getByText('arr')).toBeTruthy());
 
     fireEvent.click(screen.getByRole('button', { name: /Expand arr/ }));
@@ -146,20 +165,23 @@ describe('NamespaceView', () => {
   });
 
   it('collapses an expanded node whose variable disappeared', async () => {
-    pdv.namespace.inspect.mockImplementation(async () => {
-      throw new Error("name 'arr' is not defined");
-    });
     const query = pdv.namespace.query;
-    render(<NamespaceView kernelId="k1" autoRefresh refreshInterval={20} />);
+    renderNamespaceView({ kernelId: 'k1', autoRefresh: true, refreshInterval: 20 });
     await waitFor(() => expect(screen.getByText('arr')).toBeTruthy());
 
     fireEvent.click(screen.getByRole('button', { name: /Expand arr/ }));
-    // The failed inspect surfaces an error row first; the next refresh tick
-    // then drops the dead expansion entirely.
-    await waitFor(() => expect(query.mock.calls.length).toBeGreaterThanOrEqual(3), { timeout: 2000 });
-    await waitFor(() => {
-      expect(document.querySelector('.namespace-message-error')).toBeNull();
+    await waitFor(() => expect(screen.getByText('[0]')).toBeTruthy());
+
+    // The variable vanishes from the kernel: subsequent top-level queries no
+    // longer include it, and inspecting it would fail.
+    query.mockImplementation(async () => makeVars().filter((v) => v.name !== 'arr'));
+    pdv.namespace.inspect.mockImplementation(async () => {
+      throw new Error("name 'arr' is not defined");
     });
+
+    // The next refresh tick drops the row and prunes the dead expansion.
+    await waitFor(() => expect(screen.queryByText('arr')).toBeNull(), { timeout: 2000 });
     expect(screen.queryByText('[0]')).toBeNull();
+    expect(document.querySelector('.namespace-message-error')).toBeNull();
   });
 });

--- a/electron/renderer/src/components/NamespaceView/index.tsx
+++ b/electron/renderer/src/components/NamespaceView/index.tsx
@@ -1,11 +1,19 @@
 /**
  * NamespaceView — live tree-style browser of kernel namespace variables.
  *
- * Queries `window.pdv.namespace.query` for top-level values and lazily expands
- * nested children through `window.pdv.namespace.inspect`.
+ * Server state lives in React Query: one query for the top-level
+ * `namespace.query` (keyed by kernel + filter set) and one per expanded
+ * node's `namespace.inspect` (keyed by expression). Refresh is event-driven
+ * — execution-finish and project-load invalidate the `namespace` domains via
+ * `queries/invalidation.ts` — with an opt-in interval that simply invalidates
+ * on a timer. Expanded queries refetch in parallel on invalidation, which
+ * replaces the old hand-rolled fetch-sequence/in-flight guards.
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery, useQueries } from '@tanstack/react-query';
+import { keys } from '../../queries/keys';
+import { invalidateNamespace } from '../../queries/invalidation';
 import type {
   NamespaceInspectResult,
   NamespaceInspectorNode,
@@ -18,7 +26,6 @@ interface NamespaceViewProps {
   disabled?: boolean;
   autoRefresh?: boolean;
   refreshInterval?: number;
-  refreshToken?: number;
   onToggleAutoRefresh?: (value: boolean) => void;
 }
 
@@ -32,18 +39,28 @@ interface VisibleNamespaceRow {
 
 const INDENT_PX = 16;
 
+/** Show a pending state only after it has lasted this long (no flashing). */
+function useDeferredFlag(pending: boolean, delayMs: number): boolean {
+  const [deferred, setDeferred] = useState(false);
+  useEffect(() => {
+    if (!pending) {
+      setDeferred(false);
+      return;
+    }
+    const timer = setTimeout(() => setDeferred(true), delayMs);
+    return () => clearTimeout(timer);
+  }, [pending, delayMs]);
+  return deferred;
+}
+
 /** Kernel namespace browser panel. */
 export const NamespaceView: React.FC<NamespaceViewProps> = ({
   kernelId,
   disabled = false,
   autoRefresh = false,
   refreshInterval = 2000,
-  refreshToken = 0,
   onToggleAutoRefresh,
 }) => {
-  const [variables, setVariables] = useState<NamespaceVariable[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | undefined>();
   const [filters, setFilters] = useState<NamespaceQueryOptions>({
     includePrivate: false,
     includeModules: false,
@@ -52,53 +69,93 @@ export const NamespaceView: React.FC<NamespaceViewProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<'name' | 'type' | 'size'>('name');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
-  const [expandedExpressions, setExpandedExpressions] = useState<Set<string>>(new Set());
-  const [childrenByExpression, setChildrenByExpression] = useState<Record<string, NamespaceInspectorNode[]>>({});
-  const [inspectMetaByExpression, setInspectMetaByExpression] = useState<Record<string, NamespaceInspectResult>>({});
-  const [inspectLoading, setInspectLoading] = useState<Set<string>>(new Set());
-  const [inspectErrors, setInspectErrors] = useState<Record<string, string>>({});
+  // Nodes the user has expanded, keyed by expression. The node object is
+  // retained because re-inspection needs its rootName/path.
+  const [expandedNodes, setExpandedNodes] = useState<ReadonlyMap<string, NamespaceInspectorNode>>(
+    () => new Map(),
+  );
 
-  // Nodes the user has expanded, kept in a ref so refreshes can re-inspect
-  // them without depending on render state. Keyed by expression.
-  const expandedNodesRef = useRef<Map<string, NamespaceInspectorNode>>(new Map());
-  // Monotonic fetch sequence: a fetch only applies its results if it is
-  // still the latest, so overlapping fetches can't interleave stale state.
-  const fetchSeqRef = useRef(0);
-  const inFlightRef = useRef(false);
+  const enabled = kernelId !== null && !disabled;
+  const filtersHash = `${+!!filters.includePrivate}${+!!filters.includeModules}${+!!filters.includeCallables}`;
+  const variablesQuery = useQuery({
+    queryKey: keys.namespace(kernelId ?? '__no-kernel__', filtersHash),
+    queryFn: () => window.pdv.namespace.query(kernelId!, filters),
+    enabled,
+  });
+  const variables = useMemo(
+    () => (enabled ? variablesQuery.data ?? [] : []),
+    [enabled, variablesQuery.data],
+  );
+  const error = enabled && variablesQuery.error
+    ? (variablesQuery.error instanceof Error ? variablesQuery.error.message : String(variablesQuery.error))
+    : undefined;
+  // Spinner only for the initial (no data yet) fetch, deferred 1 s to avoid
+  // flashing; background refetches swap content in place.
+  const loading = useDeferredFlag(enabled && variablesQuery.data === undefined && !error, 1000);
 
-  const resetInspectionState = useCallback(() => {
-    expandedNodesRef.current.clear();
-    setExpandedExpressions(new Set());
-    setChildrenByExpression({});
-    setInspectMetaByExpression({});
-    setInspectLoading(new Set());
-    setInspectErrors({});
-  }, []);
+  // findRootName needs the freshest variables at inspect time, not the ones
+  // captured when the queryFn closure was built.
+  const variablesRef = useRef<NamespaceVariable[]>([]);
+  variablesRef.current = variables;
 
-  /** Drop one expression's expansion and cached inspection state. */
-  const dropExpansion = useCallback((expression: string) => {
-    expandedNodesRef.current.delete(expression);
-    setExpandedExpressions((prev) => {
-      const next = new Set(prev);
-      next.delete(expression);
-      return next;
+  const expandedList = useMemo(() => Array.from(expandedNodes.values()), [expandedNodes]);
+  const inspectResults = useQueries({
+    queries: expandedList.map((node) => ({
+      queryKey: keys.namespaceInspect(kernelId ?? '__no-kernel__', node.expression),
+      queryFn: () =>
+        window.pdv.namespace.inspect(kernelId!, {
+          rootName: node.path.length === 0 ? node.name : findRootName(node, variablesRef.current),
+          path: node.path,
+        }),
+      enabled,
+    })),
+  });
+
+  // Derived per-expression inspection state (children, meta, errors, pending).
+  const expandedExpressions = useMemo(() => new Set(expandedNodes.keys()), [expandedNodes]);
+  const childrenByExpression: Record<string, NamespaceInspectorNode[]> = {};
+  const inspectMetaByExpression: Record<string, NamespaceInspectResult> = {};
+  const inspectErrors: Record<string, string> = {};
+  const inspectLoading = new Set<string>();
+  expandedList.forEach((node, i) => {
+    const result = inspectResults[i];
+    if (result.data) {
+      childrenByExpression[node.expression] = result.data.children;
+      inspectMetaByExpression[node.expression] = result.data;
+    } else if (result.error) {
+      inspectErrors[node.expression] =
+        result.error instanceof Error ? result.error.message : String(result.error);
+    } else {
+      inspectLoading.add(node.expression);
+    }
+  });
+
+  // Collapse expansions whose root variable no longer exists in the fresh
+  // top-level listing (e.g. deleted between refreshes) so their queries
+  // don't linger and re-error forever.
+  const freshVariables = variablesQuery.data;
+  useEffect(() => {
+    if (!freshVariables) return;
+    setExpandedNodes((prev) => {
+      let changed = false;
+      const next = new Map(prev);
+      for (const [expression, node] of prev) {
+        const rootExists = node.path.length === 0
+          ? freshVariables.some((v) => v.name === node.name)
+          : freshVariables.some(
+              (v) =>
+                expression === v.expression ||
+                expression.startsWith(`${v.expression}.`) ||
+                expression.startsWith(`${v.expression}[`),
+            );
+        if (!rootExists) {
+          next.delete(expression);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
     });
-    setChildrenByExpression((prev) => {
-      const next = { ...prev };
-      delete next[expression];
-      return next;
-    });
-    setInspectMetaByExpression((prev) => {
-      const next = { ...prev };
-      delete next[expression];
-      return next;
-    });
-    setInspectErrors((prev) => {
-      const next = { ...prev };
-      delete next[expression];
-      return next;
-    });
-  }, []);
+  }, [freshVariables]);
 
   const handleSortClick = (col: 'name' | 'type' | 'size') => {
     if (col === sortBy) {
@@ -109,85 +166,18 @@ export const NamespaceView: React.FC<NamespaceViewProps> = ({
     }
   };
 
-  /**
-   * Re-inspect every user-expanded node against fresh top-level results so
-   * a refresh keeps expanded subtrees both open and current. Nodes whose
-   * inspection now fails (e.g. the variable was deleted) are collapsed.
-   */
-  const refreshExpandedChildren = useCallback(
-    async (activeKernelId: string, freshVariables: NamespaceVariable[], seq: number) => {
-      const expandedNodes = Array.from(expandedNodesRef.current.values());
-      await Promise.all(
-        expandedNodes.map(async (node) => {
-          try {
-            const result = await window.pdv.namespace.inspect(activeKernelId, {
-              rootName: node.path.length === 0 ? node.name : findRootName(node, freshVariables),
-              path: node.path,
-            });
-            if (seq !== fetchSeqRef.current) return;
-            setChildrenByExpression((prev) => ({ ...prev, [node.expression]: result.children }));
-            setInspectMetaByExpression((prev) => ({ ...prev, [node.expression]: result }));
-          } catch {
-            if (seq !== fetchSeqRef.current) return;
-            dropExpansion(node.expression);
-          }
-        }),
-      );
-    },
-    [dropExpansion],
-  );
-
-  const fetchNamespace = useCallback(async (options?: { skipIfBusy?: boolean }) => {
-    if (!kernelId || disabled) {
-      setVariables([]);
-      setError(undefined);
-      setLoading(false);
-      resetInspectionState();
-      return;
-    }
-    // Auto-refresh ticks skip rather than pile onto a slow in-flight fetch.
-    if (options?.skipIfBusy && inFlightRef.current) return;
-
-    const seq = ++fetchSeqRef.current;
-    inFlightRef.current = true;
-    setError(undefined);
-    // Show spinner only if the fetch takes longer than 1s to avoid flashing.
-    const loadingTimer = setTimeout(() => setLoading(true), 1000);
-
-    try {
-      const result = await window.pdv.namespace.query(kernelId, filters);
-      if (seq !== fetchSeqRef.current) return; // superseded by a newer fetch
-      setVariables(result);
-      // Keep user-expanded nodes open and refresh their children in place —
-      // resetting here would collapse the tree on every auto-refresh tick.
-      await refreshExpandedChildren(kernelId, result, seq);
-    } catch (err) {
-      if (seq !== fetchSeqRef.current) return;
-      setError(err instanceof Error ? err.message : String(err));
-      setVariables([]);
-      resetInspectionState();
-    } finally {
-      clearTimeout(loadingTimer);
-      if (seq === fetchSeqRef.current) {
-        setLoading(false);
-        inFlightRef.current = false;
-      }
-    }
-  }, [kernelId, filters, disabled, resetInspectionState, refreshExpandedChildren]);
-
-  useEffect(() => {
-    void fetchNamespace();
-  }, [fetchNamespace, refreshToken]);
-
+  // Opt-in interval refresh: invalidate the namespace domains on a timer;
+  // the top-level query and every expanded inspection refetch in parallel.
+  // React Query dedupes ticks that land while a refetch is in flight.
   useEffect(() => {
     if (!autoRefresh || !kernelId || disabled) return;
 
     const interval = setInterval(() => {
-      void fetchNamespace({ skipIfBusy: true });
+      invalidateNamespace(kernelId);
     }, refreshInterval);
 
     return () => clearInterval(interval);
-  }, [autoRefresh, refreshInterval, kernelId, fetchNamespace, disabled]);
+  }, [autoRefresh, refreshInterval, kernelId, disabled]);
 
   const sortedVariables = useMemo(() => {
     return [...variables].sort((a, b) => {
@@ -199,94 +189,43 @@ export const NamespaceView: React.FC<NamespaceViewProps> = ({
     });
   }, [variables, sortBy, sortDir]);
 
-  const fetchChildren = useCallback(async (node: NamespaceInspectorNode) => {
-    if (!kernelId) return;
-    const key = node.expression;
-    setInspectLoading((prev) => new Set(prev).add(key));
-    setInspectErrors((prev) => {
-      const next = { ...prev };
-      delete next[key];
-      return next;
-    });
-
-    try {
-      const result = await window.pdv.namespace.inspect(kernelId, {
-        rootName: node.path.length === 0 ? node.name : findRootName(node, variables),
-        path: node.path,
-      });
-      setChildrenByExpression((prev) => ({ ...prev, [key]: result.children }));
-      setInspectMetaByExpression((prev) => ({ ...prev, [key]: result }));
-    } catch (err) {
-      setInspectErrors((prev) => ({
-        ...prev,
-        [key]: err instanceof Error ? err.message : String(err),
-      }));
-    } finally {
-      setInspectLoading((prev) => {
-        const next = new Set(prev);
-        next.delete(key);
-        return next;
-      });
-    }
-  }, [kernelId, variables]);
-
+  // Expanding mounts the node's inspect query (cache-hit renders instantly,
+  // stale data revalidates in the background); collapsing unmounts it.
   const toggleExpanded = useCallback((node: NamespaceInspectorNode) => {
     if (!node.hasChildren) return;
-    const key = node.expression;
-    const collapsing = expandedNodesRef.current.has(key);
-    if (collapsing) {
-      expandedNodesRef.current.delete(key);
-    } else {
-      expandedNodesRef.current.set(key, node);
-    }
-    setExpandedExpressions((prev) => {
-      const next = new Set(prev);
-      if (collapsing) {
-        next.delete(key);
+    setExpandedNodes((prev) => {
+      const next = new Map(prev);
+      if (next.has(node.expression)) {
+        next.delete(node.expression);
       } else {
-        next.add(key);
+        next.set(node.expression, node);
       }
       return next;
     });
-    if (!collapsing && !childrenByExpression[key] && !inspectLoading.has(key)) {
-      void fetchChildren(node);
-    }
-  }, [childrenByExpression, fetchChildren, inspectLoading]);
+  }, []);
 
-  const visibleRows = useMemo(() => {
-    const rows: VisibleNamespaceRow[] = [];
-    for (const variable of sortedVariables) {
-      appendVisibleRows({
-        rows,
-        node: variable,
-        depth: 0,
-        expandedExpressions,
-        childrenByExpression,
-        inspectMetaByExpression,
-        inspectErrors,
-      });
-    }
-
-    if (!searchQuery.trim()) {
-      return rows;
-    }
-
-    const query = searchQuery.toLowerCase();
-    return rows.filter((row) => {
-      if (row.kind !== 'node' || !row.node) {
-        return false;
-      }
-      const haystack = `${row.node.name} ${row.node.expression} ${row.node.preview || ''}`.toLowerCase();
-      return haystack.includes(query);
+  const rows: VisibleNamespaceRow[] = [];
+  for (const variable of sortedVariables) {
+    appendVisibleRows({
+      rows,
+      node: variable,
+      depth: 0,
+      expandedExpressions,
+      childrenByExpression,
+      inspectMetaByExpression,
+      inspectErrors,
     });
-  }, [
-    sortedVariables,
-    expandedExpressions,
-    childrenByExpression,
-    inspectMetaByExpression,
-    inspectErrors,
-    searchQuery,
-  ]);
+  }
+  const trimmedQuery = searchQuery.trim().toLowerCase();
+  const visibleRows = !trimmedQuery
+    ? rows
+    : rows.filter((row) => {
+        if (row.kind !== 'node' || !row.node) {
+          return false;
+        }
+        const haystack = `${row.node.name} ${row.node.expression} ${row.node.preview || ''}`.toLowerCase();
+        return haystack.includes(trimmedQuery);
+      });
 
   const handleDoubleClick = (node: NamespaceInspectorNode) => {
     if (navigator?.clipboard?.writeText) {
@@ -295,7 +234,7 @@ export const NamespaceView: React.FC<NamespaceViewProps> = ({
   };
 
   const handleRefresh = () => {
-    void fetchNamespace();
+    if (kernelId) invalidateNamespace(kernelId);
   };
 
   const handleHeaderKeyDown = (sortKey: 'name' | 'type' | 'size') => (event: React.KeyboardEvent<HTMLTableCellElement>) => {

--- a/electron/renderer/src/components/StatusBar/index.tsx
+++ b/electron/renderer/src/components/StatusBar/index.tsx
@@ -7,6 +7,14 @@
 
 import React from 'react';
 import type { ProgressPayload, UpdateStatus } from '../../types/pdv';
+import { useStore } from '../../store';
+
+/** Status-bar labels per remote connection state ('local' renders nothing). */
+const CONNECTION_LABELS = {
+  'remote-connected': { text: 'SSH', className: 'status-item' },
+  'remote-reconnecting': { text: 'Reconnecting…', className: 'status-item status-warning' },
+  'remote-lost': { text: 'Connection lost', className: 'status-item status-warning' },
+} as const;
 
 interface StatusBarProps {
   isExecuting: boolean;
@@ -115,6 +123,7 @@ export const StatusBar: React.FC<StatusBarProps> = ({
         </div>
       )}
       <div className="status-left">
+        <ConnectionSegment />
         <span className="status-item">{currentProjectDir ?? 'Unsaved Project'}</span>
         {showUpdateBadge && updateStatus && (
           <span
@@ -226,4 +235,17 @@ export const StatusBar: React.FC<StatusBarProps> = ({
       </div>
     </footer>
   );
+};
+
+/**
+ * Remote-session indicator (roadmap Phase 3). Subscribes to the store's
+ * connection state and renders nothing for local sessions, so today's UI is
+ * unchanged while the surface the SSH state machine will drive already
+ * exists.
+ */
+const ConnectionSegment: React.FC = () => {
+  const connectionState = useStore((s) => s.connectionState);
+  if (connectionState === 'local') return null;
+  const { text, className } = CONNECTION_LABELS[connectionState];
+  return <span className={className}>{text}</span>;
 };

--- a/electron/renderer/src/components/Tree/index.tsx
+++ b/electron/renderer/src/components/Tree/index.tsx
@@ -1,25 +1,39 @@
 /**
  * Tree panel — browsable view of `pdv_tree` descriptors.
  *
- * Fetches root/child nodes via `treeService`, preserves expansion/selection
- * state in localStorage, and exposes context-menu actions back to `App`.
+ * Server state (children listings) lives in React Query — one query per
+ * expanded path (`['tree', kernelId, path]`), invalidated by push events via
+ * `queries/invalidation.ts`. This component owns only UI state: which paths
+ * are expanded, the selection (persisted per project in localStorage), and
+ * the context menu. A low-frequency safety-net poll revalidates visible
+ * listings through the same cache to catch plain-dict mutations that emit no
+ * push; it stays quiet while pushes are flowing.
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { List, type ListImperativeAPI, type RowComponentProps } from 'react-window';
-import { treeService, type TreeNodeData } from '../../services/tree';
+import type { TreeNodeData } from '../../services/tree';
 import { TreeNodeRow } from './TreeNodeRow';
 import { ContextMenu } from './ContextMenu';
-import { childrenDiffer, flattenTree, findNode, mergeChildren, removeNodeImmut, updateNodeImmut } from './tree-utils';
-import type { TreeChangeInfo } from '../../types';
+import { flattenFromCache, collapseSubtree, type TreeRow } from './tree-utils';
+import {
+  useTreeChildrenQueries,
+  pollTreeOnce,
+  TREE_POLL_INTERVAL_MS,
+  TREE_PUSH_SUPPRESS_MS,
+} from '../../queries/tree';
+import { invalidateTree, msSinceTreePush, parentTreePath } from '../../queries/invalidation';
 import type { Shortcuts } from '../../shortcuts';
 import { matchesShortcut } from '../../shortcuts';
 
 const ROW_HEIGHT = 32;
 
+/** How long a pending fetch must run before its row shows a spinner. */
+const LOADING_SPINNER_DELAY_MS = 1000;
+
 /** Props passed to VirtualRow via react-window's rowProps. */
 interface VirtualRowProps {
-  flatNodes: Array<TreeNodeData & { depth: number }>;
+  flatNodes: TreeRow[];
   selectedPath: string | null;
   onExpand: (node: TreeNodeData) => void;
   onDoubleClick: (node: TreeNodeData) => void;
@@ -53,14 +67,6 @@ const VirtualRow = React.memo(VirtualRowImpl) as unknown as typeof VirtualRowImp
 interface TreeProps {
   kernelId: string | null;
   disabled?: boolean;
-  refreshToken?: number;
-  pendingChanges?: TreeChangeInfo[];
-  /**
-   * Called with the exact change batch that was consumed so the owner can
-   * remove those entries (and only those) from its queue — changes pushed
-   * between render and effect commit must survive.
-   */
-  onChangesConsumed?: (consumed: TreeChangeInfo[]) => void;
   onAction?: (action: string, node: TreeNodeData) => void;
   shortcuts: Shortcuts;
   /**
@@ -86,13 +92,64 @@ function readStoredSelection(storageKey: string): string | null {
   }
 }
 
+/**
+ * Cache-friendly map of parent path → children, rebuilt only when a query's
+ * data identity actually changes (structural sharing keeps identities stable
+ * across no-op refetches, so no-op polls rebuild nothing).
+ */
+function useChildrenByPath(
+  paths: readonly string[],
+  datas: readonly (TreeNodeData[] | undefined)[],
+): ReadonlyMap<string, TreeNodeData[]> {
+  const ref = useRef<{
+    paths: readonly string[];
+    datas: readonly (TreeNodeData[] | undefined)[];
+    map: Map<string, TreeNodeData[]>;
+  } | null>(null);
+  const cached = ref.current;
+  const unchanged =
+    cached !== null &&
+    cached.paths.length === paths.length &&
+    cached.paths.every((p, i) => p === paths[i]) &&
+    cached.datas.every((d, i) => d === datas[i]);
+  if (!unchanged) {
+    const map = new Map<string, TreeNodeData[]>();
+    paths.forEach((p, i) => {
+      const data = datas[i];
+      if (data) map.set(p, data);
+    });
+    ref.current = { paths, datas, map };
+  }
+  return ref.current!.map;
+}
+
+/**
+ * Paths whose fetch has been pending longer than `delayMs`, for spinner
+ * display without flashing on fast fetches.
+ */
+function useDeferredLoadingPaths(pendingPaths: string[], delayMs: number): ReadonlySet<string> {
+  const [deferred, setDeferred] = useState<ReadonlySet<string>>(() => new Set());
+  // NUL never appears in tree paths, so the joined key is collision-free
+  // even when node keys contain spaces.
+  const key = pendingPaths.join('\u0000');
+  useEffect(() => {
+    // Drop entries that are no longer pending right away…
+    setDeferred((prev) => {
+      const next = new Set([...prev].filter((p) => pendingPaths.includes(p)));
+      return next.size === prev.size ? prev : next;
+    });
+    if (pendingPaths.length === 0) return;
+    // …and promote the still-pending set only after the delay.
+    const timer = setTimeout(() => setDeferred(new Set(pendingPaths)), delayMs);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- key encodes pendingPaths
+  }, [key, delayMs]);
+  return deferred;
+}
+
 /** Tree browser component for node navigation and node actions. */
-export const Tree: React.FC<TreeProps> = ({ kernelId, disabled = false, refreshToken = 0, pendingChanges, onChangesConsumed, onAction, shortcuts, projectKey }) => {
-  const [nodes, setNodes] = useState<TreeNodeData[]>([]);
-  const nodesRef = useRef(nodes);
-  nodesRef.current = nodes;
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | undefined>();
+export const Tree: React.FC<TreeProps> = ({ kernelId, disabled = false, onAction, shortcuts, projectKey }) => {
+  const [expandedPaths, setExpandedPaths] = useState<ReadonlySet<string>>(() => new Set());
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   // Selection persistence is scoped per project so switching projects
   // doesn't inherit (or clobber) another project's selection.
@@ -101,78 +158,49 @@ export const Tree: React.FC<TreeProps> = ({ kernelId, disabled = false, refreshT
     readStoredSelection(selectionStorageKey),
   );
 
-  const expandedPathsRef = useRef<Set<string>>(new Set());
+  const expandedPathsRef = useRef(expandedPaths);
+  expandedPathsRef.current = expandedPaths;
   const listRef = useRef<ListImperativeAPI>(null);
 
-  const loadRoot = useCallback(async () => {
-    // Show the loading placeholder only when there is nothing on screen
-    // yet; refreshes of a populated tree swap content in place.
-    setLoading(nodesRef.current.length === 0);
-    setError(undefined);
-    if (!kernelId || disabled) {
-      setNodes([]);
-      setLoading(false);
-      setError(undefined);
-      return;
-    }
-    try {
-      const rootNodes = await treeService.getRootNodes(kernelId);
+  // One mounted query per visible level: root first, then expanded paths in
+  // a stable order. Invalidation refetches them all in parallel.
+  const paths = useMemo(
+    () => ['', ...Array.from(expandedPaths).sort()],
+    [expandedPaths],
+  );
+  const results = useTreeChildrenQueries(kernelId, paths, !disabled);
 
-      // Preserve the set of previously expanded paths so the tree doesn't
-      // collapse on every refresh. Paths that no longer exist in the new tree
-      // are pruned after re-expansion.
-      const previouslyExpanded = expandedPathsRef.current;
-      const newExpanded = new Set(['']);
+  const datas = results.map((r) => r.data);
+  const childrenByPath = useChildrenByPath(paths, datas);
 
-      // Re-expand previously open nodes by depth (parents before children)
-      // so each level's children are available for the next level.
-      const sortedPaths = Array.from(previouslyExpanded)
-        .filter((p) => p !== '')
-        .sort((a, b) => a.split('.').length - b.split('.').length);
+  const pendingPaths = paths.filter((_p, i) => results[i].data === undefined && !results[i].error);
+  const loadingPaths = useDeferredLoadingPaths(pendingPaths, LOADING_SPINNER_DELAY_MS);
 
-      // Build a lookup from path → node for the freshly-fetched root children.
-      // The service returns fresh objects on every call, so tagging expansion
-      // state onto them here mutates nothing shared with other callers.
-      const nodeMap = new Map<string, TreeNodeData>();
-      for (const n of rootNodes) nodeMap.set(n.path, n);
+  const rootResult = results[0];
+  const loading = !disabled && kernelId !== null && rootResult.data === undefined && !rootResult.error;
+  const error = rootResult.error ? 'Failed to load tree' : undefined;
 
-      for (const expandPath of sortedPaths) {
-        const target = nodeMap.get(expandPath);
-        if (!target || !target.hasChildren) continue;
-        try {
-          const children = await treeService.getChildren(target, kernelId);
-          target.isExpanded = true;
-          target.children = children;
-          newExpanded.add(expandPath);
-          for (const child of children) nodeMap.set(child.path, child);
-        } catch {
-          // Node may have been removed — skip silently.
-        }
+  // Reconcile expansion with reality: collapse paths that vanished from
+  // their parent's (loaded) listing or whose own listing failed to load
+  // (node removed mid-expansion). Cheap set surgery, no fetches.
+  const erroredKey = paths.filter((p, i) => p !== '' && results[i].error).join('\u0000');
+  useEffect(() => {
+    if (expandedPaths.size === 0) return;
+    let next: ReadonlySet<string> | null = null;
+    const current = (): ReadonlySet<string> => next ?? expandedPaths;
+    for (const p of expandedPaths) {
+      const parent = parentTreePath(p);
+      const parentListing = childrenByPath.get(parent);
+      const parentVisible = parent === '' || expandedPaths.has(parent);
+      if (parentVisible && parentListing && !parentListing.some((n) => n.path === p)) {
+        next = collapseSubtree(current(), p);
       }
-
-      expandedPathsRef.current = newExpanded;
-
-      // Wrap in a synthetic root node so there is always a right-clickable
-      // container even when the tree is empty.
-      const syntheticRoot: TreeNodeData = {
-        id: '__root__',
-        key: 'pdv_tree',
-        path: '',
-        type: 'root',
-        preview: '',
-        hasChildren: true,
-        parentPath: null,
-        isExpanded: true,
-        children: rootNodes,
-      };
-      setNodes([syntheticRoot]);
-    } catch (err) {
-      console.error('[Tree] Failed to load root nodes', err);
-      setError('Failed to load tree');
-    } finally {
-      setLoading(false);
     }
-  }, [kernelId, disabled]);
+    for (const p of erroredKey ? erroredKey.split('\u0000') : []) {
+      if (current().has(p)) next = collapseSubtree(current(), p);
+    }
+    if (next) setExpandedPaths(next);
+  }, [childrenByPath, expandedPaths, erroredKey]);
 
   // Persist selection per project; when the project (storage key) changes,
   // load that project's stored selection instead of persisting the old one.
@@ -194,56 +222,23 @@ export const Tree: React.FC<TreeProps> = ({ kernelId, disabled = false, refreshT
     }
   }, [selectedPath, selectionStorageKey]);
 
-  useEffect(() => {
-    void loadRoot();
-  }, [loadRoot, refreshToken]);
-
   // Safety-net poll. Push notifications cover all PDVTree mutations, but
   // plain-dict mutations under the tree (e.g. `pdv_tree['data']['x'] = 1`
-  // when `data` is a plain dict) emit nothing. Once a second, fetch the
-  // root and every currently-expanded subtree, structurally compare the
-  // children, and patch just the drifted paths in place. Most ticks detect
-  // no change and are effectively free thanks to the kernel's dedicated
-  // read-only query thread (pdv.query_server). The next tick is scheduled
-  // only after the previous walk finishes, so slow walks never overlap.
+  // when `data` is a plain dict) emit nothing. Every tick revalidates the
+  // root and every expanded listing through the shared cache — in parallel,
+  // so a tick costs one round trip of wall-clock. Ticks are skipped while
+  // pushes are flowing (the push pipeline is proven live) and fetches that
+  // return unchanged data notify nothing (structural sharing + narrowed
+  // notifyOnChangeProps), so idle ticks cause zero re-renders. The next
+  // tick is scheduled only after the previous pass finishes.
   useEffect(() => {
     if (!kernelId || disabled) return;
     let cancelled = false;
     let timer: number | undefined;
 
     const pollOnce = async () => {
-      // Snapshot the paths to check at tick start so concurrent expansion
-      // changes during the poll don't matter.
-      const pathsToCheck = ['', ...expandedPathsRef.current];
-
-      for (const path of pathsToCheck) {
-        if (cancelled) return;
-        let fresh: TreeNodeData[];
-        try {
-          fresh =
-            path === ''
-              ? await treeService.getRootNodes(kernelId)
-              : await treeService.listByPath(kernelId, path);
-        } catch {
-          // Path may have been removed, or the kernel may be transiently
-          // unavailable — skip without disturbing the UI.
-          continue;
-        }
-        if (cancelled) return;
-
-        const currentNode =
-          path === '' ? nodesRef.current[0] : findNode(nodesRef.current, path);
-        const current = currentNode?.children ?? [];
-
-        if (childrenDiffer(current, fresh)) {
-          // Patch only the drifted path, preserving expansion state of
-          // surviving children — no full-depth refetch, no loading flash.
-          const merged = mergeChildren(fresh, current);
-          setNodes((prev) =>
-            updateNodeImmut(prev, path, (n) => ({ ...n, children: merged })),
-          );
-        }
-      }
+      if (msSinceTreePush() < TREE_PUSH_SUPPRESS_MS) return;
+      await pollTreeOnce(kernelId, expandedPathsRef.current);
     };
 
     const scheduleNext = () => {
@@ -251,7 +246,7 @@ export const Tree: React.FC<TreeProps> = ({ kernelId, disabled = false, refreshT
         void pollOnce().finally(() => {
           if (!cancelled) scheduleNext();
         });
-      }, 1000);
+      }, TREE_POLL_INTERVAL_MS);
     };
     scheduleNext();
     return () => {
@@ -260,118 +255,18 @@ export const Tree: React.FC<TreeProps> = ({ kernelId, disabled = false, refreshT
     };
   }, [kernelId, disabled]);
 
-  // Incremental tree update from push notifications — avoids full reload.
-  // Processes a queue of changes so rapid successive updates are not lost.
-  useEffect(() => {
-    if (!pendingChanges || pendingChanges.length === 0 || !kernelId || disabled) return;
-    // Consume this snapshot of the queue in one pass. Report exactly what
-    // was consumed so the owner removes only these entries — a change
-    // pushed between render and this effect must stay queued.
-    const changes = pendingChanges;
-    onChangesConsumed?.(changes);
-
-    // Collect all removals and parent paths to refresh across the batch.
-    const removals: string[] = [];
-    const parentsToRefresh = new Set<string>();
-
-    for (const { changed_paths, change_type } of changes) {
-      if (change_type === 'removed') {
-        removals.push(...changed_paths);
+  const handleExpand = useCallback((node: TreeNodeData) => {
+    if (!kernelId || disabled || !node.hasChildren) return;
+    setExpandedPaths((prev) => {
+      if (prev.has(node.path)) {
+        // Collapse: clear this path and all descendant expansions. Cached
+        // listings are retained, so re-expanding renders instantly.
+        return collapseSubtree(prev, node.path);
       }
-      for (const changedPath of changed_paths) {
-        const dotIdx = changedPath.lastIndexOf('.');
-        const parentPath = dotIdx > 0 ? changedPath.substring(0, dotIdx) : '';
-        // For batch, added, or updated: re-fetch the parent.
-        if (change_type !== 'removed') {
-          parentsToRefresh.add(parentPath);
-        }
-      }
-    }
-
-    // Apply removals synchronously.
-    if (removals.length > 0) {
-      setNodes((prev) => {
-        let updated = prev;
-        for (const path of removals) {
-          updated = removeNodeImmut(updated, path);
-        }
-        return updated;
-      });
-    }
-
-    // Re-fetch parents of added/updated paths (only if expanded).
-    if (parentsToRefresh.size > 0) {
-      const refreshParents = async () => {
-        for (const parentPath of parentsToRefresh) {
-          if (parentPath !== '' && !expandedPathsRef.current.has(parentPath)) continue;
-
-          // Read current nodes via ref to avoid stale closure.
-          const parentNode = parentPath === '' ? null : findNode(nodesRef.current, parentPath);
-          let freshChildren: TreeNodeData[];
-          if (parentPath === '') {
-            freshChildren = await treeService.getRootNodes(kernelId);
-          } else if (parentNode) {
-            freshChildren = await treeService.getChildren(parentNode, kernelId);
-          } else {
-            continue;
-          }
-
-          // Merge fresh children with existing ones to preserve expansion
-          // state. Fresh nodes from the API have isExpanded=false and no
-          // children; existing expanded nodes carry both.
-          const existingParent = parentPath === ''
-            ? nodesRef.current[0]
-            : findNode(nodesRef.current, parentPath);
-          const mergedChildren = mergeChildren(freshChildren, existingParent?.children);
-
-          if (parentPath === '') {
-            setNodes((prev) => updateNodeImmut(prev, '', (n) => ({ ...n, children: mergedChildren })));
-          } else {
-            setNodes((prev) => updateNodeImmut(prev, parentPath, (n) => ({ ...n, children: mergedChildren, isExpanded: true })));
-          }
-        }
-      };
-      void refreshParents();
-    }
-  }, [pendingChanges, kernelId, disabled, onChangesConsumed]);
-
-  const handleExpand = useCallback(async (node: TreeNodeData) => {
-    if (!kernelId || disabled) return;
-    if (node.isExpanded) {
-      // Collapse: discard children and clear all descendant expanded paths.
-      setNodes((prev) => updateNodeImmut(prev, node.path, (n) => ({ ...n, isExpanded: false, children: undefined })));
-      const prefix = node.path ? node.path + '.' : '';
-      for (const p of Array.from(expandedPathsRef.current)) {
-        if (p === node.path || (prefix && p.startsWith(prefix))) {
-          expandedPathsRef.current.delete(p);
-        }
-      }
-      return;
-    }
-
-    expandedPathsRef.current.add(node.path);
-    // Show spinner only if the fetch takes longer than 1s to avoid flashing.
-    const loadingTimer = setTimeout(() => {
-      setNodes((prev) => updateNodeImmut(prev, node.path, (n) => ({ ...n, isLoading: true })));
-    }, 1000);
-    try {
-      const children = await treeService.getChildren(node, kernelId);
-      clearTimeout(loadingTimer);
-      expandedPathsRef.current.add(node.path);
-      setNodes((prev) =>
-        updateNodeImmut(prev, node.path, (n) => ({
-          ...n,
-          isExpanded: true,
-          isLoading: false,
-          children,
-        })),
-      );
-    } catch (err) {
-      clearTimeout(loadingTimer);
-      console.error('[Tree] Failed to load children for', node.key, err);
-      setError(`Failed to load children for ${node.key}`);
-      setNodes((prev) => updateNodeImmut(prev, node.path, (n) => ({ ...n, isLoading: false })));
-    }
+      const next = new Set(prev);
+      next.add(node.path);
+      return next;
+    });
   }, [kernelId, disabled]);
 
   const handleDoubleClick = useCallback((node: TreeNodeData) => {
@@ -407,13 +302,16 @@ export const Tree: React.FC<TreeProps> = ({ kernelId, disabled = false, refreshT
     if (disabled) return;
     setContextMenu(null);
     if (action === 'refresh') {
-      void loadRoot();
+      if (kernelId) invalidateTree(kernelId);
       return;
     }
     onAction?.(action, node);
   };
 
-  const flatNodes = useMemo(() => flattenTree(nodes), [nodes]);
+  const flatNodes = useMemo(
+    () => flattenFromCache(childrenByPath, expandedPaths, loadingPaths),
+    [childrenByPath, expandedPaths, loadingPaths],
+  );
 
   const rowProps = useMemo<VirtualRowProps>(() => ({
     flatNodes,
@@ -472,16 +370,19 @@ export const Tree: React.FC<TreeProps> = ({ kernelId, disabled = false, refreshT
     if (event.key === 'ArrowRight' && selectedNode && !disabled) {
       event.preventDefault();
       if (selectedNode.hasChildren && !selectedNode.isExpanded) {
-        await handleExpand(selectedNode);
-      } else if (selectedNode.isExpanded && selectedNode.children && selectedNode.children.length > 0) {
-        setSelectedPath(selectedNode.children[0].path);
+        handleExpand(selectedNode);
+      } else if (selectedNode.isExpanded) {
+        const children = childrenByPath.get(selectedNode.path);
+        if (children && children.length > 0) {
+          setSelectedPath(children[0].path);
+        }
       }
       return;
     }
     if (event.key === 'ArrowLeft' && selectedNode && !disabled) {
       event.preventDefault();
       if (selectedNode.isExpanded && selectedNode.hasChildren) {
-        await handleExpand(selectedNode);
+        handleExpand(selectedNode);
       } else if (selectedNode.parentPath !== null) {
         // Step up to parent. parentPath of '' means the synthetic root row.
         setSelectedPath(selectedNode.parentPath);
@@ -558,4 +459,3 @@ export const Tree: React.FC<TreeProps> = ({ kernelId, disabled = false, refreshT
     </div>
   );
 };
-

--- a/electron/renderer/src/components/Tree/tree-utils.test.ts
+++ b/electron/renderer/src/components/Tree/tree-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { TreeNodeData } from '../../types';
-import { childrenDiffer, findNode, flattenTree, mergeChildren, updateNodeImmut } from './tree-utils';
+import { collapseSubtree, flattenFromCache } from './tree-utils';
 
 function makeNode(
   path: string,
@@ -19,157 +19,92 @@ function makeNode(
   };
 }
 
-describe('flattenTree', () => {
-  it('returns empty list for empty input', () => {
-    expect(flattenTree([])).toEqual([]);
+const NONE = new Set<string>();
+
+describe('flattenFromCache', () => {
+  it('always includes the synthetic root row', () => {
+    const rows = flattenFromCache(new Map(), NONE, NONE);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].path).toBe('');
+    expect(rows[0].key).toBe('pdv_tree');
+    expect(rows[0].depth).toBe(0);
+    expect(rows[0].isExpanded).toBe(true);
   });
 
-  it('returns flat nodes at depth 0', () => {
-    const nodes = [makeNode('a'), makeNode('b')];
-    const result = flattenTree(nodes);
-    expect(result).toHaveLength(2);
-    expect(result[0].depth).toBe(0);
-    expect(result[1].depth).toBe(0);
-    expect(result.map((n) => n.path)).toEqual(['a', 'b']);
+  it('renders root children at depth 1', () => {
+    const cache = new Map([['', [makeNode('a'), makeNode('b')]]]);
+    const rows = flattenFromCache(cache, NONE, NONE);
+    expect(rows.map((n) => n.path)).toEqual(['', 'a', 'b']);
+    expect(rows[1].depth).toBe(1);
+    expect(rows[2].depth).toBe(1);
   });
 
-  it('includes expanded children and omits collapsed children', () => {
-    const expanded = makeNode('a', {
-      isExpanded: true,
-      children: [makeNode('a.x')],
-    });
-    const collapsed = makeNode('b', {
-      isExpanded: false,
-      children: [makeNode('b.y')],
-    });
-    const result = flattenTree([expanded, collapsed]);
-    expect(result.map((n) => n.path)).toEqual(['a', 'a.x', 'b']);
-    expect(result.find((n) => n.path === 'a.x')?.depth).toBe(1);
+  it('includes children of expanded paths and omits collapsed ones', () => {
+    const cache = new Map([
+      ['', [makeNode('a', { hasChildren: true }), makeNode('b', { hasChildren: true })]],
+      ['a', [makeNode('a.x')]],
+      ['b', [makeNode('b.y')]],
+    ]);
+    const rows = flattenFromCache(cache, new Set(['a']), NONE);
+    expect(rows.map((n) => n.path)).toEqual(['', 'a', 'a.x', 'b']);
+    expect(rows.find((n) => n.path === 'a')?.isExpanded).toBe(true);
+    expect(rows.find((n) => n.path === 'b')?.isExpanded).toBe(false);
+    expect(rows.find((n) => n.path === 'a.x')?.depth).toBe(2);
   });
 
-  it('computes nested depths correctly', () => {
-    const nested = makeNode('root', {
-      isExpanded: true,
-      children: [
-        makeNode('root.child', {
-          isExpanded: true,
-          children: [makeNode('root.child.leaf')],
-        }),
-      ],
-    });
-    const result = flattenTree([nested]);
-    expect(result.find((n) => n.path === 'root')?.depth).toBe(0);
-    expect(result.find((n) => n.path === 'root.child')?.depth).toBe(1);
-    expect(result.find((n) => n.path === 'root.child.leaf')?.depth).toBe(2);
-  });
-});
-
-describe('findNode', () => {
-  const tree = [
-    makeNode('data', {
-      children: [makeNode('data.x'), makeNode('data.y', { children: [makeNode('data.y.z')] })],
-    }),
-  ];
-
-  it('finds root-level nodes', () => {
-    expect(findNode(tree, 'data')?.path).toBe('data');
+  it('treats an expanded path without cached children as expanded-but-empty', () => {
+    const cache = new Map([['', [makeNode('a', { hasChildren: true })]]]);
+    const rows = flattenFromCache(cache, new Set(['a']), NONE);
+    expect(rows.map((n) => n.path)).toEqual(['', 'a']);
+    expect(rows.find((n) => n.path === 'a')?.isExpanded).toBe(true);
   });
 
-  it('finds nested nodes', () => {
-    expect(findNode(tree, 'data.y.z')?.path).toBe('data.y.z');
+  it('never expands nodes without hasChildren, even if in the expansion set', () => {
+    const cache = new Map([
+      ['', [makeNode('a', { hasChildren: false })]],
+      ['a', [makeNode('a.ghost')]],
+    ]);
+    const rows = flattenFromCache(cache, new Set(['a']), NONE);
+    expect(rows.map((n) => n.path)).toEqual(['', 'a']);
+    expect(rows.find((n) => n.path === 'a')?.isExpanded).toBe(false);
   });
 
-  it('returns undefined when path does not exist', () => {
-    expect(findNode(tree, 'missing.path')).toBeUndefined();
-  });
-});
-
-describe('childrenDiffer', () => {
-  it('returns false for identical lists', () => {
-    expect(childrenDiffer([makeNode('a'), makeNode('b')], [makeNode('a'), makeNode('b')])).toBe(false);
+  it('marks loading paths', () => {
+    const cache = new Map([['', [makeNode('a', { hasChildren: true })]]]);
+    const rows = flattenFromCache(cache, new Set(['a']), new Set(['a']));
+    expect(rows.find((n) => n.path === 'a')?.isLoading).toBe(true);
   });
 
-  it('returns true on different length', () => {
-    expect(childrenDiffer([makeNode('a')], [makeNode('a'), makeNode('b')])).toBe(true);
-  });
-
-  it('returns true when a path is replaced', () => {
-    expect(childrenDiffer([makeNode('a')], [makeNode('b')])).toBe(true);
-  });
-
-  it('returns true when type changes', () => {
-    const a = makeNode('a', { type: 'folder' });
-    const b = makeNode('a', { type: 'script' });
-    expect(childrenDiffer([a], [b])).toBe(true);
-  });
-
-  it('returns true when preview changes (catches deep dict mutations)', () => {
-    const a = makeNode('a', { preview: '{x: 1}' });
-    const b = makeNode('a', { preview: '{x: 1, y: 2}' });
-    expect(childrenDiffer([a], [b])).toBe(true);
-  });
-
-  it('returns true when hasChildren flips', () => {
-    const a = makeNode('a', { hasChildren: false });
-    const b = makeNode('a', { hasChildren: true });
-    expect(childrenDiffer([a], [b])).toBe(true);
-  });
-
-  it('ignores ordering — equal sets compare equal', () => {
-    expect(
-      childrenDiffer([makeNode('a'), makeNode('b')], [makeNode('b'), makeNode('a')]),
-    ).toBe(false);
+  it('handles deep nesting with correct depths', () => {
+    const cache = new Map([
+      ['', [makeNode('r', { hasChildren: true })]],
+      ['r', [makeNode('r.c', { hasChildren: true })]],
+      ['r.c', [makeNode('r.c.leaf')]],
+    ]);
+    const rows = flattenFromCache(cache, new Set(['r', 'r.c']), NONE);
+    expect(rows.map((n) => [n.path, n.depth])).toEqual([
+      ['', 0],
+      ['r', 1],
+      ['r.c', 2],
+      ['r.c.leaf', 3],
+    ]);
   });
 });
 
-describe('updateNodeImmut', () => {
-  it('updates matching node and preserves unrelated references', () => {
-    const first = makeNode('a');
-    const second = makeNode('b');
-    const result = updateNodeImmut([first, second], 'a', (n) => ({ ...n, preview: 'updated' }));
-    expect(result[0].preview).toBe('updated');
-    expect(result[1]).toBe(second);
+describe('collapseSubtree', () => {
+  it('removes the path itself', () => {
+    expect(collapseSubtree(new Set(['a', 'b']), 'a')).toEqual(new Set(['b']));
   });
 
-  it('updates nested matching node', () => {
-    const parent = makeNode('a', {
-      children: [makeNode('a.child')],
-    });
-    const result = updateNodeImmut([parent], 'a.child', (n) => ({ ...n, preview: 'x' }));
-    expect(result[0].children?.[0].preview).toBe('x');
-  });
-});
-
-describe('mergeChildren', () => {
-  it('returns fresh list unchanged when nothing existed before', () => {
-    const fresh = [makeNode('a'), makeNode('b')];
-    expect(mergeChildren(fresh, undefined)).toBe(fresh);
-    expect(mergeChildren(fresh, [])).toBe(fresh);
+  it('removes all descendants but not similarly-prefixed siblings', () => {
+    const expanded = new Set(['a', 'a.x', 'a.x.y', 'ab', 'ab.z', 'b']);
+    expect(collapseSubtree(expanded, 'a')).toEqual(new Set(['ab', 'ab.z', 'b']));
   });
 
-  it('preserves expansion state and loaded children of surviving nodes', () => {
-    const grandchildren = [makeNode('a.x')];
-    const existing = [
-      makeNode('a', { isExpanded: true, children: grandchildren }),
-      makeNode('b'),
-    ];
-    const fresh = [
-      makeNode('a', { hasChildren: true, preview: 'updated' }),
-      makeNode('b', { preview: 'also updated' }),
-    ];
-    const merged = mergeChildren(fresh, existing);
-    expect(merged[0].isExpanded).toBe(true);
-    expect(merged[0].children).toBe(grandchildren);
-    expect(merged[0].preview).toBe('updated');
-    expect(merged[1].isExpanded).toBeUndefined();
-  });
-
-  it('drops removed nodes and adds new ones collapsed', () => {
-    const existing = [makeNode('gone', { isExpanded: true, children: [] })];
-    const fresh = [makeNode('new')];
-    const merged = mergeChildren(fresh, existing);
-    expect(merged).toHaveLength(1);
-    expect(merged[0].path).toBe('new');
-    expect(merged[0].isExpanded).toBeUndefined();
+  it('leaves unrelated paths untouched and does not mutate the input', () => {
+    const expanded = new Set(['a', 'b.c']);
+    const result = collapseSubtree(expanded, 'b.c');
+    expect(result).toEqual(new Set(['a']));
+    expect(expanded.has('b.c')).toBe(true);
   });
 });

--- a/electron/renderer/src/components/Tree/tree-utils.ts
+++ b/electron/renderer/src/components/Tree/tree-utils.ts
@@ -1,131 +1,91 @@
 /**
- * tree-utils.ts — pure tree helpers for flattened rendering and immutable updates.
+ * tree-utils.ts — pure helpers for flattened tree rendering.
  *
- * These utilities contain no React/runtime side effects and are shared between
- * Tree UI logic and unit tests.
+ * The Tree no longer owns a recursive node graph: listings live in the React
+ * Query cache as one flat children array per parent path, and expansion is a
+ * `Set<string>` of paths. Rendering composes those into depth-annotated rows
+ * here. No React/runtime side effects; shared with unit tests.
  */
 
 import type { TreeNodeData } from '../../types';
 
-/** Flatten an expanded tree into depth-annotated rows for table rendering. */
-export function flattenTree(
-  nodes: TreeNodeData[],
-  depth = 0,
-): Array<TreeNodeData & { depth: number }> {
-  const result: Array<TreeNodeData & { depth: number }> = [];
+/** A renderable row: a node descriptor annotated with its indent depth. */
+export type TreeRow = TreeNodeData & { depth: number };
 
-  for (const node of nodes) {
-    result.push({ ...node, depth });
-    if (node.isExpanded && node.children) {
-      result.push(...flattenTree(node.children, depth + 1));
-    }
-  }
-
-  return result;
-}
-
-/** Find a node by dot-path in a tree collection. */
-export function findNode(nodes: TreeNodeData[], path: string): TreeNodeData | undefined {
-  for (const node of nodes) {
-    if (node.path === path) return node;
-    if (node.children) {
-      const found = findNode(node.children, path);
-      if (found) return found;
-    }
-  }
-  return undefined;
-}
-
-/** Immutably remove a node by path from a tree collection. */
-export function removeNodeImmut(
-  list: TreeNodeData[],
-  path: string,
-): TreeNodeData[] {
-  let changed = false;
-  const result: TreeNodeData[] = [];
-
-  for (const node of list) {
-    if (node.path === path) {
-      changed = true;
-      continue; // skip this node (remove it)
-    }
-    if (node.children) {
-      const updatedChildren = removeNodeImmut(node.children, path);
-      if (updatedChildren !== node.children) {
-        result.push({ ...node, children: updatedChildren });
-        changed = true;
-        continue;
-      }
-    }
-    result.push(node);
-  }
-
-  return changed ? result : list;
+/** The always-present, right-clickable root row wrapping the whole tree. */
+export function syntheticRootRow(): TreeRow {
+  return {
+    id: '__root__',
+    key: 'pdv_tree',
+    path: '',
+    type: 'root',
+    preview: '',
+    hasChildren: true,
+    parentPath: null,
+    isExpanded: true,
+    isLoading: false,
+    depth: 0,
+  };
 }
 
 /**
- * Compare two child lists for visible structural difference.
+ * Compose the visible row list from cached listings and the expansion set.
  *
- * Returns true if a 1 Hz safety-net poll has detected drift the renderer
- * should re-render — i.e. a child was added, removed, or its visible
- * descriptor (key, type, hasChildren, preview) changed.
+ * A node renders as expanded when its path is in `expandedPaths` and it can
+ * have children; its children render beneath it once their listing is in
+ * `childrenByPath` (until then the node shows as expanded-but-empty, with a
+ * spinner if the fetch has been pending long enough to enter
+ * `loadingPaths`).
  *
- * Used to suppress no-op refreshes from idle polls. Push-driven updates
- * ride a separate code path and don't go through this comparison.
+ * @param childrenByPath - Cached children listing per parent path ('' = root).
+ * @param expandedPaths - Paths the user has expanded.
+ * @param loadingPaths - Paths whose pending fetch should show a spinner.
+ * @returns Rows in render order, starting with the synthetic root.
  */
-export function childrenDiffer(a: TreeNodeData[], b: TreeNodeData[]): boolean {
-  if (a.length !== b.length) return true;
-  const byPath = new Map<string, TreeNodeData>();
-  for (const node of a) byPath.set(node.path, node);
-  for (const node of b) {
-    const existing = byPath.get(node.path);
-    if (!existing) return true;
-    if (existing.key !== node.key) return true;
-    if (existing.type !== node.type) return true;
-    if (existing.hasChildren !== node.hasChildren) return true;
-    if (existing.preview !== node.preview) return true;
-  }
-  return false;
+export function flattenFromCache(
+  childrenByPath: ReadonlyMap<string, TreeNodeData[]>,
+  expandedPaths: ReadonlySet<string>,
+  loadingPaths: ReadonlySet<string>,
+): TreeRow[] {
+  const rows: TreeRow[] = [syntheticRootRow()];
+
+  const visit = (nodes: TreeNodeData[], depth: number): void => {
+    for (const node of nodes) {
+      const isExpanded = Boolean(node.hasChildren) && expandedPaths.has(node.path);
+      rows.push({
+        ...node,
+        depth,
+        isExpanded,
+        isLoading: loadingPaths.has(node.path),
+      });
+      if (isExpanded) {
+        const children = childrenByPath.get(node.path);
+        if (children) visit(children, depth + 1);
+      }
+    }
+  };
+
+  visit(childrenByPath.get('') ?? [], 1);
+  return rows;
 }
 
 /**
- * Merge freshly fetched children with the existing child list, preserving
- * per-node UI state the fetch cannot know about (expansion and already-loaded
- * grandchildren). Fresh nodes win on descriptor fields; nodes that no longer
- * exist are dropped; new nodes appear collapsed.
+ * Remove a path and all of its descendants from an expansion set.
+ *
+ * @param expanded - Current expansion set (not mutated).
+ * @param path - Path being collapsed or removed.
+ * @returns A new set without `path` or anything under it.
  */
-export function mergeChildren(
-  fresh: TreeNodeData[],
-  existing: TreeNodeData[] | undefined,
-): TreeNodeData[] {
-  if (!existing || existing.length === 0) return fresh;
-  const byPath = new Map<string, TreeNodeData>();
-  for (const node of existing) byPath.set(node.path, node);
-  return fresh.map((node) => {
-    const old = byPath.get(node.path);
-    if (old?.isExpanded && old.children) {
-      return { ...node, isExpanded: true, children: old.children };
-    }
-    return node;
-  });
-}
-
-/** Immutably update one node by path while preserving unrelated references. */
-export function updateNodeImmut(
-  list: TreeNodeData[],
+export function collapseSubtree(
+  expanded: ReadonlySet<string>,
   path: string,
-  updater: (n: TreeNodeData) => TreeNodeData,
-): TreeNodeData[] {
-  return list.map((node) => {
-    if (node.path === path) {
-      return updater(node);
-    }
-    if (node.children) {
-      const updatedChildren = updateNodeImmut(node.children, path, updater);
-      if (updatedChildren !== node.children) {
-        return { ...node, children: updatedChildren };
-      }
-    }
-    return node;
-  });
+): Set<string> {
+  const prefix = path ? `${path}.` : '';
+  const next = new Set<string>();
+  for (const p of expanded) {
+    if (p === path) continue;
+    if (prefix && p.startsWith(prefix)) continue;
+    next.add(p);
+  }
+  return next;
 }

--- a/electron/renderer/src/gui-editor-main.tsx
+++ b/electron/renderer/src/gui-editor-main.tsx
@@ -7,7 +7,9 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { GuiEditorRoot } from './gui-editor/GuiEditorRoot';
+import { queryClient } from './queries/client';
 import './styles/index.css';
 import './styles/gui-editor.css';
 
@@ -19,6 +21,8 @@ if (!rootElement) {
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <GuiEditorRoot />
+    <QueryClientProvider client={queryClient}>
+      <GuiEditorRoot />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/electron/renderer/src/gui-viewer-main.tsx
+++ b/electron/renderer/src/gui-viewer-main.tsx
@@ -7,7 +7,9 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { GuiViewerRoot } from './gui-viewer/GuiViewerRoot';
+import { queryClient } from './queries/client';
 import './styles/index.css';
 
 const rootElement = document.getElementById('root');
@@ -18,6 +20,8 @@ if (!rootElement) {
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <GuiViewerRoot />
+    <QueryClientProvider client={queryClient}>
+      <GuiViewerRoot />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/electron/renderer/src/hooks/useTreeAction.ts
+++ b/electron/renderer/src/hooks/useTreeAction.ts
@@ -1,21 +1,23 @@
 /**
  * useTreeAction — shared handler for tree context menu actions that follow
- * the pattern: call API → setLastError on failure / bump tree refresh on
- * success → close the dialog.
+ * the pattern: call API → setLastError on failure / invalidate the tree
+ * cache on success → close the dialog.
  */
 
 import { useCallback } from 'react';
+import { invalidateTree } from '../queries/invalidation';
 
 interface UseTreeActionOptions {
   setLastError: (error: string | undefined) => void;
-  setTreeRefreshToken: (fn: (t: number) => number) => void;
+  /** Active kernel whose tree cache is invalidated on success. */
+  kernelId: string | null;
 }
 
 /**
  * Returns a wrapper that executes an async tree API call and handles the
  * common success/error/refresh boilerplate.
  */
-export function useTreeAction({ setLastError, setTreeRefreshToken }: UseTreeActionOptions) {
+export function useTreeAction({ setLastError, kernelId }: UseTreeActionOptions) {
   return useCallback(
     async <T extends { success: boolean; error?: string }>(
       apiCall: () => Promise<T>,
@@ -25,8 +27,8 @@ export function useTreeAction({ setLastError, setTreeRefreshToken }: UseTreeActi
         const result = await apiCall();
         if (!result.success) {
           setLastError(result.error);
-        } else {
-          setTreeRefreshToken((t) => t + 1);
+        } else if (kernelId) {
+          invalidateTree(kernelId);
         }
       } catch (error) {
         setLastError(error instanceof Error ? error.message : String(error));
@@ -34,6 +36,6 @@ export function useTreeAction({ setLastError, setTreeRefreshToken }: UseTreeActi
         close();
       }
     },
-    [setLastError, setTreeRefreshToken],
+    [setLastError, kernelId],
   );
 }

--- a/electron/renderer/src/main.tsx
+++ b/electron/renderer/src/main.tsx
@@ -7,7 +7,9 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
 import App from './app';
+import { queryClient } from './queries/client';
 import './styles/index.css';
 
 const rootElement = document.getElementById('root');
@@ -18,6 +20,8 @@ if (!rootElement) {
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/electron/renderer/src/module-window-main.tsx
+++ b/electron/renderer/src/module-window-main.tsx
@@ -7,7 +7,9 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ModuleWindowRoot } from './module-window/ModuleWindowRoot';
+import { queryClient } from './queries/client';
 import './styles/index.css';
 
 const rootElement = document.getElementById('root');
@@ -18,6 +20,8 @@ if (!rootElement) {
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <ModuleWindowRoot />
+    <QueryClientProvider client={queryClient}>
+      <ModuleWindowRoot />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/electron/renderer/src/queries/client.ts
+++ b/electron/renderer/src/queries/client.ts
@@ -1,0 +1,49 @@
+/**
+ * client.ts — the renderer's singleton React Query client.
+ *
+ * All kernel/server state (tree listings, namespace queries, module lists,
+ * completion results, ...) flows through this client; UI-only state lives in
+ * the Zustand store (`../store`). Defaults here are tuned for a high-latency
+ * transport: every queryFn is one `window.pdv.*` round trip, which in remote
+ * mode is an SSH round trip, so refetches must be deliberate (push-driven
+ * invalidation via `./invalidation`) rather than ambient.
+ *
+ * This file does not define query keys (see `./keys`) or invalidation policy
+ * (see `./invalidation`).
+ */
+
+import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Stale-time constants, in milliseconds. Centralized so latency tuning is a
+ * one-file edit; the round-trip-budget e2e test is the measuring stick.
+ */
+export const STALE_TIMES = {
+  /** Tree listings: pushes invalidate promptly, so short is safe. */
+  tree: 2_000,
+  /** Monaco tree-path completions piggybacking on the tree cache. */
+  treeCompletion: 3_000,
+  /** Kernel code completions; invalidated on execute-finish. */
+  complete: 10_000,
+  /** Hover inspections; invalidated on execute-finish. */
+  inspectHover: 30_000,
+} as const;
+
+/** How long inactive query data is retained for instant re-expansion. */
+export const GC_TIME_MS = 5 * 60_000;
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: STALE_TIMES.tree,
+      gcTime: GC_TIME_MS,
+      retry: 1,
+      // Electron focus events are noisy and each refetch is a round trip;
+      // refetching is driven by push invalidation instead.
+      refetchOnWindowFocus: false,
+      // Reconnect invalidation is explicit (invalidateAllKernelState with
+      // reason 'reconnect'), not ambient.
+      refetchOnReconnect: false,
+    },
+  },
+});

--- a/electron/renderer/src/queries/invalidation.test.ts
+++ b/electron/renderer/src/queries/invalidation.test.ts
@@ -1,0 +1,183 @@
+/**
+ * invalidation.test.ts — unit tests for the query-key factory and the
+ * invalidation helpers against a real QueryClient.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { queryClient } from './client';
+import { keys, isKernelScopedKey } from './keys';
+import {
+  invalidateTree,
+  invalidateNamespace,
+  invalidateModules,
+  invalidateCompletions,
+  invalidateAllKernelState,
+  applyTreeChange,
+  parentTreePath,
+} from './invalidation';
+
+const K1 = 'kernel-1';
+const K2 = 'kernel-2';
+
+/** Seed the cache with fresh data under the given key. */
+function seed(queryKey: readonly unknown[]): void {
+  queryClient.setQueryData(queryKey as unknown[], { seeded: true });
+}
+
+function isStale(queryKey: readonly unknown[]): boolean {
+  const state = queryClient.getQueryState(queryKey as unknown[]);
+  if (!state) throw new Error(`no query state for ${JSON.stringify(queryKey)}`);
+  return state.isInvalidated;
+}
+
+beforeEach(() => {
+  queryClient.clear();
+});
+
+describe('keys', () => {
+  it('scopes kernel domains at index 1', () => {
+    expect(isKernelScopedKey(keys.tree(K1, 'a.b'), K1)).toBe(true);
+    expect(isKernelScopedKey(keys.tree(K1, 'a.b'), K2)).toBe(false);
+    expect(isKernelScopedKey(keys.namespaceInspect(K1, "df['col']"), K1)).toBe(true);
+    expect(isKernelScopedKey(['not-a-domain', K1], K1)).toBe(false);
+  });
+});
+
+describe('invalidateTree', () => {
+  it('invalidates one parent path without touching siblings or other kernels', () => {
+    seed(keys.tree(K1, ''));
+    seed(keys.tree(K1, 'a'));
+    seed(keys.tree(K1, 'b'));
+    seed(keys.tree(K2, 'a'));
+
+    invalidateTree(K1, 'a');
+
+    expect(isStale(keys.tree(K1, 'a'))).toBe(true);
+    expect(isStale(keys.tree(K1, ''))).toBe(false);
+    expect(isStale(keys.tree(K1, 'b'))).toBe(false);
+    expect(isStale(keys.tree(K2, 'a'))).toBe(false);
+  });
+
+  it('invalidates every listing for the kernel when path is omitted', () => {
+    seed(keys.tree(K1, ''));
+    seed(keys.tree(K1, 'a'));
+    seed(keys.tree(K2, ''));
+
+    invalidateTree(K1);
+
+    expect(isStale(keys.tree(K1, ''))).toBe(true);
+    expect(isStale(keys.tree(K1, 'a'))).toBe(true);
+    expect(isStale(keys.tree(K2, ''))).toBe(false);
+  });
+});
+
+describe('invalidateNamespace / invalidateModules / invalidateCompletions', () => {
+  it('covers both namespace domains', () => {
+    seed(keys.namespace(K1, 'h'));
+    seed(keys.namespaceInspect(K1, "df['col']"));
+    seed(keys.tree(K1, ''));
+
+    invalidateNamespace(K1);
+
+    expect(isStale(keys.namespace(K1, 'h'))).toBe(true);
+    expect(isStale(keys.namespaceInspect(K1, "df['col']"))).toBe(true);
+    expect(isStale(keys.tree(K1, ''))).toBe(false);
+  });
+
+  it('targets module listings only', () => {
+    seed(keys.modulesImported(K1));
+    seed(keys.tree(K1, ''));
+
+    invalidateModules(K1);
+
+    expect(isStale(keys.modulesImported(K1))).toBe(true);
+    expect(isStale(keys.tree(K1, ''))).toBe(false);
+  });
+
+  it('covers completion and hover caches', () => {
+    seed(keys.completion(K1, 'ctx'));
+    seed(keys.inspectHover(K1, 'expr'));
+
+    invalidateCompletions(K1);
+
+    expect(isStale(keys.completion(K1, 'ctx'))).toBe(true);
+    expect(isStale(keys.inspectHover(K1, 'expr'))).toBe(true);
+  });
+});
+
+describe('parentTreePath', () => {
+  it('returns the dot-parent, or root for top-level paths', () => {
+    expect(parentTreePath('a.b.c')).toBe('a.b');
+    expect(parentTreePath('a')).toBe('');
+  });
+});
+
+describe('applyTreeChange', () => {
+  const node = (path: string) => ({ path, key: path.split('.').at(-1) });
+
+  it("'removed' drops the node from its parent listing, purges the subtree, and invalidates the parent", () => {
+    seed(keys.tree(K1, 'a')); // parent listing
+    queryClient.setQueryData(keys.tree(K1, 'a') as unknown as unknown[], [node('a.b'), node('a.c')]);
+    seed(keys.tree(K1, 'a.b'));
+    seed(keys.tree(K1, 'a.b.deep'));
+    seed(keys.tree(K1, 'a.bogus')); // similarly-prefixed sibling must survive
+
+    applyTreeChange(K1, { changed_paths: ['a.b'], change_type: 'removed' });
+
+    expect(queryClient.getQueryData(keys.tree(K1, 'a') as unknown as unknown[])).toEqual([node('a.c')]);
+    expect(queryClient.getQueryState(keys.tree(K1, 'a.b') as unknown as unknown[])).toBeUndefined();
+    expect(queryClient.getQueryState(keys.tree(K1, 'a.b.deep') as unknown as unknown[])).toBeUndefined();
+    expect(queryClient.getQueryState(keys.tree(K1, 'a.bogus') as unknown as unknown[])).toBeDefined();
+    expect(isStale(keys.tree(K1, 'a'))).toBe(true);
+  });
+
+  it("'added'/'updated' invalidate only the changed parents", () => {
+    seed(keys.tree(K1, ''));
+    seed(keys.tree(K1, 'a'));
+    seed(keys.tree(K1, 'b'));
+
+    applyTreeChange(K1, { changed_paths: ['a.x', 'a.y', 'top'], change_type: 'added' });
+
+    expect(isStale(keys.tree(K1, 'a'))).toBe(true);
+    expect(isStale(keys.tree(K1, ''))).toBe(true); // parent of 'top'
+    expect(isStale(keys.tree(K1, 'b'))).toBe(false);
+  });
+
+  it("'unknown' invalidates every listing for the kernel", () => {
+    seed(keys.tree(K1, ''));
+    seed(keys.tree(K1, 'a'));
+    seed(keys.tree(K2, ''));
+
+    applyTreeChange(K1, { changed_paths: [], change_type: 'unknown' });
+
+    expect(isStale(keys.tree(K1, ''))).toBe(true);
+    expect(isStale(keys.tree(K1, 'a'))).toBe(true);
+    expect(isStale(keys.tree(K2, ''))).toBe(false);
+  });
+});
+
+describe('invalidateAllKernelState', () => {
+  it("removes the kernel's queries outright on kernel-switch", () => {
+    seed(keys.tree(K1, ''));
+    seed(keys.namespace(K1, 'h'));
+    seed(keys.tree(K2, ''));
+
+    invalidateAllKernelState(K1, 'kernel-switch');
+
+    expect(queryClient.getQueryState(keys.tree(K1, '') as unknown as unknown[])).toBeUndefined();
+    expect(queryClient.getQueryState(keys.namespace(K1, 'h') as unknown as unknown[])).toBeUndefined();
+    expect(queryClient.getQueryData(keys.tree(K2, '') as unknown as unknown[])).toEqual({ seeded: true });
+  });
+
+  it('invalidates (not removes) on reconnect', () => {
+    seed(keys.tree(K1, ''));
+    seed(keys.namespaceInspect(K1, 'df'));
+    seed(keys.tree(K2, ''));
+
+    invalidateAllKernelState(K1, 'reconnect');
+
+    expect(isStale(keys.tree(K1, ''))).toBe(true);
+    expect(isStale(keys.namespaceInspect(K1, 'df'))).toBe(true);
+    expect(isStale(keys.tree(K2, ''))).toBe(false);
+  });
+});

--- a/electron/renderer/src/queries/invalidation.ts
+++ b/electron/renderer/src/queries/invalidation.ts
@@ -1,0 +1,173 @@
+/**
+ * invalidation.ts — the single mapping from "something changed" to React
+ * Query cache invalidation.
+ *
+ * Push handlers (owned by App's useKernelSubscriptions) and mutation call
+ * sites call these functions instead of bumping refresh tokens. All
+ * invalidations are active-only (`refetchType: 'active'`): stale-but-inactive
+ * queries refetch lazily when their component mounts, so an invalidation
+ * never costs round trips for panels the user isn't looking at.
+ *
+ * This module is also the designated reconnect hook: when a remote session
+ * reattaches with a sequence gap (Phase 3), the reconnect handler calls
+ * `invalidateAllKernelState(kernelId, 'reconnect')` here and nothing else.
+ */
+
+import { queryClient } from './client';
+import { keys, isKernelScopedKey } from './keys';
+import type { TreeChangeInfo } from '../types';
+import type { TreeNodeData } from '../services/tree';
+
+/** Why a whole-kernel invalidation is happening; logged for diagnosis. */
+export type KernelInvalidationReason = 'kernel-switch' | 'project-load' | 'reconnect';
+
+/** Wall-clock of the most recent `tree.onChanged` push (0 = never). */
+let lastTreePushAt = 0;
+
+/** Record that a tree push just arrived (suppresses the safety-net poll). */
+export function noteTreePushActivity(): void {
+  lastTreePushAt = Date.now();
+}
+
+/** Milliseconds since the last tree push (Infinity if none yet). */
+export function msSinceTreePush(): number {
+  return lastTreePushAt === 0 ? Infinity : Date.now() - lastTreePushAt;
+}
+
+/**
+ * Parent path of a dot-separated tree path ('' for top-level entries).
+ *
+ * @param path - Absolute tree path like 'a.b.c'.
+ * @returns 'a.b' for 'a.b.c'; '' for 'a'.
+ */
+export function parentTreePath(path: string): string {
+  const dotIdx = path.lastIndexOf('.');
+  return dotIdx > 0 ? path.substring(0, dotIdx) : '';
+}
+
+/**
+ * Translate one `tree.onChanged` push into targeted cache updates.
+ *
+ * - 'removed': drop the node from its parent's cached listing immediately
+ *   (0 round trips), purge cached listings under the removed subtree, then
+ *   invalidate the parent as reconciliation.
+ * - 'added' | 'updated' | 'batch': invalidate each changed path's parent
+ *   listing (active-only — unexpanded parents refetch lazily on expansion).
+ * - 'unknown' (non-root PDVTree mutation, unmappable path): invalidate every
+ *   listing for the kernel; active ones refetch in parallel.
+ *
+ * @param kernelId - Kernel the push came from.
+ * @param change - The push payload.
+ */
+export function applyTreeChange(kernelId: string, change: TreeChangeInfo): void {
+  noteTreePushActivity();
+  if (change.change_type === 'unknown') {
+    invalidateTree(kernelId);
+    return;
+  }
+  if (change.change_type === 'removed') {
+    for (const removed of change.changed_paths) {
+      const parent = parentTreePath(removed);
+      queryClient.setQueryData<TreeNodeData[]>(
+        keys.tree(kernelId, parent),
+        (old) => old?.filter((n) => n.path !== removed),
+      );
+      queryClient.removeQueries({
+        predicate: (query) => {
+          const k = query.queryKey;
+          return (
+            k[0] === 'tree' &&
+            k[1] === kernelId &&
+            typeof k[2] === 'string' &&
+            (k[2] === removed || k[2].startsWith(`${removed}.`))
+          );
+        },
+      });
+      invalidateTree(kernelId, parent);
+    }
+    return;
+  }
+  const parents = new Set(change.changed_paths.map(parentTreePath));
+  for (const parent of parents) {
+    invalidateTree(kernelId, parent);
+  }
+}
+
+/**
+ * Invalidate tree listings for a kernel — one parent path, or all of them.
+ *
+ * @param kernelId - Kernel whose tree cache is stale.
+ * @param path - Parent path whose children changed; omit to invalidate every
+ *   cached listing (root + all expanded, refetched in parallel).
+ */
+export function invalidateTree(kernelId: string, path?: string): void {
+  void queryClient.invalidateQueries({
+    queryKey: path === undefined ? keys.treeAll(kernelId) : keys.tree(kernelId, path),
+    refetchType: 'active',
+  });
+}
+
+/**
+ * Invalidate namespace state (top-level query and expanded-node inspections).
+ *
+ * @param kernelId - Kernel whose namespace changed (typically post-execution).
+ */
+export function invalidateNamespace(kernelId: string): void {
+  void queryClient.invalidateQueries({
+    queryKey: keys.namespaceAll(kernelId),
+    refetchType: 'active',
+  });
+  void queryClient.invalidateQueries({
+    queryKey: keys.namespaceInspectAll(kernelId),
+    refetchType: 'active',
+  });
+}
+
+/**
+ * Invalidate module listings for a kernel.
+ *
+ * @param kernelId - Kernel whose imported/available modules changed.
+ */
+export function invalidateModules(kernelId: string): void {
+  void queryClient.invalidateQueries({
+    queryKey: keys.modulesAll(kernelId),
+    refetchType: 'active',
+  });
+}
+
+/**
+ * Invalidate Monaco completion/hover caches — the kernel namespace changed,
+ * so cached completions and inspections are stale.
+ *
+ * @param kernelId - Kernel that finished executing.
+ */
+export function invalidateCompletions(kernelId: string): void {
+  void queryClient.invalidateQueries({ queryKey: keys.completionAll(kernelId) });
+  void queryClient.invalidateQueries({ queryKey: keys.inspectHoverAll(kernelId) });
+}
+
+/**
+ * Invalidate or drop everything scoped to a kernel.
+ *
+ * 'kernel-switch' removes queries outright (no refetch storm for a kernel
+ * that is going away); 'project-load' and 'reconnect' invalidate active
+ * queries so visible panels refetch in parallel.
+ *
+ * @param kernelId - Kernel whose state is affected.
+ * @param reason - What happened; controls remove-vs-invalidate.
+ */
+export function invalidateAllKernelState(
+  kernelId: string,
+  reason: KernelInvalidationReason,
+): void {
+  if (reason === 'kernel-switch') {
+    queryClient.removeQueries({
+      predicate: (query) => isKernelScopedKey(query.queryKey, kernelId),
+    });
+    return;
+  }
+  void queryClient.invalidateQueries({
+    predicate: (query) => isKernelScopedKey(query.queryKey, kernelId),
+    refetchType: 'active',
+  });
+}

--- a/electron/renderer/src/queries/keys.ts
+++ b/electron/renderer/src/queries/keys.ts
@@ -1,0 +1,79 @@
+/**
+ * keys.ts — the single query-key factory for all React Query keys.
+ *
+ * Conventions:
+ *  - Index 0 is a domain string; kernel-scoped keys carry the kernel id at
+ *    index 1, so "everything for this kernel" is one predicate
+ *    (`isKernelScopedKey` below, used by invalidateAllKernelState).
+ *  - Components and providers never build key arrays inline — always through
+ *    this factory, so invalidation stays targeted and greppable.
+ */
+
+/** Domains whose keys are kernel-scoped (kernel id at index 1). */
+const KERNEL_SCOPED_DOMAINS = new Set([
+  'tree',
+  'tree-version',
+  'namespace',
+  'namespace-inspect',
+  'modules',
+  'completion',
+  'inspect-hover',
+]);
+
+export const keys = {
+  /** Children of one tree parent path ('' = root). */
+  tree: (kernelId: string, path: string) => ['tree', kernelId, path] as const,
+  /** Prefix key covering every tree listing for a kernel. */
+  treeAll: (kernelId: string) => ['tree', kernelId] as const,
+  /** Kernel-side tree version counter (poll demotion, Step 6). */
+  treeVersion: (kernelId: string) => ['tree-version', kernelId] as const,
+  /** Top-level namespace query; filtersHash distinguishes filter settings. */
+  namespace: (kernelId: string, filtersHash: string) =>
+    ['namespace', kernelId, filtersHash] as const,
+  namespaceAll: (kernelId: string) => ['namespace', kernelId] as const,
+  /** One expanded namespace node's children, keyed by its full expression. */
+  namespaceInspect: (kernelId: string, expression: string) =>
+    ['namespace-inspect', kernelId, expression] as const,
+  namespaceInspectAll: (kernelId: string) => ['namespace-inspect', kernelId] as const,
+  /** Imported/installed module listings. */
+  modulesImported: (kernelId: string) => ['modules', kernelId, 'imported'] as const,
+  modulesAll: (kernelId: string) => ['modules', kernelId] as const,
+  /** Monaco kernel completions (fetchQuery-only; never mounted). */
+  completion: (kernelId: string, contextHash: string) =>
+    ['completion', kernelId, contextHash] as const,
+  completionAll: (kernelId: string) => ['completion', kernelId] as const,
+  /** Monaco hover inspections (fetchQuery-only; never mounted). */
+  inspectHover: (kernelId: string, expressionHash: string) =>
+    ['inspect-hover', kernelId, expressionHash] as const,
+  inspectHoverAll: (kernelId: string) => ['inspect-hover', kernelId] as const,
+} as const;
+
+/**
+ * Cheap stable hash (djb2) for long strings used inside query keys, so keys
+ * stay short while still varying with their source text.
+ *
+ * @param text - Arbitrary string (e.g. editor contents up to the cursor).
+ * @returns An unsigned-int hash rendered as a base-36 string.
+ */
+export function stableHash(text: string): string {
+  let hash = 5381;
+  for (let i = 0; i < text.length; i++) {
+    hash = ((hash << 5) + hash + text.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+/**
+ * Predicate matching every key scoped to the given kernel.
+ *
+ * @param queryKey - A query's key array.
+ * @param kernelId - The kernel whose state is being targeted.
+ * @returns true when the key belongs to a kernel-scoped domain for kernelId.
+ */
+export function isKernelScopedKey(queryKey: readonly unknown[], kernelId: string): boolean {
+  return (
+    typeof queryKey[0] === 'string' &&
+    KERNEL_SCOPED_DOMAINS.has(queryKey[0]) &&
+    queryKey[1] === kernelId
+  );
+}

--- a/electron/renderer/src/queries/tree.test.ts
+++ b/electron/renderer/src/queries/tree.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+/**
+ * tree.test.ts — unit tests for the version-based safety-net poll.
+ *
+ * Pins the round-trip discipline: with the version channel, an idle poll
+ * tick is exactly one `tree.getVersion` call (no listings); a version bump
+ * invalidates cached listings; kernels without the channel are detected
+ * once and polled by listing thereafter.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { installPdvMock, type PdvMock } from '../test-fixtures/pdv-mock';
+import { queryClient } from './client';
+import { keys } from './keys';
+import { pollTreeOnce } from './tree';
+
+let pdv: PdvMock;
+
+beforeEach(() => {
+  queryClient.clear();
+  pdv = installPdvMock();
+});
+
+function isStale(kernelId: string, path: string): boolean {
+  const state = queryClient.getQueryState(keys.tree(kernelId, path) as unknown as unknown[]);
+  if (!state) throw new Error('no query state');
+  return state.isInvalidated;
+}
+
+describe('pollTreeOnce', () => {
+  it('costs one getVersion call and nothing else while the version is unchanged', async () => {
+    const kid = 'k-idle';
+    pdv.tree.getVersion.mockResolvedValue(7);
+    queryClient.setQueryData(keys.tree(kid, '') as unknown as unknown[], []);
+    queryClient.setQueryData(keys.tree(kid, 'a') as unknown as unknown[], []);
+
+    await pollTreeOnce(kid, ['a']); // baseline tick
+    await pollTreeOnce(kid, ['a']); // idle tick
+
+    expect(pdv.tree.getVersion).toHaveBeenCalledTimes(2);
+    expect(pdv.tree.list).not.toHaveBeenCalled();
+    expect(isStale(kid, '')).toBe(false);
+    expect(isStale(kid, 'a')).toBe(false);
+  });
+
+  it('invalidates every cached listing when the version moves', async () => {
+    const kid = 'k-moved';
+    queryClient.setQueryData(keys.tree(kid, '') as unknown as unknown[], []);
+    queryClient.setQueryData(keys.tree(kid, 'a') as unknown as unknown[], []);
+
+    pdv.tree.getVersion.mockResolvedValueOnce(1);
+    await pollTreeOnce(kid, ['a']); // baseline
+    pdv.tree.getVersion.mockResolvedValueOnce(2);
+    await pollTreeOnce(kid, ['a']);
+
+    expect(isStale(kid, '')).toBe(true);
+    expect(isStale(kid, 'a')).toBe(true);
+    expect(pdv.tree.list).not.toHaveBeenCalled();
+  });
+
+  it('falls back to parallel listing revalidation for kernels without the channel', async () => {
+    const kid = 'k-legacy';
+    pdv.tree.getVersion.mockResolvedValue(null);
+    pdv.tree.list.mockResolvedValue([]);
+
+    await pollTreeOnce(kid, ['a', 'b']);
+    // Root + both expanded paths were revalidated through the cache.
+    expect(pdv.tree.list).toHaveBeenCalledTimes(3);
+
+    // The unsupported result is remembered: later ticks skip getVersion.
+    await pollTreeOnce(kid, ['a', 'b']);
+    expect(pdv.tree.getVersion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/renderer/src/queries/tree.ts
+++ b/electron/renderer/src/queries/tree.ts
@@ -1,0 +1,134 @@
+/**
+ * queries/tree.ts — React Query hooks and fetchers for tree listings.
+ *
+ * One query per listed parent path, keyed `['tree', kernelId, path]`. The
+ * Tree panel mounts one query for the root plus one per expanded path, so a
+ * whole-tree invalidation refetches every visible level in parallel (≈1
+ * round trip of wall-clock) instead of the old serial walk. Monaco tree-path
+ * completions and the safety-net poll share this cache via
+ * {@link fetchTreeChildren}.
+ */
+
+import { useQueries } from '@tanstack/react-query';
+import { queryClient, STALE_TIMES } from './client';
+import { keys } from './keys';
+import { invalidateTree } from './invalidation';
+import { treeService, type TreeNodeData } from '../services/tree';
+
+/** Safety-net poll cadence (was 1 s serial-per-level; now one parallel pass). */
+export const TREE_POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Freshness bar for poll-driven fetches: data refetched within this window
+ * (e.g. by a push invalidation) is reused, so a poll tick right after a push
+ * costs nothing.
+ */
+export const TREE_POLL_STALE_MS = 1_000;
+
+/**
+ * How long after a `tree.onChanged` push the poll stays quiet — a live push
+ * pipeline proves the change stream works, so polling on top is redundant.
+ */
+export const TREE_PUSH_SUPPRESS_MS = 2_000;
+
+/**
+ * Mount one children-listing query per path.
+ *
+ * `notifyOnChangeProps: ['data', 'error']` keeps no-op poll ticks free: a
+ * background refetch that returns structurally identical data (same object
+ * identity thanks to structural sharing) notifies nothing and re-renders
+ * nothing.
+ *
+ * @param kernelId - Active kernel, or null (queries disabled).
+ * @param paths - Parent paths to list ('' = root). Order defines result order.
+ * @param enabled - Master enable (false while kernel is starting).
+ * @returns One query result per path, in the same order.
+ */
+export function useTreeChildrenQueries(
+  kernelId: string | null,
+  paths: readonly string[],
+  enabled: boolean,
+) {
+  return useQueries({
+    queries: paths.map((path) => ({
+      queryKey: keys.tree(kernelId ?? '__no-kernel__', path),
+      queryFn: () => treeService.listByPath(kernelId, path),
+      enabled: enabled && kernelId !== null,
+      staleTime: STALE_TIMES.tree,
+      notifyOnChangeProps: ['data', 'error'] as const,
+    })),
+  });
+}
+
+/**
+ * Fetch (or reuse fresh) children for one path through the shared cache.
+ *
+ * @param kernelId - Active kernel.
+ * @param path - Parent path to list ('' = root).
+ * @param staleTime - Freshness bar; cached data younger than this is
+ *   returned without a network hop.
+ * @returns The children listing.
+ * @throws Whatever `window.pdv.tree.list` throws (e.g. removed path).
+ */
+export function fetchTreeChildren(
+  kernelId: string,
+  path: string,
+  staleTime: number = TREE_POLL_STALE_MS,
+): Promise<TreeNodeData[]> {
+  return queryClient.fetchQuery({
+    queryKey: keys.tree(kernelId, path),
+    queryFn: () => treeService.listByPath(kernelId, path),
+    staleTime,
+  });
+}
+
+/**
+ * Per-kernel state for the version-based poll: whether the kernel supports
+ * `pdv.tree.version`, and the last version seen. Entries are tiny and never
+ * need explicit cleanup.
+ */
+const versionPollState = new Map<string, { supported: boolean; lastVersion: number | null }>();
+
+/**
+ * One safety-net poll tick.
+ *
+ * Preferred path (kernels with the version channel): a single
+ * `tree.getVersion` round trip; when the counter moved, invalidate every
+ * cached listing so visible levels refetch in parallel. Fallback path
+ * (older kernels): revalidate the root and every expanded listing through
+ * the shared cache, in parallel.
+ *
+ * @param kernelId - Active kernel.
+ * @param expandedPaths - Currently expanded paths (fallback path only).
+ */
+export async function pollTreeOnce(
+  kernelId: string,
+  expandedPaths: Iterable<string>,
+): Promise<void> {
+  const state = versionPollState.get(kernelId) ?? { supported: true, lastVersion: null };
+  if (state.supported) {
+    let version: number | null = null;
+    try {
+      version = await window.pdv.tree.getVersion(kernelId);
+    } catch {
+      version = null;
+    }
+    if (version !== null) {
+      const changed = state.lastVersion !== null && version !== state.lastVersion;
+      versionPollState.set(kernelId, { supported: true, lastVersion: version });
+      if (changed) invalidateTree(kernelId);
+      return;
+    }
+    // Feature-detect once per kernel: null means the kernel predates the
+    // version channel (or the query socket is down) — poll by listing.
+    versionPollState.set(kernelId, { supported: false, lastVersion: null });
+  }
+  await Promise.all(
+    ['', ...expandedPaths].map((path) =>
+      fetchTreeChildren(kernelId, path).catch(() => {
+        // Path may have been removed, or the kernel may be transiently
+        // unavailable — skip without disturbing the UI.
+      }),
+    ),
+  );
+}

--- a/electron/renderer/src/services/tree.ts
+++ b/electron/renderer/src/services/tree.ts
@@ -2,12 +2,11 @@
  * tree.ts — Renderer-side tree data access service.
  *
  * Thin adapter over `window.pdv.tree.list` that converts wire-format
- * descriptors into renderer `TreeNodeData` objects. Deliberately uncached:
- * every call returns freshly fetched, freshly built objects, so callers can
- * tag UI state (`isExpanded`, `children`) onto the results without aliasing
- * data seen by other callers, and no consumer ever renders stale structure.
- * Listing goes through the kernel's dedicated read-only query thread
- * (pdv.query_server), so fetches stay fast even mid-execution.
+ * descriptors into renderer `TreeNodeData` objects. This layer itself never
+ * caches — it is the queryFn layer for `queries/tree.ts`, where caching and
+ * invalidation live with principled push-driven invalidation. Listing goes
+ * through the kernel's dedicated read-only query thread (pdv.query_server),
+ * so fetches stay fast even mid-execution.
  */
 
 import type { NodeDescriptor } from '../types/pdv';

--- a/electron/renderer/src/store/consoleSlice.ts
+++ b/electron/renderer/src/store/consoleSlice.ts
@@ -1,0 +1,28 @@
+/**
+ * consoleSlice.ts — console execution-history log entries.
+ *
+ * The log list lives in the store so only the Console panel re-renders on
+ * output: App used to hold it in useState, which re-rendered the entire app
+ * on every 16 ms output flush during streaming executions. `setLogs` keeps
+ * the React `Dispatch<SetStateAction<...>>` shape so hooks that receive it
+ * as a prop (subscriptions, note tabs, project workflow) are unchanged.
+ */
+
+import type { LogEntry } from '../types';
+import type { AppSlice } from './index';
+
+export interface ConsoleSlice {
+  logs: LogEntry[];
+  /** React-setter-compatible updater (accepts a value or a function). */
+  setLogs: (update: LogEntry[] | ((prev: LogEntry[]) => LogEntry[])) => void;
+  clearLogs: () => void;
+}
+
+export const createConsoleSlice: AppSlice<ConsoleSlice> = (set) => ({
+  logs: [],
+  setLogs: (update) =>
+    set((state) => ({
+      logs: typeof update === 'function' ? update(state.logs) : update,
+    })),
+  clearLogs: () => set({ logs: [] }),
+});

--- a/electron/renderer/src/store/dialogSlice.ts
+++ b/electron/renderer/src/store/dialogSlice.ts
@@ -1,0 +1,95 @@
+/**
+ * dialogSlice.ts — app-level modal state.
+ *
+ * One dialog at a time: every app-level dialog is a variant of the
+ * `ActiveDialog` union, so opening one implicitly closes the previous.
+ * `closeTopmost` encodes the whole Escape priority in one place:
+ * unsaved-changes confirm first, then the active dialog. SettingsDialog
+ * stays outside the union (it suppresses Escape while recording shortcuts)
+ * but its visibility lives here; the welcome overlay is not
+ * Escape-dismissible and stays with the welcome state.
+ */
+
+import type { TreeNodeData } from '../types';
+import type { AppSlice } from './index';
+
+/** Union of all app-level modals that occupy the single dialog slot. */
+export type ActiveDialog =
+  | { kind: 'script'; node: TreeNodeData }
+  | { kind: 'rename'; path: string; nodeKey: string }
+  | { kind: 'move'; path: string; nodeType: string }
+  | { kind: 'duplicate'; path: string; nodeType: string }
+  | { kind: 'createNode'; parentPath: string }
+  | { kind: 'createScript'; parentPath: string }
+  | { kind: 'createNote'; parentPath: string }
+  | { kind: 'createGui'; parentPath: string }
+  | { kind: 'createLib'; parentPath: string }
+  | { kind: 'newModule' }
+  | {
+      kind: 'moduleMetadata';
+      alias: string;
+      name: string;
+      version: string;
+      description?: string;
+      language?: 'python' | 'julia';
+    }
+  | { kind: 'importModule' }
+  | { kind: 'saveAs' }
+  | { kind: 'newProject' }
+  | { kind: 'newJuliaProject' };
+
+export type SettingsTab = 'general' | 'shortcuts' | 'appearance' | 'runtime' | 'about';
+
+export interface DialogSlice {
+  activeDialog: ActiveDialog | null;
+  showSettings: boolean;
+  settingsInitialTab: SettingsTab;
+  /** Pending destructive action awaiting the unsaved-changes confirm. */
+  pendingDirtyAction: { label: string; run: () => void } | null;
+  /** React-setter-compatible updater (accepts a value or a function). */
+  setActiveDialog: (
+    update: ActiveDialog | null | ((prev: ActiveDialog | null) => ActiveDialog | null),
+  ) => void;
+  closeDialog: () => void;
+  /** Open Settings, optionally on a specific tab. */
+  openSettings: (tab?: SettingsTab) => void;
+  setShowSettings: (visible: boolean) => void;
+  setPendingDirtyAction: (action: { label: string; run: () => void } | null) => void;
+  /**
+   * Close the highest-priority open modal (unsaved-changes confirm, then the
+   * active dialog). Returns true if something was closed — the global Escape
+   * handler uses this to decide whether to swallow the key.
+   */
+  closeTopmost: () => boolean;
+}
+
+export const createDialogSlice: AppSlice<DialogSlice> = (set, get) => ({
+  activeDialog: null,
+  showSettings: false,
+  settingsInitialTab: 'general',
+  pendingDirtyAction: null,
+  setActiveDialog: (update) =>
+    set((state) => ({
+      activeDialog: typeof update === 'function' ? update(state.activeDialog) : update,
+    })),
+  closeDialog: () => set({ activeDialog: null }),
+  openSettings: (tab) =>
+    set((state) => ({
+      showSettings: true,
+      settingsInitialTab: tab ?? state.settingsInitialTab,
+    })),
+  setShowSettings: (visible) => set({ showSettings: visible }),
+  setPendingDirtyAction: (action) => set({ pendingDirtyAction: action }),
+  closeTopmost: () => {
+    const { pendingDirtyAction, activeDialog } = get();
+    if (pendingDirtyAction) {
+      set({ pendingDirtyAction: null });
+      return true;
+    }
+    if (activeDialog) {
+      set({ activeDialog: null });
+      return true;
+    }
+    return false;
+  },
+});

--- a/electron/renderer/src/store/index.ts
+++ b/electron/renderer/src/store/index.ts
@@ -1,0 +1,30 @@
+/**
+ * store/index.ts — the renderer's shared Zustand store.
+ *
+ * Discipline rule (#233, non-negotiable): shared state goes in the store,
+ * local component state stays `useState`. A button's hover state is
+ * `useState`; the active project's dirty flag is the store. Kernel/server
+ * data is NOT store state — it lives in React Query (`../queries`).
+ *
+ * Slices are composed here; each slice lives in its own file as an
+ * {@link AppSlice}. Store actions are identity-stable, so they can be passed
+ * where React state setters were expected without churning effect deps.
+ */
+
+import { create } from 'zustand';
+import type { StateCreator } from 'zustand';
+import { createConsoleSlice, type ConsoleSlice } from './consoleSlice';
+import { createDialogSlice, type DialogSlice } from './dialogSlice';
+import { createSessionSlice, type SessionSlice } from './sessionSlice';
+
+/** Union of all slice shapes; extended as slices land. */
+export type AppStore = ConsoleSlice & DialogSlice & SessionSlice;
+
+/** Helper type for defining a slice against the full store. */
+export type AppSlice<T> = StateCreator<AppStore, [], [], T>;
+
+export const useStore = create<AppStore>()((...args) => ({
+  ...createConsoleSlice(...args),
+  ...createDialogSlice(...args),
+  ...createSessionSlice(...args),
+}));

--- a/electron/renderer/src/store/sessionSlice.ts
+++ b/electron/renderer/src/store/sessionSlice.ts
@@ -1,0 +1,30 @@
+/**
+ * sessionSlice.ts — session-level connection state.
+ *
+ * `connectionState` is the renderer surface for remote mode (roadmap Phase
+ * 3): 'local' today, driven by the SSH connection state machine once remote
+ * sessions land. StatusBar subscribes and renders nothing for 'local'.
+ *
+ * The remaining session fields (kernel id/status, project dir/name, dirty
+ * flag) still live in App's useState and migrate here incrementally — they
+ * are threaded through hook option bags whose rewiring is deliberately kept
+ * out of the latency-focused steps.
+ */
+
+import type { AppSlice } from './index';
+
+export type ConnectionState =
+  | 'local'
+  | 'remote-connected'
+  | 'remote-reconnecting'
+  | 'remote-lost';
+
+export interface SessionSlice {
+  connectionState: ConnectionState;
+  setConnectionState: (state: ConnectionState) => void;
+}
+
+export const createSessionSlice: AppSlice<SessionSlice> = (set) => ({
+  connectionState: 'local',
+  setConnectionState: (connectionState) => set({ connectionState }),
+});

--- a/electron/renderer/src/store/store.test.ts
+++ b/electron/renderer/src/store/store.test.ts
@@ -1,0 +1,68 @@
+/**
+ * store.test.ts — unit tests for the shared Zustand store slices.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useStore } from './index';
+
+const initialState = useStore.getState();
+
+beforeEach(() => {
+  useStore.setState(initialState, true);
+});
+
+describe('dialogSlice.closeTopmost', () => {
+  it('closes the unsaved-changes confirm before the active dialog', () => {
+    useStore.setState({
+      activeDialog: { kind: 'saveAs' },
+      pendingDirtyAction: { label: 'exit', run: vi.fn() },
+    });
+
+    expect(useStore.getState().closeTopmost()).toBe(true);
+    expect(useStore.getState().pendingDirtyAction).toBeNull();
+    expect(useStore.getState().activeDialog).toEqual({ kind: 'saveAs' });
+
+    expect(useStore.getState().closeTopmost()).toBe(true);
+    expect(useStore.getState().activeDialog).toBeNull();
+
+    expect(useStore.getState().closeTopmost()).toBe(false);
+  });
+
+  it('openSettings sets visibility and optionally the tab', () => {
+    useStore.getState().openSettings('runtime');
+    expect(useStore.getState().showSettings).toBe(true);
+    expect(useStore.getState().settingsInitialTab).toBe('runtime');
+
+    useStore.getState().setShowSettings(false);
+    useStore.getState().openSettings();
+    // Tab preserved when not specified.
+    expect(useStore.getState().settingsInitialTab).toBe('runtime');
+  });
+
+  it('setActiveDialog supports functional updates', () => {
+    useStore.getState().setActiveDialog({ kind: 'newModule' });
+    useStore
+      .getState()
+      .setActiveDialog((prev) => (prev?.kind === 'newModule' ? null : prev));
+    expect(useStore.getState().activeDialog).toBeNull();
+  });
+});
+
+describe('consoleSlice', () => {
+  it('setLogs accepts values and updaters; clearLogs empties', () => {
+    const entry = { id: 'a', timestamp: 0, code: '' };
+    useStore.getState().setLogs([entry]);
+    useStore.getState().setLogs((prev) => [...prev, { ...entry, id: 'b' }]);
+    expect(useStore.getState().logs.map((l) => l.id)).toEqual(['a', 'b']);
+    useStore.getState().clearLogs();
+    expect(useStore.getState().logs).toEqual([]);
+  });
+});
+
+describe('sessionSlice', () => {
+  it('defaults to local and updates connection state', () => {
+    expect(useStore.getState().connectionState).toBe('local');
+    useStore.getState().setConnectionState('remote-reconnecting');
+    expect(useStore.getState().connectionState).toBe('remote-reconnecting');
+  });
+});

--- a/electron/renderer/src/styles/editor.css
+++ b/electron/renderer/src/styles/editor.css
@@ -326,3 +326,9 @@
   border-radius: 4px;
   background-color: var(--bg-primary);
 }
+
+.log-images-expired {
+  color: var(--text-secondary);
+  font-style: italic;
+  margin: 4px 0;
+}

--- a/electron/renderer/src/test-fixtures/pdv-mock.ts
+++ b/electron/renderer/src/test-fixtures/pdv-mock.ts
@@ -59,6 +59,7 @@ function buildBase() {
     tree: {
       list: stub<PDVApi["tree"]["list"]>(async () => []),
       get: stub<PDVApi["tree"]["get"]>(async () => ({})),
+      getVersion: stub<PDVApi["tree"]["getVersion"]>(async () => null),
       createScript: stub<PDVApi["tree"]["createScript"]>(async () => ({ success: true })),
       createNote: stub<PDVApi["tree"]["createNote"]>(async () => ({ success: true })),
       createGui: stub<PDVApi["tree"]["createGui"]>(async () => ({ success: true })),
@@ -232,6 +233,7 @@ function buildBase() {
       defaultPythonVersion: "3.13",
       supportedJuliaVersions: ["1.10", "1.11", "1.12"],
       defaultJuliaVersion: "1.11",
+      getInvokeCounts: () => ({}),
     },
     launchers: {
       openAgent: stub<PDVApi["launchers"]["openAgent"]>(async () => ({ success: true })),

--- a/electron/renderer/src/types/index.ts
+++ b/electron/renderer/src/types/index.ts
@@ -124,6 +124,12 @@ export interface LogEntry {
   origin?: KernelExecutionOrigin;
   duration?: number;
   images?: Array<{ mime: string; data: string }>;
+  /**
+   * Count of images dropped from this entry to bound renderer memory (base64
+   * plots are large; only the newest entries keep theirs). Rendered as an
+   * "image expired" note.
+   */
+  imagesDropped?: number;
 }
 
 /** A persisted/active code-cell tab in the editor pane. */

--- a/electron/renderer/src/types/pdv.d.ts
+++ b/electron/renderer/src/types/pdv.d.ts
@@ -1031,6 +1031,11 @@ export interface PDVApi {
   tree: {
     list(kernelId: string, path?: string): Promise<NodeDescriptor[]>;
     get(kernelId: string, path: string): Promise<Record<string, unknown>>;
+    /**
+     * Monotonic tree-version counter, or null when the kernel predates the
+     * version channel (callers fall back to listing-based polling).
+     */
+    getVersion(kernelId: string): Promise<number | null>;
     createScript(
       kernelId: string,
       targetPath: string,
@@ -1336,6 +1341,11 @@ export interface PDVApi {
     defaultJuliaVersion: string;
     /** Version preselected in the New Project dialog (e.g. `"3.13"`). */
     defaultPythonVersion: string;
+    /**
+     * E2E-only diagnostics: snapshot of per-channel invoke counts (empty
+     * outside PDV_E2E=1). Read by the round-trip-budget spec.
+     */
+    getInvokeCounts(): Record<string, number>;
   };
   /** External-app launchers driven by the action bar. */
   launchers: {

--- a/pdv-julia/Project.toml
+++ b/pdv-julia/Project.toml
@@ -1,6 +1,6 @@
 name = "PDVKernel"
 uuid = "8f4a2c1e-7b3d-4e5f-9a6b-2c8d1e0f3a7b"
-version = "0.2.1"
+version = "0.2.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/pdv-julia/Project.toml
+++ b/pdv-julia/Project.toml
@@ -1,6 +1,6 @@
 name = "PDVKernel"
 uuid = "8f4a2c1e-7b3d-4e5f-9a6b-2c8d1e0f3a7b"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/pdv-julia/src/PDVKernel.jl
+++ b/pdv-julia/src/PDVKernel.jl
@@ -40,7 +40,7 @@ import Pkg
 # Unified PDV version (must match electron/package.json and
 # pdv-python/pyproject.toml — ARCHITECTURE.md key design rule 10). Probed by
 # the app's environment detector via `println(PDVKernel.VERSION)`.
-const VERSION = "0.2.1"
+const VERSION = "0.2.0"
 const __pdv_protocol_version__ = VERSION
 
 export PDVTree, PDVModule, PDVFile, PDVScript, PDVNote, PDVGui, PDVNamelist,

--- a/pdv-julia/src/PDVKernel.jl
+++ b/pdv-julia/src/PDVKernel.jl
@@ -40,7 +40,7 @@ import Pkg
 # Unified PDV version (must match electron/package.json and
 # pdv-python/pyproject.toml — ARCHITECTURE.md key design rule 10). Probed by
 # the app's environment detector via `println(PDVKernel.VERSION)`.
-const VERSION = "0.2.0"
+const VERSION = "0.2.1"
 const __pdv_protocol_version__ = VERSION
 
 export PDVTree, PDVModule, PDVFile, PDVScript, PDVNote, PDVGui, PDVNamelist,

--- a/pdv-julia/src/handlers/lifecycle.jl
+++ b/pdv-julia/src/handlers/lifecycle.jl
@@ -149,6 +149,10 @@ function _install_postexecute_cache_hook()
         IJulia.push_postexecute_hook!(() -> begin
             tree = get_pdv_tree()
             tree !== nothing && rebuild_query_cache!(tree)
+            # Silent-mutation detection: bumps the tree version (served by
+            # pdv.tree.version) and pings the renderer on drift that no
+            # precise notification covered.
+            _post_execute_version_check()
             nothing
         end)
         _postexecute_hook_installed[] = true

--- a/pdv-julia/src/handlers/tree.jl
+++ b/pdv-julia/src/handlers/tree.jl
@@ -522,8 +522,21 @@ function handle_tree_duplicate(msg::AbstractDict)
     nothing
 end
 
+# Handle `pdv.tree.version`: return the tree's monotonic mutation counter.
+# Served through the read-only query server so the renderer's safety-net
+# poll costs one cheap round trip regardless of tree size. Mirrors
+# pdv-python's handle_tree_version.
+function handle_tree_version(msg::AbstractDict)
+    msg_id = get(msg, "msg_id", nothing)
+    send_message("pdv.tree.version.response",
+                 Dict{String,Any}("version" => get_tree_version());
+                 in_reply_to=msg_id)
+    nothing
+end
+
 register_message_handler("pdv.tree.list", handle_tree_list)
 register_message_handler("pdv.tree.get", handle_tree_get)
+register_message_handler("pdv.tree.version", handle_tree_version)
 register_message_handler("pdv.tree.resolve_file", handle_tree_resolve_file)
 register_message_handler("pdv.tree.delete", handle_tree_delete)
 register_message_handler("pdv.tree.create_node", handle_tree_create_node)

--- a/pdv-julia/src/query_server.jl
+++ b/pdv-julia/src/query_server.jl
@@ -36,6 +36,7 @@
 const _QUERY_ALLOWED_TYPES = Set([
     "pdv.tree.list",
     "pdv.tree.get",
+    "pdv.tree.version",
     "pdv.tree.resolve_file",
     "pdv.tree.resolve_path",
     "pdv.help",
@@ -150,6 +151,14 @@ function _handle_threaded_query(raw::Vector{UInt8})::Dict{String,Any}
             listing = cached_tree_listing(path)
             listing !== nothing && return _threaded_reply(
                 msg_id, msg_type, "ok", Dict{String,Any}("nodes" => listing))
+        end
+
+        # The version counter is two lock-guarded Refs — safe to read
+        # off-thread, and answering here keeps the renderer's poll at one
+        # round trip even while the main thread is compute-bound.
+        if msg_type == "pdv.tree.version"
+            return _threaded_reply(msg_id, msg_type, "ok",
+                Dict{String,Any}("version" => get_tree_version()))
         end
 
         return _threaded_reply(msg_id, msg_type, "error", Dict{String,Any}(

--- a/pdv-julia/src/tree.jl
+++ b/pdv-julia/src/tree.jl
@@ -463,6 +463,31 @@ const _GLOBAL_PENDING = Ref{Bool}(false)
 const _GLOBAL_TIMER = Ref{Union{Nothing,Timer}}(nothing)
 const _GLOBAL_LOCK = ReentrantLock()
 
+# Monotonic mutation counter served by `pdv.tree.version` (query server).
+# The renderer's safety-net poll compares this instead of re-listing every
+# expanded level — one cheap round trip per tick. Bumped by every mutation
+# notification and by the post-execute structural fingerprint (which catches
+# plain-Dict mutations that emit nothing). Mirrors pdv-python's
+# PDVTree._tree_version one-to-one.
+const _TREE_VERSION = Ref{Int}(0)
+const _VERSION_LOCK = ReentrantLock()
+# Post-execute fingerprint state: last fingerprint of the root tree, and
+# whether any mutation notification fired since the last check (drift that
+# was already precisely notified doesn't fire a redundant coarse ping).
+const _LAST_FINGERPRINT = Ref{Union{Nothing,UInt64}}(nothing)
+const _CHANGED_SINCE_FINGERPRINT = Ref{Bool}(false)
+
+"""Increment the tree-version counter (thread-safe)."""
+function _bump_tree_version()
+    lock(_VERSION_LOCK) do
+        _TREE_VERSION[] += 1
+    end
+    nothing
+end
+
+"""Return the current tree-version counter (thread-safe)."""
+get_tree_version() = lock(() -> _TREE_VERSION[], _VERSION_LOCK)
+
 """
     attach_comm!(tree, send_fn)
 
@@ -501,6 +526,8 @@ function detach_comm!(tree::AbstractPDVTree)
 end
 
 function _emit_changed(tree::AbstractPDVTree, path::String, change_type::String)
+    _bump_tree_version()
+    _CHANGED_SINCE_FINGERPRINT[] = true
     if _ROOT_TREE[] === tree
         tree.send_fn === nothing && return
         lock(tree.debounce_lock) do
@@ -549,6 +576,84 @@ function _flush_global()
     end
     # Nested-PDVTree mutations reach the snapshot through this path too.
     _ROOT_TREE[] !== nothing && rebuild_query_cache!(_ROOT_TREE[])
+    nothing
+end
+
+"""
+    _structure_fingerprint(tree) -> UInt64
+
+Cheap structural fingerprint of the renderer-visible tree: keys, value type
+names, scalar values (whose previews show the value), and shape/length for
+sized containers (whose previews show structure, not contents). Never
+touches array contents, so the walk stays fast on large data. Bounded by a
+node budget and depth cap. Keys are sorted so Julia's Dict iteration order
+(which can change across rehashes) never affects the result. Mirrors
+pdv-python's `PDVTree._structure_fingerprint`.
+"""
+function _structure_fingerprint(tree)::UInt64
+    h = Ref(hash(UInt64(0)))
+    budget = Ref(100_000)
+    root = tree isa AbstractPDVTree ? tree.data : tree
+    _fingerprint_walk!(h, budget, root, 0)
+    return h[]
+end
+
+function _fingerprint_walk!(h::Ref{UInt64}, budget::Ref{Int}, node::AbstractDict, depth::Int)
+    depth > 32 && return nothing
+    for key in sort!(collect(keys(node)); by=string)
+        budget[] <= 0 && return nothing
+        budget[] -= 1
+        value = get(node, key, nothing)
+        h[] = hash(key, h[])
+        inner = value isa AbstractPDVTree ? value.data : value
+        if inner isa AbstractDict
+            h[] = hash("{", h[])
+            _fingerprint_walk!(h, budget, inner, depth + 1)
+            h[] = hash("}", h[])
+            continue
+        end
+        h[] = hash(string(typeof(value)), h[])
+        if value === nothing || value isa Bool || value isa Real || value isa AbstractString
+            h[] = hash(value, h[])
+        elseif value isa AbstractArray
+            h[] = hash(size(value), h[])
+        else
+            try
+                h[] = hash(length(value), h[])
+            catch
+            end
+        end
+    end
+    nothing
+end
+
+"""
+    _post_execute_version_check() -> Nothing
+
+Detect silent tree mutations after each execution (IJulia postexecute
+hook). Plain-Dict mutations under the tree emit no change notification;
+comparing a structural fingerprint before/after execution catches them. On
+silent drift, the version counter is bumped and a coarse
+`change_type: "unknown"` ping is emitted so the renderer refreshes
+immediately. Drift that was already precisely notified only records the new
+fingerprint. Mirrors pdv-python's `PDVTree._post_execute_check`.
+"""
+function _post_execute_version_check()
+    tree = _ROOT_TREE[]
+    tree === nothing && return nothing
+    fingerprint = try
+        _structure_fingerprint(tree)
+    catch
+        return nothing  # user objects can break anything; never propagate
+    end
+    already_notified = _CHANGED_SINCE_FINGERPRINT[]
+    _CHANGED_SINCE_FINGERPRINT[] = false
+    fingerprint == _LAST_FINGERPRINT[] && return nothing
+    first_check = _LAST_FINGERPRINT[] === nothing
+    _LAST_FINGERPRINT[] = fingerprint
+    (already_notified || first_check) && return nothing
+    _bump_tree_version()
+    _emit_global_ping()
     nothing
 end
 

--- a/pdv-julia/test/runtests.jl
+++ b/pdv-julia/test/runtests.jl
@@ -2403,4 +2403,65 @@ end
     clear_handlers!()
 end
 
+@testset "tree version counter + post-execute fingerprint" begin
+    # Mirrors pdv-python's TestTreeVersion / TestPostExecuteFingerprint.
+    t = PDVTree()
+    msgs = Tuple{String,Dict}[]
+    attach_comm!(t, (ty, pl) -> push!(msgs, (ty, pl)))
+    try
+        # Every mutation notification bumps the counter.
+        before = PDVKernel.get_tree_version()
+        t["v1"] = 1
+        t["v1"] = 2
+        delete!(t, "v1")
+        @test PDVKernel.get_tree_version() >= before + 3
+
+        # pdv.tree.version handler responds with the counter.
+        captured = run_handler(t, "pdv.tree.version")
+        resp = response_of(captured, "pdv.tree.version")
+        @test resp["status"] == "ok"
+        @test resp["payload"]["version"] == PDVKernel.get_tree_version()
+
+        # Whitelisted on the query server.
+        @test "pdv.tree.version" in PDVKernel._QUERY_ALLOWED_TYPES
+
+        # Post-execute fingerprint: baseline, then a silent plain-Dict
+        # mutation bumps and pings; notified mutations stay quiet.
+        PDVKernel._LAST_FINGERPRINT[] = nothing
+        PDVKernel._CHANGED_SINCE_FINGERPRINT[] = false
+        set_quiet!(t, "data", Dict{String,Any}("x" => 1))
+        PDVKernel._post_execute_version_check()  # baseline; first check never pings
+
+        vbefore = PDVKernel.get_tree_version()
+        t.data["data"]["y"] = 2  # bypasses PDVTree setindex! — no notification
+        PDVKernel._post_execute_version_check()
+        @test PDVKernel.get_tree_version() == vbefore + 1
+        # The coarse ping is debounced; flush it and check it arrived.
+        PDVKernel._flush_global()
+        @test any(m -> m[2]["change_type"] == "unknown", msgs)
+
+        # A notified mutation records the new fingerprint without pinging.
+        empty!(msgs)
+        t["notified"] = 1
+        _flush_changes(t)
+        vafter = PDVKernel.get_tree_version()
+        PDVKernel._post_execute_version_check()
+        @test PDVKernel.get_tree_version() == vafter  # no extra bump
+        PDVKernel._flush_global()
+        @test !any(m -> m[2]["change_type"] == "unknown", msgs)
+
+        # No drift → no bump, no ping.
+        vquiet = PDVKernel.get_tree_version()
+        PDVKernel._post_execute_version_check()
+        @test PDVKernel.get_tree_version() == vquiet
+
+        # Scalar leaf values participate (previews show them).
+        t.data["data"]["x"] = 999
+        PDVKernel._post_execute_version_check()
+        @test PDVKernel.get_tree_version() == vquiet + 1
+    finally
+        detach_comm!(t)
+    end
+end
+
 end # top-level testset

--- a/pdv-python/pdv/__init__.py
+++ b/pdv-python/pdv/__init__.py
@@ -690,6 +690,15 @@ def bootstrap(ip=None):
     if ip is not None:
         comms_mod.register_comm_target(ip)
 
+    # Post-execute structural fingerprint: catches plain-dict mutations that
+    # emit no change notification, bumping the tree version (served by
+    # pdv.tree.version) and pinging the renderer on silent drift.
+    if ip is not None and hasattr(ip, "events"):
+        try:
+            ip.events.register("post_execute", PDVTree._post_execute_check)
+        except Exception:  # noqa: BLE001 — never let bootstrap fail on this
+            pass
+
     # Configure a non-blocking interactive matplotlib backend so that
     # plt.show() opens native windows rather than falling back to the
     # ipykernel default (inline/Agg), which would silently swallow plots.

--- a/pdv-python/pdv/handlers/tree.py
+++ b/pdv-python/pdv/handlers/tree.py
@@ -814,8 +814,37 @@ def handle_tree_duplicate(msg: dict) -> None:
     )
 
 
+def handle_tree_version(msg: dict) -> None:
+    """Handle the ``pdv.tree.version`` message.
+
+    Returns the tree's monotonic mutation counter. Served through the
+    read-only query server so the renderer's safety-net poll costs one
+    cheap round trip regardless of tree size, even mid-execution.
+
+    Response payload
+    ----------------
+    .. code-block:: json
+
+        { "version": 42 }
+
+    Parameters
+    ----------
+    msg : dict
+        Parsed PDV message envelope.
+    """
+    from pdv.comms import send_message  # noqa: PLC0415
+    from pdv.tree import PDVTree  # noqa: PLC0415
+
+    send_message(
+        "pdv.tree.version.response",
+        {"version": PDVTree.get_tree_version()},
+        in_reply_to=msg.get("msg_id"),
+    )
+
+
 register("pdv.tree.list", handle_tree_list)
 register("pdv.tree.get", handle_tree_get)
+register("pdv.tree.version", handle_tree_version)
 register("pdv.tree.resolve_file", handle_tree_resolve_file)
 register("pdv.tree.delete", handle_tree_delete)
 register("pdv.tree.create_node", handle_tree_create_node)

--- a/pdv-python/pdv/query_server.py
+++ b/pdv-python/pdv/query_server.py
@@ -28,6 +28,7 @@ _ALLOWED_TYPES: frozenset[str] = frozenset(
     {
         "pdv.tree.list",
         "pdv.tree.get",
+        "pdv.tree.version",
         "pdv.tree.resolve_file",
         "pdv.tree.resolve_path",
         "pdv.help",

--- a/pdv-python/pdv/tree.py
+++ b/pdv-python/pdv/tree.py
@@ -1334,6 +1334,34 @@ class PDVTree(dict):
     _global_timer: threading.Timer | None = None
     _global_lock: threading.Lock = threading.Lock()
 
+    # Monotonic mutation counter served by ``pdv.tree.version`` (query
+    # server). The renderer's safety-net poll compares this instead of
+    # re-listing every expanded level — one cheap round trip per tick.
+    # Bumped by every mutation notification and by the post-execute
+    # structural fingerprint (which catches plain-dict mutations that emit
+    # nothing). Class-level: versions only need to be comparable within one
+    # kernel process.
+    _tree_version: int = 0
+    _version_lock: threading.Lock = threading.Lock()
+    # Post-execute fingerprint state: the last fingerprint of the root tree,
+    # and whether any mutation notification fired since the last check (so a
+    # fingerprint drift that was already precisely notified doesn't fire a
+    # redundant coarse ping).
+    _last_fingerprint: int | None = None
+    _changed_since_fingerprint: bool = False
+
+    @classmethod
+    def _bump_version(cls) -> None:
+        """Increment the tree-version counter (thread-safe)."""
+        with cls._version_lock:
+            cls._tree_version += 1
+
+    @classmethod
+    def get_tree_version(cls) -> int:
+        """Return the current tree-version counter (thread-safe)."""
+        with cls._version_lock:
+            return cls._tree_version
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__()
         self._working_dir: str | None = None
@@ -1433,6 +1461,8 @@ class PDVTree(dict):
         change_type : str
             One of ``'added'``, ``'removed'``, or ``'updated'``.
         """
+        PDVTree._bump_version()
+        PDVTree._changed_since_fingerprint = True
         if self is PDVTree._root_tree:
             if self._send_fn is None:
                 return
@@ -1486,6 +1516,99 @@ class PDVTree(dict):
             "pdv.tree.changed",
             {"changed_paths": [], "change_type": "unknown"},
         )
+
+    @classmethod
+    def _structure_fingerprint(cls, tree: dict) -> int:
+        """Compute a cheap structural fingerprint of *tree*.
+
+        Captures what the renderer's listings display: keys, value type
+        names, scalar values (whose previews show the value), and
+        shape/length for sized containers (whose previews show structure,
+        not contents). Deliberately never touches array/dataframe contents,
+        so the walk stays fast on large data. Bounded by a node budget and a
+        depth cap against pathological trees.
+
+        Fingerprints are only compared within one kernel process, so
+        Python's per-process ``hash()`` randomization is harmless.
+
+        Parameters
+        ----------
+        tree : dict
+            The root tree (or any dict) to fingerprint.
+
+        Returns
+        -------
+        int
+            A hash that changes when the renderer-visible structure does.
+        """
+        parts: list[object] = []
+        budget = 100_000
+
+        def visit(node: dict, depth: int) -> None:
+            nonlocal budget
+            if depth > 32:
+                return
+            for key in list(dict.keys(node)):
+                if budget <= 0:
+                    return
+                budget -= 1
+                try:
+                    value = dict.__getitem__(node, key)
+                except KeyError:
+                    continue  # deleted concurrently
+                parts.append(key)
+                if isinstance(value, dict):
+                    parts.append("{")
+                    visit(value, depth + 1)
+                    parts.append("}")
+                    continue
+                parts.append(type(value).__name__)
+                if value is None or isinstance(value, (bool, int, float, str)):
+                    parts.append(value)
+                else:
+                    shape = getattr(value, "shape", None)
+                    if shape is not None:
+                        parts.append(str(shape))
+                    else:
+                        try:
+                            parts.append(len(value))  # type: ignore[arg-type]
+                        except TypeError:
+                            pass
+
+        visit(tree, 0)
+        return hash(tuple(parts))
+
+    @classmethod
+    def _post_execute_check(cls) -> None:
+        """Detect silent tree mutations after each execution.
+
+        Registered as an IPython ``post_execute`` event. Plain-dict
+        mutations under the tree (``pdv_tree['data']['x'] = 1`` where
+        ``data`` is a plain dict) emit no change notification; comparing a
+        structural fingerprint before/after execution catches them at the
+        source. On silent drift, the version counter is bumped and a coarse
+        ``change_type: "unknown"`` ping is emitted so the renderer refreshes
+        immediately. Drift that was already precisely notified only records
+        the new fingerprint (the precise push and version bump already
+        happened).
+        """
+        root = cls._root_tree
+        if root is None:
+            return
+        try:
+            fingerprint = cls._structure_fingerprint(root)
+        except Exception:  # noqa: BLE001 — user objects can break anything
+            return
+        already_notified = cls._changed_since_fingerprint
+        cls._changed_since_fingerprint = False
+        if fingerprint == cls._last_fingerprint:
+            return
+        first_check = cls._last_fingerprint is None
+        cls._last_fingerprint = fingerprint
+        if already_notified or first_check:
+            return
+        cls._bump_version()
+        cls._emit_global_ping()
 
     def _flush_changes(self) -> None:
         """Send all pending change notifications as a single batch.

--- a/pdv-python/pyproject.toml
+++ b/pdv-python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdv-python"
-version = "0.2.1"
+version = "0.2.0"
 description = "PDV kernel support package — implements the PDV comm protocol and data structures for Python kernels."
 readme = "README.md"
 license = "MIT"

--- a/pdv-python/pyproject.toml
+++ b/pdv-python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdv-python"
-version = "0.2.0"
+version = "0.2.1"
 description = "PDV kernel support package — implements the PDV comm protocol and data structures for Python kernels."
 readme = "README.md"
 license = "MIT"

--- a/pdv-python/tests/test_handlers_tree.py
+++ b/pdv-python/tests/test_handlers_tree.py
@@ -478,3 +478,93 @@ class TestHandleTreeGet:
         response = mock_comm._sent[0]
         assert response["status"] == "error"
         assert "path_not_found" in response["payload"]["code"]
+
+
+class TestTreeVersion:
+    def test_version_bumps_on_mutation(self, tree_with_comm):
+        """Every mutation notification increments the class-level counter."""
+        from pdv.tree import PDVTree
+
+        before = PDVTree.get_tree_version()
+        tree_with_comm["v1"] = 1
+        tree_with_comm["v1"] = 2
+        del tree_with_comm["v1"]
+        assert PDVTree.get_tree_version() >= before + 3
+
+    def test_handle_tree_version_returns_counter(self, tree_with_comm):
+        """pdv.tree.version responds with the current counter."""
+        from pdv.handlers.tree import handle_tree_version
+        from pdv.tree import PDVTree
+
+        mock_comm = _make_mock_comm()
+        msg = _make_msg("pdv.tree.version", {})
+        with (
+            patch.object(comms_mod, "_comm", mock_comm),
+            patch.object(comms_mod, "_pdv_tree", tree_with_comm),
+        ):
+            handle_tree_version(msg)
+        response = mock_comm._sent[0]
+        assert response["type"] == "pdv.tree.version.response"
+        assert response["status"] == "ok"
+        assert response["payload"]["version"] == PDVTree.get_tree_version()
+        assert response["in_reply_to"] == msg["msg_id"]
+
+    def test_version_allowed_on_query_server(self):
+        """The query server whitelists pdv.tree.version as read-only."""
+        from pdv.query_server import _ALLOWED_TYPES
+
+        assert "pdv.tree.version" in _ALLOWED_TYPES
+
+
+class TestPostExecuteFingerprint:
+    def _fresh_root(self, tree):
+        """Reset class-level fingerprint state around a root tree."""
+        from pdv.tree import PDVTree
+
+        PDVTree._last_fingerprint = None
+        PDVTree._changed_since_fingerprint = False
+        return PDVTree
+
+    def test_silent_plain_dict_mutation_bumps_and_pings(self, tree_with_comm):
+        """A plain-dict mutation (no notification) is caught post-execute."""
+        PDVTree = self._fresh_root(tree_with_comm)
+        tree_with_comm.set_quiet("data", {"x": 1})
+        PDVTree._post_execute_check()  # baseline (first check never pings)
+
+        before = PDVTree.get_tree_version()
+        # Mutate the plain dict directly — emits no pdv.tree.changed.
+        dict.__getitem__(tree_with_comm, "data")["y"] = 2
+        with patch.object(PDVTree, "_emit_global_ping") as ping:
+            PDVTree._post_execute_check()
+        assert PDVTree.get_tree_version() == before + 1
+        ping.assert_called_once()
+
+    def test_notified_mutation_does_not_double_ping(self, tree_with_comm):
+        """Drift already covered by a precise notification stays quiet."""
+        PDVTree = self._fresh_root(tree_with_comm)
+        PDVTree._post_execute_check()  # baseline
+
+        tree_with_comm["k"] = 1  # emits a precise notification
+        with patch.object(PDVTree, "_emit_global_ping") as ping:
+            PDVTree._post_execute_check()
+        ping.assert_not_called()
+
+    def test_no_drift_no_bump(self, tree_with_comm):
+        """An execution that touches nothing leaves version and ping alone."""
+        PDVTree = self._fresh_root(tree_with_comm)
+        PDVTree._post_execute_check()  # baseline
+        before = PDVTree.get_tree_version()
+        with patch.object(PDVTree, "_emit_global_ping") as ping:
+            PDVTree._post_execute_check()
+        assert PDVTree.get_tree_version() == before
+        ping.assert_not_called()
+
+    def test_scalar_value_change_is_detected(self, tree_with_comm):
+        """Scalar leaf values participate in the fingerprint (previews show them)."""
+        PDVTree = self._fresh_root(tree_with_comm)
+        tree_with_comm.set_quiet("data", {"x": 1})
+        PDVTree._post_execute_check()  # baseline
+        dict.__getitem__(tree_with_comm, "data")["x"] = 999
+        with patch.object(PDVTree, "_emit_global_ping") as ping:
+            PDVTree._post_execute_check()
+        ping.assert_called_once()


### PR DESCRIPTION
Phase 1 of the remote-mode roadmap (issue #132): make the renderer's IPC traffic disciplined enough that every `window.pdv` call can become an SSH round trip without PDV ever feeling laggy. Implements #233 (Zustand + React Query) plus the agreed tree-update design (version channel + fingerprint), as one PR with the 8 planned steps as its internal build order.

## What changed

**Renderer (React Query + Zustand)**
- Tree and NamespaceView converted to per-path/per-node queries; `tree.onChanged` pushes map to targeted invalidations in `renderer/src/queries/invalidation.ts` (removals patch caches in place, 0 round trips). The old refresh-token pub/sub and `pendingTreeChanges` queue are gone (one deliberate survivor: `modulesRefreshToken`, see below).
- Post-execution full serial tree reload removed; invalidations refetch visible listings in parallel (≈1 RTT wall-clock). Kernel switches drop kernel-scoped caches outright.
- Zustand store slices: console logs (streamed output re-renders only the Console panel, not the whole app), dialogs (`ActiveDialog` union + `closeTopmost()` Escape priority), and the `connectionState` placeholder Phase 3's SSH state machine will drive (StatusBar renders it; invisible for local sessions).
- Monaco: completions issued at word start and cached through the query layer (typing within a word costs 0 round trips; tree-path completions share the Tree panel's cache), hovers get a 200 ms rest delay + 30 s cache; execute-finish invalidates both.
- Console image memory cap: entries beyond the newest 200 drop their base64 plots with an "image expired" marker (bounds multi-GB retention in long plotting sessions).

**Kernels (parity — both pdv-python and PDVKernel.jl)**
- Monotonic tree-version counter, bumped on every mutation notification, served as `pdv.tree.version` via the read-only query server (answered off-thread in Julia's threaded mode).
- Post-execute structural fingerprint (IPython `post_execute` / IJulia postexecute) catches silent plain-dict mutations at the source: bumps the version and emits the coarse `unknown` ping so the renderer refreshes immediately, without double-pinging changes that were already precisely notified.
- The renderer's safety-net poll is demoted from `(1 + expanded)` **serial** `tree.list` calls per second to **one** `tree.getVersion` per 2 s, suppressed while pushes are flowing, with per-kernel feature detection falling back to parallel listing revalidation for older kernels.

**Docs & guards**
- ARCHITECTURE.md §7.4 rewritten (three-mechanism propagation contract), §11.5 subscription rules updated; CLAUDE.md rule 7 rewritten; new "round-trip discipline" item in the PR checklist; HOOKS.md updated.
- New `e2e/round-trip-budget.spec.ts`: counts real IPC invokes (preload counters under `PDV_E2E=1`) and asserts an idle app with an expanded tree makes **zero** listing calls (version checks only) and a cell run stays bounded. This is the executable regression guard for the latency budget.

**Version**: unchanged at 0.2.0 — it is unreleased (latest tag v0.2.0-pre1), so the `pdv.tree.version` protocol addition rides the in-development version; older *released* kernels are handled by the renderer's feature detection.

## Deliberate scope deferrals (documented in code/HOOKS.md)
- `modulesRefreshToken` and the modules→queries migration.
- Mechanical execution/layout/treeUi store-slice migrations (console/dialog/session slices landed).
- Two planned sub-items needed no code: the startup fan-out was already parallel, and the streamed-vs-result image wire dedup already exists in `kernel-manager.ts`.

## Test plan
- [x] `cd electron && npm test` — 78 files / 943 tests green
- [x] `cd pdv-python && pytest tests/` — 710 passed (includes new version/fingerprint tests)
- [x] `julia --project=pdv-julia -e 'using Pkg; Pkg.test()'` — 648 passed (includes new version/fingerprint testset)
- [x] TypeScript typechecks clean on both roots
- [x] `pdv-python/scripts/sweep-deps.sh` — **all cells green** (pdv-python touched)
- [x] Playwright e2e (`npm run build:e2e` + `test:e2e`, real Python kernel): full suite green; new round-trip-budget spec passes. Occasional single-spec kernel-boot-timeout flakes reproduce only under high machine load and pass deterministically in isolation.
- [x] Manual smoke tests on the dev app
- [ ] CI Julia integration/e2e suites (not runnable locally)

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HcHknCABN5nZ4XdzFzTNSh
