### PR TITLE
Remote B1: spawn seam + per-host setup script / login-environment capture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2285,6 +2285,31 @@ working directory on this machine. The session id is stable per user, so
 reconnecting after a crash or an app restart finds the same session, kernel
 and Tree instead of stranding the previous daemon.
 
+**Login environment and the per-host setup script.** A daemon spawned over
+an ssh exec channel never ran a login shell, so PATH entries that every
+interactive shell on the cluster has — Lmod modules, juliaup, conda hooks —
+are invisible to it and to every kernel and probe it spawns. At startup the
+daemon therefore captures the login environment once (`server/login-env.ts`):
+`bash -lc '. setup.sh >/dev/null 2>&1; env -0 > <file>'`, parsed from the
+file (login shells *print*, and profile chatter interleaved with the capture
+— or with any per-spawn wrapper's stdout — would corrupt interpreter probes
+that regex their output) and applied to the daemon's own `process.env`,
+which every spawn call site builds from. One login shell per daemon, not per
+spawn; `PDV_*` and `ELECTRON_RUN_AS_NODE` are protected from profile
+override; a failed capture degrades to the inherited environment. The
+optional setup script is per host: its master copy lives on the laptop
+(`<userData>/remote-setup/<host>.sh`, hand-editable offline) and
+`remote/setup-script.ts` ships it to `run/sessions/<id>/setup.sh` at
+`startSession`, *before* the daemon may be created, since it is sourced only
+during that startup capture — script edits apply from the next session
+start. A configured script that cannot be delivered fails the session start
+loudly; silently missing interpreters are the harder bug. When no script is
+configured the remote copy is removed, so deleting the local file
+un-configures the host. All server-side tool spawns are funnelled through
+one seam (`server/spawn.ts`, enforced by an import guard) — the future hook
+for Slurm-launched kernels, which is also why environment does not ride
+there as a wrapper.
+
 `shell/remote-server.ts` is the remote `ServerHandle`. The transport is
 unchanged — an ssh channel is a stream pair and `RpcClient` already takes one
 — but the *lifetime* differs, which is why it is a separate implementation:
@@ -2954,7 +2979,7 @@ PDV does not ship a static API reference, which would drift. Instead:
 The following features are acknowledged as future work and must not influence the current architecture in ways that complicate the above design:
 
 - **Modules ecosystem hardening** — core module lifecycle is implemented (install from disk/GitHub, import, uninstall, update, bundled examples, project-local storage); deeper registry/trust features are deferred
-- **Remote session completeness** — remote sessions work end to end (§11.7 area above: connect, bootstrap, session daemon, environment provisioning via the bundled uv, path picking); still deferred are the per-host setup script and Slurm-aware kernel launch (interactive analysis on a login node is the sanctioned beta scope), remote Julia sessions (need juliaup on the host), remote→local file export, remote launchers, and the VS Code-style command palette that will replace the placeholder path picker
+- **Remote session completeness** — remote sessions work end to end (§11.7 area above: connect, bootstrap, session daemon, environment provisioning via the bundled uv, path picking); still deferred are Slurm-aware kernel launch (interactive analysis on a login node is the sanctioned beta scope; the per-host setup script and login-environment capture have landed), remote Julia sessions (need juliaup on the host), remote→local file export, remote launchers, and the VS Code-style command palette that will replace the placeholder path picker
 - **Local→remote upload import and remote MCP** — explicitly excluded from remote v1
 - **Multiple simultaneous kernels** — architecture supports it (kernels have IDs) but UI exposes only one at a time
 - **R kernel support** — deferred; would follow the `pdv-julia` pattern (a kernel-side package implementing the language-agnostic protocol of §3)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2296,16 +2296,23 @@ file (login shells *print*, and profile chatter interleaved with the capture
 that regex their output) and applied to the daemon's own `process.env`,
 which every spawn call site builds from. One login shell per daemon, not per
 spawn; `PDV_*` and `ELECTRON_RUN_AS_NODE` are protected from profile
-override; a failed capture degrades to the inherited environment. The
-optional setup script is per host: its master copy lives on the laptop
-(`<userData>/remote-setup/<host>.sh`, hand-editable offline) and
-`remote/setup-script.ts` ships it to `run/sessions/<id>/setup.sh` at
-`startSession`, *before* the daemon may be created, since it is sourced only
-during that startup capture — script edits apply from the next session
-start. A configured script that cannot be delivered fails the session start
-loudly; silently missing interpreters are the harder bug. When no script is
-configured the remote copy is removed, so deleting the local file
-un-configures the host. All server-side tool spawns are funnelled through
+override — that prefix is the daemon's reserved namespace, so a setup
+script's own exports must not use it. A failed capture degrades to the
+inherited environment, but never silently when a script was shipped: the
+capture reports *evidence* of sourcing (a sentinel exported by the capture
+shell, not a stat of the file), the verdict is recorded as
+`setupScriptApplied` in `session.json`, and a shipped-but-not-applied
+script logs loudly. The optional setup script is per host: its master copy
+lives on the laptop (`<userData>/remote-setup/<host>.sh`, hand-editable
+offline, CRLF normalized at ship time) and `remote/setup-script.ts` ships
+it at every `startSession`, before any path that could spawn a daemon,
+since it is sourced only during that startup capture — script edits apply
+from the next session start, and a daemon resurrected by the handle's
+internal reconnect loop sources the last-shipped copy. A configured script
+that cannot be delivered fails the session start loudly; silently missing
+interpreters are the harder bug. When no script is configured the remote
+copy is removed, so at each session start the host reflects the local
+master copy, present or absent. All server-side tool spawns are funnelled through
 one seam (`server/spawn.ts`, enforced by an import guard) — the future hook
 for Slurm-launched kernels, which is also why environment does not ride
 there as a wrapper.

--- a/electron/e2e/remote-session.spec.ts
+++ b/electron/e2e/remote-session.spec.ts
@@ -79,7 +79,15 @@ test.afterEach(async () => {
 
 test("connects to a host and moves the session onto it", async () => {
   launched = await launchPDV({ env: remoteEnv() });
-  const { app, window: page } = launched;
+  const { app, window: page, homeDir } = launched;
+
+  // A per-host setup script configured before connecting. The assertions at
+  // the bottom prove the whole chain: master copy → shipped to the session
+  // dir on the "host" → sourced by the daemon's login-env capture.
+  const setupContent = "export PDV_E2E_SETUP_MARKER='shipped and sourced'\n";
+  const userData = await app.evaluate(({ app: a }) => a.getPath("userData"));
+  await fs.mkdir(path.join(userData, "remote-setup"), { recursive: true });
+  await fs.writeFile(path.join(userData, "remote-setup", "testhost.sh"), setupContent, "utf8");
 
   await sendMenuAction(app, { action: "remote:connect" });
 
@@ -103,6 +111,22 @@ test("connects to a host and moves the session onto it", async () => {
   await expect(page.locator(".status-bar")).toContainText(/testhost/i, {
     timeout: 10_000,
   });
+
+  // The setup script really shipped: byte-identical in the session dir on
+  // the "host" (the temp HOME the fake ssh executes under)...
+  const sessionDir = path.join(
+    homeDir,
+    ".pdv-server",
+    "run",
+    "sessions",
+    `pdv-${os.userInfo().username}`,
+  );
+  expect(await fs.readFile(path.join(sessionDir, "setup.sh"), "utf8")).toBe(setupContent);
+  // ...and the daemon really sourced it during its login-env capture. The
+  // log line is written before the socket binds, so reaching "running on"
+  // above guarantees it is already on disk.
+  const daemonLog = await fs.readFile(path.join(sessionDir, "session.log"), "utf8");
+  expect(daemonLog).toMatch(/applied login environment .*setup\.sh sourced/);
 });
 
 test("keeps the local session working when the host cannot be reached", async () => {

--- a/electron/e2e/remote-session.spec.ts
+++ b/electron/e2e/remote-session.spec.ts
@@ -34,12 +34,20 @@ import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 
+import { expectKernelReady } from "./helpers/kernel-status";
 import { launchPDV, type LaunchedApp } from "./helpers/launch";
 import { sendMenuAction } from "./helpers/menu-action";
+import { createNewPythonProject } from "./helpers/new-project";
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 const FAKE_SSH = path.join(REPO_ROOT, "main", "remote", "__fixtures__", "fake-ssh.cjs");
 const SERVER_ENTRY = path.join(REPO_ROOT, "dist", "main", "server", "server-main.js");
+/** The real app version, read at runtime — the daemon's comm layer enforces it. */
+const APP_VERSION = (
+  JSON.parse(fsSync.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8")) as {
+    version: string;
+  }
+).version;
 
 /** Runtime dirs created per launch; removed in afterEach. */
 const runtimeDirs: string[] = [];
@@ -60,8 +68,13 @@ function remoteEnv(): Record<string, string> {
     // the ssh binary directly rather than needing an interpreter prefix.
     PDV_SSH_PATH: FAKE_SSH,
     // The daemon and the attach proxy are the real pdv-server, run through
-    // the Electron binary as plain Node exactly as production does.
-    PDV_REMOTE_SERVER_COMMAND: `ELECTRON_RUN_AS_NODE=1 "${process.execPath}" "${SERVER_ENTRY}"`,
+    // the Electron binary as plain Node exactly as production does. The env
+    // contract mirrors the bootstrap-generated command (bootstrap.ts):
+    // PDV_APP_VERSION must ride along, or the daemon starts as version
+    // "unknown" and the comm router rejects every kernel message.
+    PDV_REMOTE_SERVER_COMMAND:
+      `PDV_APP_VERSION="${APP_VERSION}" ` +
+      `ELECTRON_RUN_AS_NODE=1 "${process.execPath}" "${SERVER_ENTRY}"`,
     FAKE_SSH_MASTER: "alive",
     FAKE_SSH_EXEC: "local",
   };
@@ -78,13 +91,18 @@ test.afterEach(async () => {
 });
 
 test("connects to a host and moves the session onto it", async () => {
+  test.setTimeout(240_000);
   launched = await launchPDV({ env: remoteEnv() });
   const { app, window: page, homeDir } = launched;
 
   // A per-host setup script configured before connecting. The assertions at
   // the bottom prove the whole chain: master copy → shipped to the session
-  // dir on the "host" → sourced by the daemon's login-env capture.
-  const setupContent = "export PDV_E2E_SETUP_MARKER='shipped and sourced'\n";
+  // dir on the "host" → sourced by the daemon's login-env capture → applied
+  // to a kernel a user's code can see. Deliberately NOT a PDV_-prefixed
+  // name: that prefix is the daemon's reserved namespace and applyLoginEnv
+  // discards it (the first version of this spec fell into exactly that
+  // trap, asserting a marker that could never have been applied).
+  const setupContent = "export E2E_SETUP_MARKER='shipped and sourced'\n";
   const userData = await app.evaluate(({ app: a }) => a.getPath("userData"));
   await fs.mkdir(path.join(userData, "remote-setup"), { recursive: true });
   await fs.writeFile(path.join(userData, "remote-setup", "testhost.sh"), setupContent, "utf8");
@@ -122,11 +140,42 @@ test("connects to a host and moves the session onto it", async () => {
     `pdv-${os.userInfo().username}`,
   );
   expect(await fs.readFile(path.join(sessionDir, "setup.sh"), "utf8")).toBe(setupContent);
-  // ...and the daemon really sourced it during its login-env capture. The
-  // log line is written before the socket binds, so reaching "running on"
-  // above guarantees it is already on disk.
+  // ...and the daemon really sourced it: this log suffix is derived from a
+  // sentinel the capture shell exports after the `.` line — evidence from
+  // inside the capture, not a stat of the file. Written before the socket
+  // binds, so reaching "running on" above guarantees it is on disk.
   const daemonLog = await fs.readFile(path.join(sessionDir, "session.log"), "utf8");
-  expect(daemonLog).toMatch(/applied login environment .*setup\.sh sourced/);
+  expect(daemonLog).toMatch(/applied login environment .*setup script sourced/);
+  // session.json records the same verdict for later diagnostics.
+  const meta = JSON.parse(
+    await fs.readFile(path.join(sessionDir, "session.json"), "utf8"),
+  ) as { setupScriptApplied?: boolean };
+  expect(meta.setupScriptApplied).toBe(true);
+
+  // Finally, the part a user actually cares about: a kernel started in this
+  // session sees the variable. This closes the gap none of the file/log
+  // assertions can — that the captured environment was APPLIED to
+  // process.env and inherited by the kernel spawn.
+  await dialog.getByRole("button", { name: "Close" }).click();
+  await createNewPythonProject(page);
+  // Remote path provisions a uv env before the kernel boots; generous but
+  // bounded (uv download cache is shared across specs).
+  await expectKernelReady(page, 150_000);
+  const editor = page.getByRole("textbox", { name: "Editor content" });
+  await editor.focus();
+  const modifier = process.platform === "darwin" ? "Meta" : "Control";
+  await page.keyboard.press(`${modifier}+a`);
+  await page.keyboard.press("Backspace");
+  await page.keyboard.type(
+    "import os; print('marker=' + os.environ.get('E2E_SETUP_MARKER', 'MISSING'))",
+  );
+  await page.getByRole("button", { name: "Execute" }).click();
+  // Not `.first()`: the session-move console marker ("── session moved to
+  // testhost ──") occupies the first stdout slot. Filter to the marker line
+  // so a "marker=MISSING" result still fails with the actual value shown.
+  await expect(
+    page.locator(".log-stdout").filter({ hasText: "marker=" }).first(),
+  ).toContainText("marker=shipped and sourced", { timeout: 30_000 });
 });
 
 test("keeps the local session working when the host cannot be reached", async () => {
@@ -175,7 +224,7 @@ test("surfaces a remote kernel-start failure instead of spinning", async () => {
     env: {
       ...remoteEnv(),
       PDV_REMOTE_SERVER_COMMAND:
-        `PDV_PDV_DIR="${remotePdvDir}" ` +
+        `PDV_APP_VERSION="${APP_VERSION}" PDV_PDV_DIR="${remotePdvDir}" ` +
         `ELECTRON_RUN_AS_NODE=1 "${process.execPath}" "${SERVER_ENTRY}"`,
     },
   });

--- a/electron/main/environment-detector.ts
+++ b/electron/main/environment-detector.ts
@@ -17,18 +17,15 @@
  * config.ts — source of user-configured paths
  */
 
-import { execFile, spawn } from "child_process";
-import { promisify } from "util";
 import * as path from "path";
 import * as os from "os";
 import * as fs from "fs";
 import type { PushSender } from "./server/invoke-registry";
 import { getResourcesRoot } from "./server/server-paths";
+import { serverExecFile, serverSpawn } from "./server/spawn";
 import { sanitizedJuliaEnv } from "./julia-discovery";
 import { coreVersion, getAppVersion } from "./pdv-protocol";
 import { parseMajorMinor } from "./python-versions";
-
-const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -281,7 +278,7 @@ export class EnvironmentDetector {
     pythonPath: string
   ): Promise<string | undefined> {
     try {
-      const { stdout, stderr } = await execFileAsync(
+      const { stdout, stderr } = await serverExecFile(
         pythonPath,
         ["--version"],
         { timeout: PROBE_TIMEOUT_MS }
@@ -307,7 +304,7 @@ export class EnvironmentDetector {
     pythonPath: string
   ): Promise<PDVInstallStatus> {
     try {
-      const { stdout } = await execFileAsync(
+      const { stdout } = await serverExecFile(
         pythonPath,
         ["-c", "import pdv; print(pdv.__version__)"],
         { timeout: PROBE_TIMEOUT_MS }
@@ -369,7 +366,7 @@ export class EnvironmentDetector {
       // sanitizedJuliaEnv: probe the runtime's DEFAULT environment — a
       // shell-exported JULIA_PROJECT would resolve PDVKernel from the
       // user's own project instead (review M8).
-      const { stdout } = await execFileAsync(
+      const { stdout } = await serverExecFile(
         juliaPath,
         ["--startup-file=no", "-e", probe],
         { timeout: PROBE_TIMEOUT_MS, env: sanitizedJuliaEnv() }
@@ -396,7 +393,7 @@ export class EnvironmentDetector {
    */
   static async checkIpykernelInstalled(pythonPath: string): Promise<boolean> {
     try {
-      await execFileAsync(
+      await serverExecFile(
         pythonPath,
         ["-c", "import ipykernel"],
         { timeout: PROBE_TIMEOUT_MS }
@@ -420,7 +417,7 @@ export class EnvironmentDetector {
    */
   static async checkIsFreeThreaded(pythonPath: string): Promise<boolean> {
     try {
-      const { stdout } = await execFileAsync(
+      const { stdout } = await serverExecFile(
         pythonPath,
         [
           "-c",
@@ -646,7 +643,7 @@ export class EnvironmentDetector {
 
     return new Promise((resolve) => {
       const chunks: string[] = [];
-      const proc = spawn(pythonPath, ["-m", "pip", "install", "--no-color", installPath], {
+      const proc = serverSpawn(pythonPath, ["-m", "pip", "install", "--no-color", installPath], {
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 120_000,
       });
@@ -742,7 +739,7 @@ async function _probeEnv(
   kind: EnvironmentKind
 ): Promise<DetectedEnvironment | null> {
   try {
-    const { stdout, stderr } = await execFileAsync(
+    const { stdout, stderr } = await serverExecFile(
       pythonPath,
       ["--version"],
       { timeout: PROBE_TIMEOUT_MS }
@@ -795,7 +792,7 @@ async function _listCondaEnvs(): Promise<string[]> {
  */
 async function _listCondaEnvsViaCommand(): Promise<string[]> {
   try {
-    const { stdout } = await execFileAsync(
+    const { stdout } = await serverExecFile(
       "conda",
       ["env", "list", "--json"],
       { timeout: CONDA_TIMEOUT_MS }

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -132,6 +132,10 @@ export async function registerIpcHandlers(
     // Built by `npm run build:server-bundle`. Absent in a checkout that has
     // not built them, which simply skips the bootstrap.
     bundleDir: path.join(__dirname, "..", "remote-bundles"),
+    // Per-host setup-script master copies (one `<host>.sh` per alias).
+    // Hand-edited for now; a Settings Remote Hosts tab gains an editor in a
+    // later PR of this series.
+    setupScriptDir: path.join(userDataDir, "remote-setup"),
     // Only a router can move the session; anything else (a bare handle in a
     // test) gets connection control without session swapping rather than a
     // menu item that fails when used.

--- a/electron/main/ipc-register-remote-session.test.ts
+++ b/electron/main/ipc-register-remote-session.test.ts
@@ -385,17 +385,34 @@ describe("unreachable-session guards and recovery", () => {
 });
 
 describe("setup-script shipping at session start", () => {
-  it("ships the script before the swap, with the connection's identity", async () => {
-    const routerKindAtShip: string[] = [];
+  it("ships the script before any channel can spawn a daemon", async () => {
+    // Order is the property under test: the daemon sources setup.sh exactly
+    // once, at startup — so the ship must precede the first channel open
+    // (which runs `attach --create`), not merely the router swap. A version
+    // that shipped between handle.start() and swap() passed a swap-only
+    // assertion while the daemon had already been created scriptless.
+    const order: string[] = [];
     const ship = vi.fn(
       async (_opts: { host: string; sessionId: string; setupScriptDir: string }) => {
-        routerKindAtShip.push(router.kind);
+        order.push("ship");
         return { ok: true as const, shipped: true };
       },
     );
     register({
       setupScriptDir: path.join(workDir, "remote-setup"),
       shipScript: ship as unknown as Parameters<typeof registerRemoteIpcHandlers>[0]["shipScript"],
+      openChannel: (() => {
+        order.push("channel-open");
+        const socket = net.connect(paths.sockPath);
+        socket.on("error", () => undefined);
+        sockets.push(socket);
+        return {
+          readable: socket,
+          writable: socket,
+          child: undefined as never,
+          dispose: () => socket.destroy(),
+        };
+      }) as unknown as Parameters<typeof registerRemoteIpcHandlers>[0]["openChannel"],
     });
 
     const result = (await invokeIpc(IPC.remote.startSession)) as { ok: boolean };
@@ -406,9 +423,8 @@ describe("setup-script shipping at session start", () => {
       sessionId: SESSION,
       setupScriptDir: path.join(workDir, "remote-setup"),
     });
-    // Shipped BEFORE the daemon attach/swap: a script arriving after
-    // --create would silently not apply until the next session.
-    expect(routerKindAtShip).toEqual(["local"]);
+    expect(order[0]).toBe("ship");
+    expect(order).toContain("channel-open");
     expect(router.kind).toBe("remote");
   });
 

--- a/electron/main/ipc-register-remote-session.test.ts
+++ b/electron/main/ipc-register-remote-session.test.ts
@@ -383,3 +383,62 @@ describe("unreachable-session guards and recovery", () => {
     expect(states.at(-1)).toMatchObject({ kind: "local", state: "connected" });
   });
 });
+
+describe("setup-script shipping at session start", () => {
+  it("ships the script before the swap, with the connection's identity", async () => {
+    const routerKindAtShip: string[] = [];
+    const ship = vi.fn(
+      async (_opts: { host: string; sessionId: string; setupScriptDir: string }) => {
+        routerKindAtShip.push(router.kind);
+        return { ok: true as const, shipped: true };
+      },
+    );
+    register({
+      setupScriptDir: path.join(workDir, "remote-setup"),
+      shipScript: ship as unknown as Parameters<typeof registerRemoteIpcHandlers>[0]["shipScript"],
+    });
+
+    const result = (await invokeIpc(IPC.remote.startSession)) as { ok: boolean };
+    expect(result.ok).toBe(true);
+    expect(ship).toHaveBeenCalledTimes(1);
+    expect(ship.mock.calls[0][0]).toMatchObject({
+      host: "testhost",
+      sessionId: SESSION,
+      setupScriptDir: path.join(workDir, "remote-setup"),
+    });
+    // Shipped BEFORE the daemon attach/swap: a script arriving after
+    // --create would silently not apply until the next session.
+    expect(routerKindAtShip).toEqual(["local"]);
+    expect(router.kind).toBe("remote");
+  });
+
+  it("a failed ship declines the start and leaves the local session untouched", async () => {
+    const ship = vi.fn(async () => ({
+      ok: false as const,
+      message: "The setup script for testhost could not be delivered.",
+    }));
+    register({
+      setupScriptDir: path.join(workDir, "remote-setup"),
+      shipScript: ship as unknown as Parameters<typeof registerRemoteIpcHandlers>[0]["shipScript"],
+    });
+
+    const result = (await invokeIpc(IPC.remote.startSession)) as {
+      ok: boolean;
+      message?: string;
+    };
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("setup script");
+    expect(router.kind).toBe("local");
+    expect(localHandle.shutdownCalls).toBe(0);
+  });
+
+  it("skips shipping entirely when no setupScriptDir is configured", async () => {
+    const ship = vi.fn(async () => ({ ok: true as const, shipped: true }));
+    register({
+      shipScript: ship as unknown as Parameters<typeof registerRemoteIpcHandlers>[0]["shipScript"],
+    });
+    const result = (await invokeIpc(IPC.remote.startSession)) as { ok: boolean };
+    expect(result.ok).toBe(true);
+    expect(ship).not.toHaveBeenCalled();
+  });
+});

--- a/electron/main/ipc-register-remote.ts
+++ b/electron/main/ipc-register-remote.ts
@@ -27,6 +27,7 @@ import {
   type SessionStatePayload,
 } from "./ipc";
 import { openSessionChannel } from "./remote/remote-channel";
+import { shipSetupScript } from "./remote/setup-script";
 import { RemoteServerHandle } from "./shell/remote-server";
 import type { ServerHandle } from "./shell/server-supervisor";
 import type { SessionRouter } from "./shell/session-router";
@@ -67,6 +68,15 @@ export interface RegisterRemoteIpcOptions {
   sessionId?: string;
   /** Opens the ssh channel. Injected by tests. */
   openChannel?: typeof openSessionChannel;
+  /**
+   * Directory of per-host setup-script master copies
+   * (`<userData>/remote-setup`). Omitting it skips setup-script shipping
+   * entirely, which is what a build (or test) with no setup-script support
+   * should do rather than failing every session start.
+   */
+  setupScriptDir?: string;
+  /** Ships the setup script. Injected by tests. */
+  shipScript?: typeof shipSetupScript;
   /**
    * Starts a fresh local pdv-server. Ending a remote session (and
    * disconnecting while one runs) swaps the window back onto it; omitting
@@ -247,6 +257,26 @@ export function registerRemoteIpcHandlers(
     const sessionId = options.sessionId ?? defaultSessionId();
     const open = options.openChannel ?? openSessionChannel;
     const host = manager.getStatus().host;
+
+    // The setup script must be on the host BEFORE the daemon spawns: the
+    // daemon sources it exactly once, during its startup login-environment
+    // capture, so a script arriving after `--create` would silently not
+    // apply until the next session. A configured script that cannot be
+    // delivered fails the start loudly — a session whose interpreters are
+    // silently missing is the harder bug to diagnose.
+    if (options.setupScriptDir && host) {
+      const ship = options.shipScript ?? shipSetupScript;
+      const shipped = await ship({
+        control,
+        host,
+        sessionId,
+        setupScriptDir: options.setupScriptDir,
+        sshPath,
+      });
+      if (!shipped.ok) {
+        return { ok: false, message: shipped.message };
+      }
+    }
 
     const handle = new RemoteServerHandle({
       sessionId,

--- a/electron/main/ipc-register-remote.ts
+++ b/electron/main/ipc-register-remote.ts
@@ -233,37 +233,21 @@ export function registerRemoteIpcHandlers(
         message: "Connect to a host before starting a session there.",
       };
     }
-    if (router.kind === "remote") {
-      // The recovery path: the session is already here but its channel was
-      // lost past the automatic backoff (`auth-required`). The user has just
-      // re-authenticated in this dialog, so an interactive reattach is
-      // exactly what "run session here" should mean now.
-      const current = activeRemoteHandle();
-      if (current && current.connectionState !== "connected") {
-        try {
-          await current.retryNow();
-          return { ok: true, sessionId: options.sessionId ?? defaultSessionId() };
-        } catch (err) {
-          console.error("[remote] reattach via existing handle failed:", err);
-          // Fall through and build a fresh handle: a handle that was
-          // superseded (or closed) can never reattach — "reconnect" must
-          // still work, and the attach protocol makes a fresh handle safe.
-        }
-      } else if (current) {
-        return { ok: false, message: "This window already runs a remote session." };
-      }
-    }
-
     const sessionId = options.sessionId ?? defaultSessionId();
-    const open = options.openChannel ?? openSessionChannel;
     const host = manager.getStatus().host;
 
-    // The setup script must be on the host BEFORE the daemon spawns: the
-    // daemon sources it exactly once, during its startup login-environment
-    // capture, so a script arriving after `--create` would silently not
-    // apply until the next session. A configured script that cannot be
-    // delivered fails the start loudly — a session whose interpreters are
-    // silently missing is the harder bug to diagnose.
+    // The setup script must be on the host BEFORE any path that can spawn a
+    // daemon: it is sourced exactly once, during the daemon's startup
+    // login-environment capture, so a script arriving after `--create`
+    // silently does not apply until the next session. That includes the
+    // retryNow recovery below — its attach runs with `create: true` and
+    // will resurrect a daemon that died while disconnected, which must
+    // source the CURRENT script, not whatever a previous startSession left
+    // behind. A configured script that cannot be delivered fails the start
+    // loudly — a session whose interpreters are silently missing is the
+    // harder bug to diagnose. (The one unshipped path left is the handle's
+    // internal reconnect loop; a daemon resurrected there sources the last
+    // startSession's copy, which is also the newest one ever shipped.)
     if (options.setupScriptDir && host) {
       const ship = options.shipScript ?? shipSetupScript;
       const shipped = await ship({
@@ -277,6 +261,29 @@ export function registerRemoteIpcHandlers(
         return { ok: false, message: shipped.message };
       }
     }
+
+    if (router.kind === "remote") {
+      // The recovery path: the session is already here but its channel was
+      // lost past the automatic backoff (`auth-required`). The user has just
+      // re-authenticated in this dialog, so an interactive reattach is
+      // exactly what "run session here" should mean now.
+      const current = activeRemoteHandle();
+      if (current && current.connectionState !== "connected") {
+        try {
+          await current.retryNow();
+          return { ok: true, sessionId };
+        } catch (err) {
+          console.error("[remote] reattach via existing handle failed:", err);
+          // Fall through and build a fresh handle: a handle that was
+          // superseded (or closed) can never reattach — "reconnect" must
+          // still work, and the attach protocol makes a fresh handle safe.
+        }
+      } else if (current) {
+        return { ok: false, message: "This window already runs a remote session." };
+      }
+    }
+
+    const open = options.openChannel ?? openSessionChannel;
 
     const handle = new RemoteServerHandle({
       sessionId,

--- a/electron/main/julia-discovery.ts
+++ b/electron/main/julia-discovery.ts
@@ -21,18 +21,15 @@
  * - Register IPC handlers (ipc-register-environment.ts).
  */
 
-import { execFile, spawn } from "child_process";
-import { promisify } from "util";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import type { PushSender } from "./server/invoke-registry";
 import { getResourcesRoot } from "./server/server-paths";
+import { serverExecFile, serverSpawn } from "./server/spawn";
 
 import { coreVersion, getAppVersion } from "./pdv-protocol";
 import type { EnvironmentInstallResult } from "./environment-detector";
-
-const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -342,7 +339,7 @@ export async function probeJuliaRuntime(
 ): Promise<JuliaProbeResult | null> {
   let stdout: string;
   try {
-    ({ stdout } = await execFileAsync(
+    ({ stdout } = await serverExecFile(
       juliaPath,
       ["--startup-file=no", "-e", PROBE_SNIPPET],
       { timeout: PROBE_TIMEOUT_MS, env: sanitizedJuliaEnv() }
@@ -669,7 +666,7 @@ function _installPDVKernelExclusive(
     const chunks: string[] = [];
     // sanitizedJuliaEnv: a shell-exported JULIA_PROJECT would redirect
     // Pkg.develop/Pkg.add into the user's own project (review M8).
-    const proc = spawn(juliaPath, ["--startup-file=no", "-e", code], {
+    const proc = serverSpawn(juliaPath, ["--startup-file=no", "-e", code], {
       env: sanitizedJuliaEnv({
         NO_COLOR: "1",
         JULIA_PKG_PROGRESS_BARS: "0",

--- a/electron/main/julia-env.ts
+++ b/electron/main/julia-env.ts
@@ -22,9 +22,9 @@
  *   inside the kernel, §10.6.8 — dispatched by ipc-register-environment.ts).
  */
 
-import { spawn } from "child_process";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { serverSpawn } from "./server/spawn";
 import type { PushSender } from "./server/invoke-registry";
 
 import type { ProjectPackage } from "./ipc";
@@ -150,7 +150,7 @@ export function instantiateJuliaEnvironment(
       NO_COLOR: "1",
       JULIA_PKG_PROGRESS_BARS: "0",
     };
-    const proc = spawn(juliaPath, args, {
+    const proc = serverSpawn(juliaPath, args, {
       cwd: workingDir,
       env,
       stdio: ["ignore", "pipe", "pipe"],

--- a/electron/main/juliaup-runner.ts
+++ b/electron/main/juliaup-runner.ts
@@ -33,9 +33,9 @@
  *    selector and the project-load flow own that policy.
  */
 
-import { spawn } from "child_process";
 import * as fs from "fs";
 import * as os from "os";
+import { serverSpawn } from "./server/spawn";
 import * as path from "path";
 import type { PushSender } from "./server/invoke-registry";
 
@@ -391,7 +391,7 @@ function runStreamed(
 ): Promise<EnvironmentInstallResult> {
   return new Promise((resolve) => {
     const chunks: string[] = [];
-    const proc = spawn(file, args, {
+    const proc = serverSpawn(file, args, {
       env: { ...process.env, NO_COLOR: "1", ...opts.env },
       stdio: ["ignore", "pipe", "pipe"],
       timeout: ACQUIRE_TIMEOUT_MS,

--- a/electron/main/kernel-manager.ts
+++ b/electron/main/kernel-manager.ts
@@ -27,7 +27,7 @@ import * as fs from "fs";
 import * as net from "net";
 import * as os from "os";
 import * as path from "path";
-import { spawn, ChildProcess } from "child_process";
+import { serverSpawn, type ChildProcess } from "./server/spawn";
 import { EventEmitter } from "events";
 import type { KernelCompleteResult, KernelInspectResult } from "./ipc";
 import { buildExecutionError, type KernelExecutionLocation } from "./kernel-error-parser";
@@ -505,7 +505,7 @@ export class KernelManager extends EventEmitter {
     }
     argv = argv.map((a) => a.replace("{connection_file}", connectionFile));
 
-    const kernelProcess = spawn(argv[0], argv.slice(1), {
+    const kernelProcess = serverSpawn(argv[0], argv.slice(1), {
       env: { ...process.env, ...(spec?.env ?? {}) },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/electron/main/module-manager.ts
+++ b/electron/main/module-manager.ts
@@ -16,11 +16,9 @@
  * - Dependency auto-installation.
  */
 
-import { execFile } from "child_process";
 import * as fs from "fs/promises";
 import { statSync } from "fs";
 import * as path from "path";
-import { promisify } from "util";
 
 import { atomicWriteJson } from "./atomic-write";
 
@@ -51,8 +49,7 @@ import {
 } from "./modules/manifest-utils";
 import type { NodeDescriptor } from "./pdv-protocol";
 import { getResourcesRoot } from "./server/server-paths";
-
-const execFileAsync = promisify(execFile);
+import { serverExecFile } from "./server/spawn";
 
 /** Current on-disk metadata index schema version. */
 const MODULE_INDEX_SCHEMA_VERSION = "1.0";
@@ -1287,7 +1284,7 @@ export class ModuleManager {
     cwd?: string
   ): Promise<{ stdout: string; stderr: string }> {
     try {
-      const { stdout, stderr } = await execFileAsync("git", args, cwd ? { cwd } : undefined);
+      const { stdout, stderr } = await serverExecFile("git", args, cwd ? { cwd } : undefined);
       return { stdout: stdout.toString(), stderr: stderr.toString() };
     } catch (error) {
       const err = error as {

--- a/electron/main/process-stats.ts
+++ b/electron/main/process-stats.ts
@@ -18,10 +18,7 @@
  * scheduling is the caller's responsibility (see kernel-manager.ts).
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
+import { serverExecFile } from "./server/spawn";
 
 /**
  * Read the resident-set-size (RSS) of a process by PID, in bytes.
@@ -36,7 +33,7 @@ export async function getProcessRssBytes(pid: number): Promise<number | null> {
 
   try {
     if (process.platform === "darwin" || process.platform === "linux") {
-      const { stdout } = await execFileAsync("ps", ["-o", "rss=", "-p", String(pid)], {
+      const { stdout } = await serverExecFile("ps", ["-o", "rss=", "-p", String(pid)], {
         timeout: 2000,
       });
       const kb = parseInt(stdout.trim(), 10);
@@ -45,7 +42,7 @@ export async function getProcessRssBytes(pid: number): Promise<number | null> {
     }
 
     if (process.platform === "win32") {
-      const { stdout } = await execFileAsync(
+      const { stdout } = await serverExecFile(
         "tasklist",
         ["/FI", `PID eq ${pid}`, "/NH", "/FO", "CSV"],
         { timeout: 2000 },

--- a/electron/main/remote/setup-script.test.ts
+++ b/electron/main/remote/setup-script.test.ts
@@ -122,6 +122,44 @@ describe("shipSetupScript", () => {
     expect(fs.existsSync(path.join(remoteDir, "setup.sh"))).toBe(false);
   });
 
+  itUnix("normalizes CRLF line endings before shipping", async () => {
+    // A `\r` that ships embeds itself in every exported value and breaks
+    // `module load python\r` invisibly — the capture discards the output
+    // where the error would have shown.
+    const scriptDir = makeTempDir();
+    const fakeHome = makeTempDir();
+    fs.writeFileSync(
+      path.join(scriptDir, "feyn.sh"),
+      "module load python\r\nexport A=b\r\n",
+    );
+    const exec = vi.fn(async (_control, command: string) => {
+      const run = spawnSync("/bin/sh", ["-c", command], {
+        env: { ...process.env, HOME: fakeHome },
+        encoding: "utf8",
+      });
+      expect(run.status).toBe(0);
+      return okResult;
+    });
+    await shipSetupScript({
+      control: CONTROL,
+      host: "feyn",
+      sessionId: "pdv-matt",
+      setupScriptDir: scriptDir,
+      exec,
+    });
+    const landed = path.join(
+      fakeHome,
+      ".pdv-server",
+      "run",
+      "sessions",
+      "pdv-matt",
+      "setup.sh",
+    );
+    expect(await fs.promises.readFile(landed, "utf8")).toBe(
+      "module load python\nexport A=b\n",
+    );
+  });
+
   it("treats a whitespace-only master copy as unconfigured", async () => {
     const scriptDir = makeTempDir();
     fs.writeFileSync(path.join(scriptDir, "feyn.sh"), "  \n\t\n");

--- a/electron/main/remote/setup-script.test.ts
+++ b/electron/main/remote/setup-script.test.ts
@@ -1,0 +1,187 @@
+/**
+ * setup-script.test.ts — Shipping the per-host setup script.
+ *
+ * The write-command test executes the generated shell command through a
+ * REAL `/bin/sh` with `$HOME` pointed at a temp directory and asserts the
+ * exact bytes that land on disk — quoting bugs live in the gap between what
+ * PDV computes and what the shell does with it, and an assertion on the
+ * command string alone would test the computation against itself.
+ */
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { SshExecResult } from "./ssh-mux";
+import { localSetupScriptPath, shipSetupScript } from "./setup-script";
+
+const CONTROL = { host: "feyn", controlPath: "/tmp/pdv-test.sock" };
+
+const okResult: SshExecResult = {
+  ok: true,
+  exitCode: 0,
+  stdout: "",
+  stderr: "",
+  failure: null,
+};
+
+let tempDirs: string[] = [];
+const makeTempDir = (): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pdv-setup-script-"));
+  tempDirs.push(dir);
+  return dir;
+};
+
+afterEach(() => {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tempDirs = [];
+});
+
+describe("localSetupScriptPath", () => {
+  it("keys the master copy on the sanitized host alias", () => {
+    expect(localSetupScriptPath("/d", "feyn")).toBe("/d/feyn.sh");
+    expect(localSetupScriptPath("/d", "flux.pppl.gov")).toBe("/d/flux.pppl.gov.sh");
+    expect(localSetupScriptPath("/d", "evil/../host name")).toBe(
+      "/d/evil_.._host_name.sh",
+    );
+  });
+});
+
+describe("shipSetupScript", () => {
+  const itUnix = it.skipIf(process.platform === "win32");
+
+  itUnix("the generated command writes the exact script bytes under $HOME", async () => {
+    const scriptDir = makeTempDir();
+    const fakeHome = makeTempDir();
+    // Content chosen to break naive quoting: single quotes, double quotes,
+    // dollar expansion, backticks, newlines, and no trailing newline.
+    const content =
+      "module load python/3.12\n" +
+      "export MSG='it''s \"quoted\" $HOME `here`'\n" +
+      "echo done";
+    fs.writeFileSync(path.join(scriptDir, "feyn.sh"), content);
+
+    const exec = vi.fn(async (_control, command: string) => {
+      const run = spawnSync("/bin/sh", ["-c", command], {
+        env: { ...process.env, HOME: fakeHome },
+        encoding: "utf8",
+      });
+      expect(run.status).toBe(0);
+      return okResult;
+    });
+
+    const result = await shipSetupScript({
+      control: CONTROL,
+      host: "feyn",
+      sessionId: "pdv-matt",
+      setupScriptDir: scriptDir,
+      exec,
+    });
+
+    expect(result).toEqual({ ok: true, shipped: true });
+    const landed = path.join(
+      fakeHome,
+      ".pdv-server",
+      "run",
+      "sessions",
+      "pdv-matt",
+      "setup.sh",
+    );
+    expect(fs.readFileSync(landed, "utf8")).toBe(content);
+    // The temp file did not survive the atomic rename.
+    expect(fs.existsSync(`${landed}.tmp`)).toBe(false);
+  });
+
+  itUnix("removes the remote script when no master copy exists", async () => {
+    const scriptDir = makeTempDir();
+    const fakeHome = makeTempDir();
+    const remoteDir = path.join(fakeHome, ".pdv-server", "run", "sessions", "pdv-matt");
+    fs.mkdirSync(remoteDir, { recursive: true });
+    fs.writeFileSync(path.join(remoteDir, "setup.sh"), "stale\n");
+
+    const exec = vi.fn(async (_control, command: string) => {
+      const run = spawnSync("/bin/sh", ["-c", command], {
+        env: { ...process.env, HOME: fakeHome },
+        encoding: "utf8",
+      });
+      expect(run.status).toBe(0);
+      return okResult;
+    });
+
+    const result = await shipSetupScript({
+      control: CONTROL,
+      host: "feyn",
+      sessionId: "pdv-matt",
+      setupScriptDir: scriptDir,
+      exec,
+    });
+
+    expect(result).toEqual({ ok: true, shipped: false });
+    expect(fs.existsSync(path.join(remoteDir, "setup.sh"))).toBe(false);
+  });
+
+  it("treats a whitespace-only master copy as unconfigured", async () => {
+    const scriptDir = makeTempDir();
+    fs.writeFileSync(path.join(scriptDir, "feyn.sh"), "  \n\t\n");
+    const exec = vi.fn(async (_control: unknown, _command: string) => okResult);
+    const result = await shipSetupScript({
+      control: CONTROL,
+      host: "feyn",
+      sessionId: "pdv-matt",
+      setupScriptDir: scriptDir,
+      exec,
+    });
+    expect(result).toEqual({ ok: true, shipped: false });
+    expect(exec.mock.calls[0]?.[1]).toContain("rm -f");
+  });
+
+  it("fails loudly when a configured script cannot be delivered", async () => {
+    const scriptDir = makeTempDir();
+    fs.writeFileSync(path.join(scriptDir, "feyn.sh"), "module load python\n");
+    const exec = vi.fn(
+      async (): Promise<SshExecResult> => ({
+        ok: false,
+        exitCode: 1,
+        stdout: "",
+        stderr: "mkdir: cannot create directory",
+        failure: null,
+      }),
+    );
+    const result = await shipSetupScript({
+      control: CONTROL,
+      host: "feyn",
+      sessionId: "pdv-matt",
+      setupScriptDir: scriptDir,
+      exec,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("feyn");
+      expect(result.message).toContain("mkdir: cannot create directory");
+      expect(result.message).toContain(localSetupScriptPath(scriptDir, "feyn"));
+    }
+  });
+
+  it("reports success when only the removal of an unconfigured script fails", async () => {
+    const scriptDir = makeTempDir();
+    const exec = vi.fn(
+      async (): Promise<SshExecResult> => ({
+        ok: false,
+        exitCode: 1,
+        stdout: "",
+        stderr: "boom",
+        failure: null,
+      }),
+    );
+    const result = await shipSetupScript({
+      control: CONTROL,
+      host: "feyn",
+      sessionId: "pdv-matt",
+      setupScriptDir: scriptDir,
+      exec,
+    });
+    expect(result).toEqual({ ok: true, shipped: false });
+  });
+});

--- a/electron/main/remote/setup-script.ts
+++ b/electron/main/remote/setup-script.ts
@@ -1,0 +1,135 @@
+/**
+ * setup-script.ts — Ship the per-host setup script to a remote session.
+ *
+ * A cluster session often needs environment setup that only the user can
+ * specify — `module load python`, a conda activate, a scratch PATH entry.
+ * The master copy of that script lives on the LAPTOP, one file per host
+ * alias under `<userData>/remote-setup/<host>.sh`, so it is editable while
+ * offline and survives reinstalls on the cluster. At session start it is
+ * written to the session directory on the host
+ * (`~/.pdv-server/run/sessions/<id>/setup.sh`), where the daemon's
+ * login-environment capture (`server/login-env.ts`) sources it on its next
+ * start.
+ *
+ * When no script is configured locally the remote copy is removed, so
+ * deleting the local file is how a host is un-configured — a stale script
+ * silently shaping every kernel's environment would be worse than none.
+ *
+ * This module does NOT decide when shipping happens (`ipc-register-remote`
+ * ships at session start), provide editing UI (a Settings tab does, later),
+ * or interpret the script — it is content, not configuration.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+import { posixShellQuote } from "../editor-spawn";
+import { execViaSsh, type SshControl } from "./ssh-mux";
+
+/** Options for {@link shipSetupScript}. */
+export interface ShipSetupScriptOptions {
+  /** Live control connection to the host. */
+  control: SshControl;
+  /** Host alias as the user typed it — keys the local master copy. */
+  host: string;
+  /** Session whose directory receives the script. */
+  sessionId: string;
+  /** Directory of local master copies (`<userData>/remote-setup`). */
+  setupScriptDir: string;
+  /** `ssh` binary override (the PDV_SSH_PATH seam). */
+  sshPath?: string;
+  /** Injected by tests; production uses {@link execViaSsh}. */
+  exec?: typeof execViaSsh;
+}
+
+/** Outcome of {@link shipSetupScript}. */
+export type ShipSetupScriptResult =
+  | {
+      ok: true;
+      /** True when a script was written; false when none is configured. */
+      shipped: boolean;
+    }
+  | { ok: false; message: string };
+
+/**
+ * Local master-copy path for a host's setup script.
+ *
+ * The alias becomes a filename, so anything the filesystem might interpret
+ * is replaced. Two aliases that collide after sanitization share a script,
+ * which is harmless: aliases that close over the same characters are
+ * overwhelmingly the same host family.
+ *
+ * @param setupScriptDir - Directory of master copies.
+ * @param host - Host alias.
+ * @returns Absolute path of the master copy (existence not checked).
+ */
+export function localSetupScriptPath(setupScriptDir: string, host: string): string {
+  const safe = host.replace(/[^A-Za-z0-9._-]/g, "_");
+  return path.join(setupScriptDir, `${safe}.sh`);
+}
+
+/**
+ * Write (or remove) the session's setup script on the connected host.
+ *
+ * The write is atomic on the remote side (`.tmp` then `mv`) so a daemon
+ * capturing mid-ship reads either the old script or the new one, never a
+ * truncated file. Content travels as a single-quoted literal — POSIX
+ * quoting via {@link posixShellQuote}, never string interpolation of paths
+ * or content into shell syntax.
+ *
+ * @param options - Connection, host alias, session id and local directory.
+ * @returns `ok: true` with whether a script was shipped; `ok: false` with a
+ *   user-facing message when a configured script could not be delivered
+ *   (failing loudly beats a session whose interpreters are silently
+ *   missing). Removal failures are logged but reported as success — the
+ *   exotic failure there does not endanger the session being started.
+ */
+export async function shipSetupScript(
+  options: ShipSetupScriptOptions,
+): Promise<ShipSetupScriptResult> {
+  const exec = options.exec ?? execViaSsh;
+  const localPath = localSetupScriptPath(options.setupScriptDir, options.host);
+
+  let content: string | null;
+  try {
+    const raw = fs.readFileSync(localPath, "utf8");
+    content = raw.trim().length > 0 ? raw : null;
+  } catch {
+    content = null; // No master copy: treat as unconfigured.
+  }
+
+  // `"$HOME/..."'<id>'` — adjacent quoted strings concatenate in POSIX sh,
+  // so the id rides in its own single-quoted literal.
+  const sessionDir = `"$HOME/.pdv-server/run/sessions/"${posixShellQuote(options.sessionId)}`;
+
+  if (content === null) {
+    const result = await exec(
+      options.control,
+      `rm -f ${sessionDir}"/setup.sh"`,
+      { sshPath: options.sshPath },
+    );
+    if (!result.ok) {
+      console.error(
+        `[remote] could not remove the setup script on ${options.host}: ` +
+          `${result.stderr.trim() || (result.failure ?? "unknown")}`,
+      );
+    }
+    return { ok: true, shipped: false };
+  }
+
+  const command =
+    `mkdir -p ${sessionDir} && ` +
+    `printf '%s' ${posixShellQuote(content)} > ${sessionDir}"/setup.sh.tmp" && ` +
+    `mv ${sessionDir}"/setup.sh.tmp" ${sessionDir}"/setup.sh"`;
+  const result = await exec(options.control, command, { sshPath: options.sshPath });
+  if (!result.ok) {
+    return {
+      ok: false,
+      message:
+        `The setup script for ${options.host} could not be delivered: ` +
+        `${result.stderr.trim() || (result.failure ?? "unknown failure")}. ` +
+        `Fix or remove ${localPath} and try again.`,
+    };
+  }
+  return { ok: true, shipped: true };
+}

--- a/electron/main/remote/setup-script.ts
+++ b/electron/main/remote/setup-script.ts
@@ -15,6 +15,11 @@
  * deleting the local file is how a host is un-configured — a stale script
  * silently shaping every kernel's environment would be worse than none.
  *
+ * Script contract: it is sourced by `bash -l` with all output discarded,
+ * and environment mutations are its entire effect. Variables named `PDV_*`
+ * (and `ELECTRON_RUN_AS_NODE`) are the daemon's own namespace — exports
+ * under that prefix are silently discarded by the login-env application.
+ *
  * This module does NOT decide when shipping happens (`ipc-register-remote`
  * ships at session start), provide editing UI (a Settings tab does, later),
  * or interpret the script — it is content, not configuration.
@@ -92,7 +97,12 @@ export async function shipSetupScript(
 
   let content: string | null;
   try {
-    const raw = fs.readFileSync(localPath, "utf8");
+    // CRLF is normalized at read time: the master copy is PDV-owned
+    // configuration a user may edit with anything, and a shipped `\r`
+    // embeds itself in every exported value (`FOO=bar\r`) or breaks
+    // `module load python\r` invisibly — the capture discards the output
+    // where the error would have shown.
+    const raw = fs.readFileSync(localPath, "utf8").replace(/\r\n/g, "\n");
     content = raw.trim().length > 0 ? raw : null;
   } catch {
     content = null; // No master copy: treat as unconfigured.

--- a/electron/main/server/attach-cli.ts
+++ b/electron/main/server/attach-cli.ts
@@ -29,8 +29,16 @@ import { acquireSpawnLock } from "./session-lock";
 import { readSessionMeta } from "./session-meta";
 import { resolveSessionPaths, type SessionPaths } from "./session-paths";
 
-/** How long to wait for a freshly spawned daemon to bind its socket. */
-export const SPAWN_WAIT_MS = 10_000;
+/**
+ * How long to wait for a freshly spawned daemon to bind its socket. Sized
+ * to contain the daemon's startup login-environment capture — up to 15 s
+ * when a setup script full of `module load` lines exists
+ * (`login-env.ts`'s SETUP_CAPTURE_TIMEOUT_MS) — plus bundle require and
+ * bind overhead on a contended login node. A successful start never waits
+ * this long (the poll returns as soon as the socket answers); the budget
+ * only delays the failure verdict.
+ */
+export const SPAWN_WAIT_MS = 25_000;
 
 /** Poll interval while waiting for the socket to appear. */
 const SPAWN_POLL_MS = 50;

--- a/electron/main/server/login-env.test.ts
+++ b/electron/main/server/login-env.test.ts
@@ -48,18 +48,25 @@ describe("captureLoginEnv", () => {
   });
 
   itUnix("captures the login shell's environment", async () => {
-    const env = await captureLoginEnv();
-    expect(env).not.toBeNull();
+    const captured = await captureLoginEnv();
+    expect(captured).not.toBeNull();
     // PATH is the one variable every shell must end up with.
-    expect(env?.PATH).toBeTruthy();
+    expect(captured?.env.PATH).toBeTruthy();
+    expect(captured?.setupScriptSourced).toBe(false);
   });
 
-  itUnix("sources the setup script when it exists", async () => {
+  itUnix("sources the setup script and reports evidence of it", async () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pdv-login-env-"));
     const script = path.join(tempDir, "setup.sh");
-    fs.writeFileSync(script, "export PDV_LOGIN_ENV_TEST_MARKER='from setup'\n");
-    const env = await captureLoginEnv({ setupScriptPath: script });
-    expect(env?.PDV_LOGIN_ENV_TEST_MARKER).toBe("from setup");
+    fs.writeFileSync(script, "export LOGIN_ENV_TEST_MARKER='from setup'\n");
+    const captured = await captureLoginEnv({ setupScriptPath: script });
+    expect(captured?.env.LOGIN_ENV_TEST_MARKER).toBe("from setup");
+    expect(captured?.setupScriptSourced).toBe(true);
+    // The evidence sentinel and the capture's own plumbing never leak into
+    // the returned map.
+    expect(captured?.env.PDV_SETUP_SOURCED).toBeUndefined();
+    expect(captured?.env.PDV_SETUP_SCRIPT).toBeUndefined();
+    expect(captured?.env.PDV_ENV_OUT).toBeUndefined();
   });
 
   itUnix("survives a setup script that fails and discards its output", async () => {
@@ -68,20 +75,22 @@ describe("captureLoginEnv", () => {
     fs.writeFileSync(
       script,
       "echo '9.99 chatter that must not corrupt anything'\n" +
-        "export PDV_LOGIN_ENV_TEST_MARKER=survived\n" +
+        "export LOGIN_ENV_TEST_MARKER=survived\n" +
         "this-command-does-not-exist\n",
     );
-    const env = await captureLoginEnv({ setupScriptPath: script });
+    const captured = await captureLoginEnv({ setupScriptPath: script });
     // The failing line does not abort the capture, and the marker before it
     // was still exported.
-    expect(env?.PDV_LOGIN_ENV_TEST_MARKER).toBe("survived");
+    expect(captured?.env.LOGIN_ENV_TEST_MARKER).toBe("survived");
+    expect(captured?.setupScriptSourced).toBe(true);
   });
 
-  itUnix("ignores a missing setup script", async () => {
-    const env = await captureLoginEnv({
+  itUnix("ignores a missing setup script and does not claim it sourced one", async () => {
+    const captured = await captureLoginEnv({
       setupScriptPath: "/nonexistent/pdv-setup-test.sh",
     });
-    expect(env).not.toBeNull();
+    expect(captured).not.toBeNull();
+    expect(captured?.setupScriptSourced).toBe(false);
   });
 
   itUnix("returns null when the shell hangs past the budget", async () => {

--- a/electron/main/server/login-env.test.ts
+++ b/electron/main/server/login-env.test.ts
@@ -1,0 +1,154 @@
+/**
+ * login-env.test.ts — Login-environment capture and application.
+ *
+ * The capture tests run REAL login shells: what this module exists for is
+ * the gap between a computed environment and what a shell actually produces
+ * (profile chatter, multi-line values, exported functions), and a mocked
+ * shell cannot exercise any of that. The apply tests pin the protection
+ * contract: a user profile must never override the daemon's own `PDV_*`
+ * state.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  applyLoginEnv,
+  captureLoginEnv,
+  parseNulEnv,
+} from "./login-env";
+
+const itUnix = it.skipIf(process.platform === "win32");
+
+describe("parseNulEnv", () => {
+  it("parses NUL-separated pairs", () => {
+    expect(parseNulEnv("A=1\0B=two\0")).toEqual({ A: "1", B: "two" });
+  });
+
+  it("preserves values containing newlines and equals signs", () => {
+    const raw = "FUNC=() {\n  echo hi\n}\0URL=a=b=c\0";
+    expect(parseNulEnv(raw)).toEqual({
+      FUNC: "() {\n  echo hi\n}",
+      URL: "a=b=c",
+    });
+  });
+
+  it("skips empty and malformed entries", () => {
+    expect(parseNulEnv("\0=nokey\0PLAIN\0OK=yes\0")).toEqual({ OK: "yes" });
+  });
+});
+
+describe("captureLoginEnv", () => {
+  let tempDir: string | null = null;
+  afterEach(() => {
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  });
+
+  itUnix("captures the login shell's environment", async () => {
+    const env = await captureLoginEnv();
+    expect(env).not.toBeNull();
+    // PATH is the one variable every shell must end up with.
+    expect(env?.PATH).toBeTruthy();
+  });
+
+  itUnix("sources the setup script when it exists", async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pdv-login-env-"));
+    const script = path.join(tempDir, "setup.sh");
+    fs.writeFileSync(script, "export PDV_LOGIN_ENV_TEST_MARKER='from setup'\n");
+    const env = await captureLoginEnv({ setupScriptPath: script });
+    expect(env?.PDV_LOGIN_ENV_TEST_MARKER).toBe("from setup");
+  });
+
+  itUnix("survives a setup script that fails and discards its output", async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pdv-login-env-"));
+    const script = path.join(tempDir, "setup.sh");
+    fs.writeFileSync(
+      script,
+      "echo '9.99 chatter that must not corrupt anything'\n" +
+        "export PDV_LOGIN_ENV_TEST_MARKER=survived\n" +
+        "this-command-does-not-exist\n",
+    );
+    const env = await captureLoginEnv({ setupScriptPath: script });
+    // The failing line does not abort the capture, and the marker before it
+    // was still exported.
+    expect(env?.PDV_LOGIN_ENV_TEST_MARKER).toBe("survived");
+  });
+
+  itUnix("ignores a missing setup script", async () => {
+    const env = await captureLoginEnv({
+      setupScriptPath: "/nonexistent/pdv-setup-test.sh",
+    });
+    expect(env).not.toBeNull();
+  });
+
+  itUnix("returns null when the shell hangs past the budget", async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pdv-login-env-"));
+    const slowShell = path.join(tempDir, "slow-shell");
+    fs.writeFileSync(slowShell, "#!/bin/sh\nsleep 5\n", { mode: 0o755 });
+    const env = await captureLoginEnv({ shellPath: slowShell, timeoutMs: 200 });
+    expect(env).toBeNull();
+  });
+
+  itUnix("returns null when the shell is missing", async () => {
+    const env = await captureLoginEnv({
+      shellPath: "/nonexistent/pdv-no-such-bash",
+    });
+    expect(env).toBeNull();
+  });
+});
+
+describe("applyLoginEnv", () => {
+  const TOUCHED = [
+    "PDV_LOGIN_APPLY_A",
+    "PDV_APPLY_PROTECTED_TEST",
+    "LOGIN_APPLY_PLAIN",
+    "ELECTRON_RUN_AS_NODE",
+  ] as const;
+  const saved = new Map<string, string | undefined>();
+
+  afterEach(() => {
+    for (const key of TOUCHED) {
+      const value = saved.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    saved.clear();
+  });
+
+  const save = (): void => {
+    for (const key of TOUCHED) saved.set(key, process.env[key]);
+  };
+
+  it("adds and changes plain variables, counting only real changes", () => {
+    save();
+    delete process.env.LOGIN_APPLY_PLAIN;
+    const changed = applyLoginEnv({ LOGIN_APPLY_PLAIN: "v" });
+    expect(process.env.LOGIN_APPLY_PLAIN).toBe("v");
+    expect(changed).toBe(1);
+    // Applying the same value again changes nothing.
+    expect(applyLoginEnv({ LOGIN_APPLY_PLAIN: "v" })).toBe(0);
+  });
+
+  it("never lets a capture override PDV_* or ELECTRON_RUN_AS_NODE", () => {
+    save();
+    process.env.PDV_APPLY_PROTECTED_TEST = "daemon-truth";
+    process.env.ELECTRON_RUN_AS_NODE = "1";
+    const changed = applyLoginEnv({
+      PDV_APPLY_PROTECTED_TEST: "profile-lie",
+      ELECTRON_RUN_AS_NODE: "0",
+    });
+    expect(changed).toBe(0);
+    expect(process.env.PDV_APPLY_PROTECTED_TEST).toBe("daemon-truth");
+    expect(process.env.ELECTRON_RUN_AS_NODE).toBe("1");
+  });
+
+  it("leaves variables absent from the capture untouched", () => {
+    save();
+    process.env.LOGIN_APPLY_PLAIN = "keep-me";
+    applyLoginEnv({ PDV_LOGIN_APPLY_A: "x" });
+    expect(process.env.LOGIN_APPLY_PLAIN).toBe("keep-me");
+  });
+});

--- a/electron/main/server/login-env.ts
+++ b/electron/main/server/login-env.ts
@@ -27,7 +27,11 @@
  * output is discarded — diagnosis belongs to the explicit test channel, not
  * to interleaving with a capture. Environment mutations are the script's
  * entire contract; Lmod is implemented purely in environment variables, so
- * a capture loses nothing a wrapper would have kept.
+ * a capture loses nothing a wrapper would have kept. One reservation in
+ * that contract: variables named `PDV_*` (and `ELECTRON_RUN_AS_NODE`) are
+ * the daemon's own namespace and are silently discarded by
+ * {@link applyLoginEnv} — a setup script must not use the prefix for its
+ * own exports.
  *
  * This module does NOT run on the shell side, decide when to re-capture
  * (the daemon captures once at boot; edits to the setup script apply on the
@@ -44,12 +48,27 @@ import { serverExecFile } from "./spawn";
 const PROTECTED_ENV_PREFIXES = ["PDV_", "ELECTRON_RUN_AS_NODE"];
 
 /**
- * Default budget for the login shell. Deliberately half of the attacher's
- * `SPAWN_WAIT_MS` (10 s): the capture runs before the daemon binds its
- * socket, so a budget as large as the attacher's would let a slow profile
- * fail the whole attach instead of just degrading to the inherited env.
+ * Default budget for the login shell with no setup script. The capture runs
+ * before the daemon binds its socket, so the budget must stay well inside
+ * the attacher's socket wait (`SPAWN_WAIT_MS`) — a slow profile should
+ * degrade to the inherited env, not fail the whole attach.
  */
 export const CAPTURE_TIMEOUT_MS = 5_000;
+
+/**
+ * Budget when a setup script exists: `module load` lines legitimately take
+ * multiple seconds on a contended login node, and a user who configured a
+ * script has said the environment matters more than a fast boot. The
+ * attacher's socket wait is sized to contain this plus bind overhead.
+ */
+export const SETUP_CAPTURE_TIMEOUT_MS = 15_000;
+
+/**
+ * Sentinel the capture shell exports after sourcing the setup script, so
+ * "the script really ran" is evidence read from the capture itself — never
+ * inferred from the file existing. Stripped from the returned map.
+ */
+const SETUP_SOURCED_SENTINEL = "PDV_SETUP_SOURCED";
 
 /** Options for {@link captureLoginEnv}. */
 export interface CaptureLoginEnvOptions {
@@ -60,45 +79,76 @@ export interface CaptureLoginEnvOptions {
   setupScriptPath?: string;
   /** Shell binary. Defaults to `bash` from PATH. Injected by tests. */
   shellPath?: string;
-  /** Capture budget in milliseconds. Defaults to {@link CAPTURE_TIMEOUT_MS}. */
+  /**
+   * Capture budget in milliseconds. Defaults to {@link CAPTURE_TIMEOUT_MS},
+   * or {@link SETUP_CAPTURE_TIMEOUT_MS} when the setup script exists.
+   */
   timeoutMs?: number;
+}
+
+/** Result of a successful {@link captureLoginEnv}. */
+export interface CapturedLoginEnv {
+  /** The captured environment map. */
+  env: Record<string, string>;
+  /**
+   * True when the setup script was really sourced — evidence from a
+   * sentinel the capture shell exports after the `.` line, not a guess
+   * from the file existing on disk.
+   */
+  setupScriptSourced: boolean;
 }
 
 /**
  * Run one login shell and capture the environment it ends with.
  *
  * @param options - Setup script and timeout options.
- * @returns The captured environment map, or `null` when the capture failed
- *   (no bash, profile hung past the budget, unwritable temp dir, win32).
- *   Failure is survivable by design: the daemon then runs with its
- *   inherited environment, exactly as it did before this module existed.
+ * @returns The captured environment plus sourcing evidence, or `null` when
+ *   the capture failed (no bash, profile hung past the budget, unwritable
+ *   temp dir, win32). Failure is survivable by design: the daemon then runs
+ *   with its inherited environment, exactly as it did before this module
+ *   existed — but the caller must surface it when a setup script was
+ *   configured, because then the user explicitly asked for an environment
+ *   they are not getting.
  */
 export async function captureLoginEnv(
   options: CaptureLoginEnvOptions = {},
-): Promise<Record<string, string> | null> {
+): Promise<CapturedLoginEnv | null> {
   if (process.platform === "win32") return null;
 
   const outPath = path.join(
     os.tmpdir(),
     `pdv-login-env-${process.pid}-${Date.now()}.tmp`,
   );
+  const setupScriptExists =
+    !!options.setupScriptPath && fs.existsSync(options.setupScriptPath);
   // The script and output paths travel as environment variables, never
   // spliced into the shell string: quoting inside a nested shell is exactly
   // the class of computed-vs-OS bug the remote work keeps hitting.
   const script =
     'if [ -n "$PDV_SETUP_SCRIPT" ] && [ -f "$PDV_SETUP_SCRIPT" ]; then' +
-    ' . "$PDV_SETUP_SCRIPT" >/dev/null 2>&1; fi; env -0 > "$PDV_ENV_OUT"';
+    ` . "$PDV_SETUP_SCRIPT" >/dev/null 2>&1; export ${SETUP_SOURCED_SENTINEL}=1;` +
+    ' fi; env -0 > "$PDV_ENV_OUT"';
 
   try {
     await serverExecFile(options.shellPath ?? "bash", ["-lc", script], {
-      timeout: options.timeoutMs ?? CAPTURE_TIMEOUT_MS,
+      timeout:
+        options.timeoutMs ??
+        (setupScriptExists ? SETUP_CAPTURE_TIMEOUT_MS : CAPTURE_TIMEOUT_MS),
       env: {
         ...process.env,
         PDV_SETUP_SCRIPT: options.setupScriptPath ?? "",
         PDV_ENV_OUT: outPath,
       },
     });
-    return parseNulEnv(fs.readFileSync(outPath, "utf8"));
+    const env = parseNulEnv(fs.readFileSync(outPath, "utf8"));
+    const setupScriptSourced = env[SETUP_SOURCED_SENTINEL] === "1";
+    delete env[SETUP_SOURCED_SENTINEL];
+    // The capture's own plumbing variables must not read as "the login
+    // environment" (they would be discarded by applyLoginEnv anyway, but
+    // returning them would mislead any other consumer of the map).
+    delete env.PDV_SETUP_SCRIPT;
+    delete env.PDV_ENV_OUT;
+    return { env, setupScriptSourced };
   } catch (err) {
     console.error(
       `[login-env] capture failed; continuing with the inherited environment: ` +

--- a/electron/main/server/login-env.ts
+++ b/electron/main/server/login-env.ts
@@ -1,0 +1,163 @@
+/**
+ * login-env.ts — Capture the host's login-shell environment for the daemon.
+ *
+ * A remote session daemon is spawned from an `ssh <host> '…attach…'` exec
+ * channel, which runs a NON-login shell: `~/.bash_profile`, `/etc/profile.d`
+ * (and with them Lmod's module system, juliaup's PATH entry, conda's hook)
+ * never ran, so interpreters that every interactive shell on the cluster can
+ * see are invisible to the daemon and to everything it spawns. This module
+ * closes that gap by running ONE login shell at daemon startup —
+ * `bash -lc '. setup.sh; env -0 > <file>'` — and applying the captured
+ * environment to the daemon's own `process.env`. Every subprocess seam
+ * (`server/spawn.ts`) call site already builds its env from `process.env`,
+ * so kernels, probes, uv and Pkg all inherit the login environment with no
+ * per-spawn cost.
+ *
+ * Why a one-shot capture instead of wrapping every spawn in `bash -lc`:
+ * login shells PRINT — Lmod messages and profile chatter land on stdout
+ * before any redirect inside the `-c` string takes effect, and interpreter
+ * probes parse stdout with permissive regexes (`resolvePythonMajorMinor`
+ * matches the first `\d+.\d+` it sees). Writing `env -0` to a FILE keeps
+ * the capture immune to that chatter, and paying the login-shell cost once
+ * per daemon rather than per spawn keeps probe latency flat.
+ *
+ * The optional per-session setup script (`sessions/<id>/setup.sh`, shipped
+ * by the shell at session start) is sourced inside the same login shell, so
+ * `module load …` lines work exactly as they would typed at a prompt. Its
+ * output is discarded — diagnosis belongs to the explicit test channel, not
+ * to interleaving with a capture. Environment mutations are the script's
+ * entire contract; Lmod is implemented purely in environment variables, so
+ * a capture loses nothing a wrapper would have kept.
+ *
+ * This module does NOT run on the shell side, decide when to re-capture
+ * (the daemon captures once at boot; edits to the setup script apply on the
+ * next session start), or spawn user tools (`spawn.ts` does).
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { serverExecFile } from "./spawn";
+
+/** Environment keys the capture must never override or remove. */
+const PROTECTED_ENV_PREFIXES = ["PDV_", "ELECTRON_RUN_AS_NODE"];
+
+/**
+ * Default budget for the login shell. Deliberately half of the attacher's
+ * `SPAWN_WAIT_MS` (10 s): the capture runs before the daemon binds its
+ * socket, so a budget as large as the attacher's would let a slow profile
+ * fail the whole attach instead of just degrading to the inherited env.
+ */
+export const CAPTURE_TIMEOUT_MS = 5_000;
+
+/** Options for {@link captureLoginEnv}. */
+export interface CaptureLoginEnvOptions {
+  /**
+   * Absolute path of a setup script to source inside the login shell.
+   * Sourced only when the file exists; its stdout/stderr are discarded.
+   */
+  setupScriptPath?: string;
+  /** Shell binary. Defaults to `bash` from PATH. Injected by tests. */
+  shellPath?: string;
+  /** Capture budget in milliseconds. Defaults to {@link CAPTURE_TIMEOUT_MS}. */
+  timeoutMs?: number;
+}
+
+/**
+ * Run one login shell and capture the environment it ends with.
+ *
+ * @param options - Setup script and timeout options.
+ * @returns The captured environment map, or `null` when the capture failed
+ *   (no bash, profile hung past the budget, unwritable temp dir, win32).
+ *   Failure is survivable by design: the daemon then runs with its
+ *   inherited environment, exactly as it did before this module existed.
+ */
+export async function captureLoginEnv(
+  options: CaptureLoginEnvOptions = {},
+): Promise<Record<string, string> | null> {
+  if (process.platform === "win32") return null;
+
+  const outPath = path.join(
+    os.tmpdir(),
+    `pdv-login-env-${process.pid}-${Date.now()}.tmp`,
+  );
+  // The script and output paths travel as environment variables, never
+  // spliced into the shell string: quoting inside a nested shell is exactly
+  // the class of computed-vs-OS bug the remote work keeps hitting.
+  const script =
+    'if [ -n "$PDV_SETUP_SCRIPT" ] && [ -f "$PDV_SETUP_SCRIPT" ]; then' +
+    ' . "$PDV_SETUP_SCRIPT" >/dev/null 2>&1; fi; env -0 > "$PDV_ENV_OUT"';
+
+  try {
+    await serverExecFile(options.shellPath ?? "bash", ["-lc", script], {
+      timeout: options.timeoutMs ?? CAPTURE_TIMEOUT_MS,
+      env: {
+        ...process.env,
+        PDV_SETUP_SCRIPT: options.setupScriptPath ?? "",
+        PDV_ENV_OUT: outPath,
+      },
+    });
+    return parseNulEnv(fs.readFileSync(outPath, "utf8"));
+  } catch (err) {
+    console.error(
+      `[login-env] capture failed; continuing with the inherited environment: ` +
+        `${(err as Error).message}`,
+    );
+    return null;
+  } finally {
+    try {
+      fs.unlinkSync(outPath);
+    } catch {
+      // Never written, or already gone.
+    }
+  }
+}
+
+/**
+ * Apply a captured environment to this process.
+ *
+ * Every captured variable is assigned onto `process.env` except protected
+ * keys (`PDV_*`, `ELECTRON_RUN_AS_NODE`): those carry the daemon's own
+ * contract (resources root, zeromq path, version) and a user profile that
+ * exports one must lose to the values the daemon was started with.
+ * Variables present in `process.env` but absent from the capture are left
+ * alone — a profile cannot *remove* daemon state, only add to it.
+ *
+ * @param captured - Map from {@link captureLoginEnv}.
+ * @returns The number of variables that were added or changed.
+ */
+export function applyLoginEnv(captured: Record<string, string>): number {
+  let changed = 0;
+  for (const [key, value] of Object.entries(captured)) {
+    if (PROTECTED_ENV_PREFIXES.some((p) => key === p || key.startsWith(p))) {
+      continue;
+    }
+    if (process.env[key] !== value) {
+      process.env[key] = value;
+      changed += 1;
+    }
+  }
+  return changed;
+}
+
+/**
+ * Parse `env -0` output into a map.
+ *
+ * NUL separation is what makes this parse exact: environment values may
+ * contain newlines (bash functions exported via `BASH_FUNC_*`, multi-line
+ * module variables), so a line-based parse would corrupt them.
+ *
+ * @param raw - Raw `env -0` output.
+ * @returns Map of environment variables.
+ */
+export function parseNulEnv(raw: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const entry of raw.split("\0")) {
+    if (!entry) continue;
+    const eq = entry.indexOf("=");
+    if (eq <= 0) continue;
+    env[entry.slice(0, eq)] = entry.slice(eq + 1);
+  }
+  return env;
+}

--- a/electron/main/server/server-files.ts
+++ b/electron/main/server/server-files.ts
@@ -34,6 +34,7 @@ export const SERVER_DESTINED_FILES: readonly string[] = [
   "server/server-paths.ts",
   "server/shell-confirm.ts",
   "server/wire.ts",
+  "server/spawn.ts",
   "server/self-check.ts",
   "server/session-paths.ts",
   "server/session-lock.ts",

--- a/electron/main/server/server-files.ts
+++ b/electron/main/server/server-files.ts
@@ -35,6 +35,7 @@ export const SERVER_DESTINED_FILES: readonly string[] = [
   "server/shell-confirm.ts",
   "server/wire.ts",
   "server/spawn.ts",
+  "server/login-env.ts",
   "server/self-check.ts",
   "server/session-paths.ts",
   "server/session-lock.ts",

--- a/electron/main/server/server-main.ts
+++ b/electron/main/server/server-main.ts
@@ -59,6 +59,7 @@ import { setAppVersion } from "../pdv-protocol";
 import { RPC_CHANNELS } from "../transport/protocol";
 import { RpcServer } from "../transport/rpc-server";
 import { runSelfCheck } from "./self-check";
+import { applyLoginEnv, captureLoginEnv } from "./login-env";
 import { attachToSession, proxyStdio } from "./attach-cli";
 import { SessionHost } from "./session-host";
 import { resolveSessionPaths } from "./session-paths";
@@ -352,6 +353,23 @@ async function runSessionHost(args: string[]): Promise<void> {
   const pdvDir = process.env.PDV_PDV_DIR ?? path.join(os.homedir(), ".PDV");
   fs.mkdirSync(pdvDir, { recursive: true });
   setAppVersion(version);
+
+  // A daemon spawned over an ssh exec channel never ran a login shell, so
+  // Lmod/juliaup/conda PATH entries are invisible to it and to every kernel
+  // and probe it spawns. Capture the login environment (sourcing the
+  // session's setup script when one was shipped) BEFORE any manager exists —
+  // process.env is what every spawn call site builds from. A failed capture
+  // is logged and survived: the daemon then behaves exactly as before.
+  const captured = await captureLoginEnv({
+    setupScriptPath: paths.setupScriptPath,
+  });
+  if (captured) {
+    const changed = applyLoginEnv(captured);
+    console.log(
+      `[session-host] applied login environment (${changed} variables ` +
+        `added or changed${fs.existsSync(paths.setupScriptPath) ? ", setup.sh sourced" : ""})`,
+    );
+  }
 
   const commRouter = new CommRouter();
   const queryRouter = new QueryRouter();

--- a/electron/main/server/server-main.ts
+++ b/electron/main/server/server-main.ts
@@ -347,7 +347,18 @@ async function runSessionHost(args: string[]): Promise<void> {
     return;
   }
   const root = flagValue(args, "--root") ?? defaultRoot();
-  const version = process.env.PDV_APP_VERSION ?? "unknown";
+  // Required, exactly as in serve mode — and MORE dangerous to default here:
+  // the attach handshake gates on the RPC protocol version (by design, so an
+  // app upgrade never orphans a live daemon), which means a daemon running
+  // as version "unknown" starts fine, attaches fine, and then the comm
+  // router silently rejects every kernel message as version-incompatible.
+  // A daemon that can never accept a kernel must refuse to start instead.
+  const version = process.env.PDV_APP_VERSION;
+  if (!version) {
+    console.error("[session-host] PDV_APP_VERSION is required (kernel comm version check)");
+    process.exit(2);
+    return;
+  }
 
   const paths = resolveSessionPaths({ sessionId, root });
   const pdvDir = process.env.PDV_PDV_DIR ?? path.join(os.homedir(), ".PDV");
@@ -359,15 +370,28 @@ async function runSessionHost(args: string[]): Promise<void> {
   // and probe it spawns. Capture the login environment (sourcing the
   // session's setup script when one was shipped) BEFORE any manager exists —
   // process.env is what every spawn call site builds from. A failed capture
-  // is logged and survived: the daemon then behaves exactly as before.
+  // is survived (the daemon then behaves exactly as before this existed),
+  // but when a setup script was shipped the failure is loud and recorded in
+  // session.json: the user explicitly asked for an environment they are not
+  // getting, and "interpreters silently missing" is the harder bug.
+  const setupScriptShipped = fs.existsSync(paths.setupScriptPath);
   const captured = await captureLoginEnv({
     setupScriptPath: paths.setupScriptPath,
   });
+  const setupScriptApplied = captured?.setupScriptSourced ?? false;
   if (captured) {
-    const changed = applyLoginEnv(captured);
+    const changed = applyLoginEnv(captured.env);
     console.log(
       `[session-host] applied login environment (${changed} variables ` +
-        `added or changed${fs.existsSync(paths.setupScriptPath) ? ", setup.sh sourced" : ""})`,
+        `added or changed${captured.setupScriptSourced ? "; setup script sourced" : ""})`,
+    );
+  }
+  if (setupScriptShipped && !setupScriptApplied) {
+    console.error(
+      `[session-host] SETUP SCRIPT NOT APPLIED: ${paths.setupScriptPath} was ` +
+        "shipped but the login-environment capture did not source it " +
+        "(capture failed or timed out). Kernels in this session run WITHOUT " +
+        "the configured environment.",
     );
   }
 
@@ -459,6 +483,7 @@ async function runSessionHost(args: string[]): Promise<void> {
     sockPath: paths.sockPath,
     runtimeSource: paths.runtimeSource,
     startedAt: new Date().toISOString(),
+    setupScriptApplied,
   });
 
   console.log(

--- a/electron/main/server/session-meta.ts
+++ b/electron/main/server/session-meta.ts
@@ -47,6 +47,14 @@ export interface SessionMeta {
   runtimeSource: string;
   /** ISO timestamp of daemon start. */
   startedAt: string;
+  /**
+   * True when a shipped setup script was really sourced by the startup
+   * login-environment capture (evidence from the capture, not file
+   * existence). Absent on daemons predating the field. False with a script
+   * on disk means the capture failed — the session runs without the
+   * configured environment.
+   */
+  setupScriptApplied?: boolean;
 }
 
 /**

--- a/electron/main/server/session-paths.ts
+++ b/electron/main/server/session-paths.ts
@@ -84,6 +84,12 @@ export interface SessionPaths {
   lockPath: string;
   /** Daemon log (stdout/stderr are redirected here, never to the channel). */
   logPath: string;
+  /**
+   * Per-session setup script sourced into the daemon's login-env capture
+   * (`login-env.ts`). Written by the shell at session start; absent when the
+   * host has no script configured.
+   */
+  setupScriptPath: string;
   /** The Unix socket clients attach to; node-local, never on NFS. */
   sockPath: string;
   /** Which candidate the socket directory came from. */
@@ -189,6 +195,7 @@ export function resolveSessionPaths(
       metaPath: path.join(sessionDir, "session.json"),
       lockPath: path.join(sessionDir, "spawn.lock"),
       logPath: path.join(sessionDir, "session.log"),
+      setupScriptPath: path.join(sessionDir, "setup.sh"),
       sockPath,
       runtimeSource: candidate.source,
       hostname: opts.hostname ?? os.hostname(),

--- a/electron/main/server/spawn.test.ts
+++ b/electron/main/server/spawn.test.ts
@@ -90,18 +90,30 @@ describe("serverSpawn", () => {
 
   it("kills the child when the abort signal fires", async () => {
     const controller = new AbortController();
-    const proc = serverSpawn("sh", ["-c", "sleep 5"], {
+    // sleep 30 (not 5): a failed kill must TIME OUT loudly, never pass by
+    // the child exiting naturally inside the test budget.
+    const proc = serverSpawn("sh", ["-c", "sleep 30"], {
       stdio: ["ignore", "pipe", "pipe"],
       signal: controller.signal,
-    });
-    const closed = new Promise<number | null>((resolve) => {
-      proc.on("close", resolve);
     });
     proc.on("error", () => {
       /* AbortError is expected; the assertion is that the child dies. */
     });
+    // Abort only after the process really exists — aborting mid-spawn raced
+    // on CI Linux, where the kill landed before the pid did and the exit
+    // event never fired inside the budget. `exit`, not `close`: close also
+    // waits for stdio to drain through any grandchildren holding the pipes.
+    await new Promise<void>((resolve) => proc.once("spawn", resolve));
+    const exited = new Promise<{ code: number | null; signal: string | null }>(
+      (resolve) => {
+        proc.once("exit", (code, signal) => resolve({ code, signal }));
+      },
+    );
     controller.abort();
-    const code = await closed;
+    const { code, signal } = await exited;
+    // A signal kill reports (null, SIGTERM); either way it must not be a
+    // clean exit 0.
+    expect(signal ?? "no-signal").toMatch(/^SIG/);
     expect(code).not.toBe(0);
   });
 });

--- a/electron/main/server/spawn.test.ts
+++ b/electron/main/server/spawn.test.ts
@@ -1,0 +1,138 @@
+/**
+ * spawn.test.ts — Behavior contracts of the server spawn seam, plus the
+ * import guard that makes it the *single* subprocess seam.
+ *
+ * The contract tests pin the semantics call sites rely on: `serverExecFile`
+ * resolves decoded streams on success and rejects with `stdout`/`stderr`
+ * attached on failure (module-manager surfaces git errors from those
+ * fields), and `serverSpawn` hands back a live child whose streaming,
+ * timeout, and abort behavior matches `child_process.spawn`.
+ *
+ * The guard test enforces the seam: no server-destined file other than
+ * spawn.ts itself (and daemonize.ts, which spawns pdv-server rather than a
+ * user tool) may import `child_process`. Without this, a new tool spawn
+ * added anywhere in the server tree would silently bypass the future
+ * remote setup-script wrapping and run without the session's environment.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { SERVER_DESTINED_FILES } from "./server-files";
+import { serverExecFile, serverSpawn } from "./spawn";
+
+const MAIN_DIR = path.resolve(__dirname, "..");
+
+describe("serverExecFile", () => {
+  it("resolves with decoded stdout and stderr on exit 0", async () => {
+    const { stdout, stderr } = await serverExecFile("sh", [
+      "-c",
+      "printf out; printf err >&2",
+    ]);
+    expect(stdout).toBe("out");
+    expect(stderr).toBe("err");
+  });
+
+  it("rejects on non-zero exit with stdout/stderr attached to the error", async () => {
+    let caught: unknown;
+    try {
+      await serverExecFile("sh", ["-c", "printf partial; printf oops >&2; exit 3"]);
+    } catch (err) {
+      caught = err;
+    }
+    const e = caught as { code?: number; stdout?: string; stderr?: string };
+    expect(e).toBeTruthy();
+    expect(e.code).toBe(3);
+    expect(e.stdout).toBe("partial");
+    expect(e.stderr).toBe("oops");
+  });
+
+  it("rejects when the timeout elapses", async () => {
+    await expect(
+      serverExecFile("sh", ["-c", "sleep 5"], { timeout: 200 })
+    ).rejects.toMatchObject({ killed: true });
+  });
+
+  it("runs in the given cwd and env", async () => {
+    const { stdout } = await serverExecFile("sh", ["-c", "pwd; printf %s \"$PDV_SPAWN_TEST\""], {
+      cwd: path.dirname(__dirname),
+      env: { ...process.env, PDV_SPAWN_TEST: "marker" },
+    });
+    expect(stdout).toContain(fs.realpathSync(path.dirname(__dirname)));
+    expect(stdout).toContain("marker");
+  });
+});
+
+describe("serverSpawn", () => {
+  it("returns a child whose streams and exit code behave like child_process.spawn", async () => {
+    const proc = serverSpawn("sh", ["-c", "printf hello; exit 7"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const chunks: string[] = [];
+    proc.stdout?.on("data", (b: Buffer) => chunks.push(b.toString()));
+    const code = await new Promise<number | null>((resolve) => {
+      proc.on("close", resolve);
+    });
+    expect(chunks.join("")).toBe("hello");
+    expect(code).toBe(7);
+  });
+
+  it("emits an error event (not a throw) when the binary does not exist", async () => {
+    const proc = serverSpawn("/nonexistent/pdv-spawn-test-binary", [], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const err = await new Promise<Error>((resolve) => {
+      proc.on("error", resolve);
+    });
+    expect(err.message).toContain("ENOENT");
+  });
+
+  it("kills the child when the abort signal fires", async () => {
+    const controller = new AbortController();
+    const proc = serverSpawn("sh", ["-c", "sleep 5"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      signal: controller.signal,
+    });
+    const closed = new Promise<number | null>((resolve) => {
+      proc.on("close", resolve);
+    });
+    proc.on("error", () => {
+      /* AbortError is expected; the assertion is that the child dies. */
+    });
+    controller.abort();
+    const code = await closed;
+    expect(code).not.toBe(0);
+  });
+});
+
+describe("spawn seam import guard", () => {
+  /** Matches static imports, type-only imports, and requires of child_process. */
+  const CHILD_PROCESS_IMPORT_RE =
+    /(?:from\s+["'](?:node:)?child_process["'])|(?:require\(\s*["'](?:node:)?child_process["']\s*\))|(?:import\s*\(\s*["'](?:node:)?child_process["']\s*\))/;
+
+  /**
+   * Files allowed to touch child_process directly: the seam itself, and
+   * daemonize.ts — which spawns the pdv-server session daemon (server
+   * infrastructure, never a user tool, so setup-script wrapping must not
+   * apply to it).
+   */
+  const ALLOWED = new Set(["server/spawn.ts", "server/daemonize.ts"]);
+
+  it("no server-destined file imports child_process outside the seam", () => {
+    const offenders = SERVER_DESTINED_FILES.filter((rel) => {
+      if (ALLOWED.has(rel)) return false;
+      const source = fs.readFileSync(path.join(MAIN_DIR, rel), "utf8");
+      return CHILD_PROCESS_IMPORT_RE.test(source);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it("the guard regex is not vacuous (matches real import forms)", () => {
+    expect(CHILD_PROCESS_IMPORT_RE.test('import { spawn } from "child_process";')).toBe(true);
+    expect(CHILD_PROCESS_IMPORT_RE.test('import { execFile } from "node:child_process";')).toBe(true);
+    expect(CHILD_PROCESS_IMPORT_RE.test('const cp = require("child_process");')).toBe(true);
+    expect(CHILD_PROCESS_IMPORT_RE.test('const cp = await import("child_process");')).toBe(true);
+    expect(CHILD_PROCESS_IMPORT_RE.test('import * as path from "path";')).toBe(false);
+  });
+});

--- a/electron/main/server/spawn.ts
+++ b/electron/main/server/spawn.ts
@@ -1,0 +1,106 @@
+/**
+ * spawn.ts — The single subprocess seam for server-side tool execution.
+ *
+ * Every server-destined module that runs an external tool — interpreter
+ * probes, kernel launch, uv/juliaup/Pkg provisioning, git, ps — routes its
+ * subprocess through this module instead of importing `child_process`
+ * directly (enforced by `spawn.test.ts`'s import guard). Centralizing the
+ * spawn point exists for remote mode: this seam is where a Slurm launch
+ * path (`srun`-wrapped kernels, per-host allocation config) can be added
+ * without touching any call site. Login-shell environment (Lmod modules,
+ * the per-host setup script) deliberately does NOT ride here as a per-spawn
+ * wrapper — `login-env.ts` captures it once at daemon startup and applies
+ * it to `process.env`, which every call site already builds from; see that
+ * file's header for why a per-spawn `bash -lc` wrap was rejected.
+ *
+ * Today both helpers are thin, behavior-preserving delegates to
+ * `child_process`: `serverExecFile` keeps promisified `execFile`'s exact
+ * resolution and rejection shapes (callers rely on `stdout`/`stderr` being
+ * attached to the rejection error), and `serverSpawn` returns the raw
+ * `ChildProcess` so callers keep their own streaming, deadline, and
+ * kill logic.
+ *
+ * This file does NOT decide *what* to run or interpret tool output — env
+ * forcing (e.g. `NO_COLOR`, `sanitizedJuliaEnv`), timeouts, and output
+ * parsing stay with the callers. Shell-side spawns (launchers, ssh, the
+ * server supervisor) and `daemonize.ts` (which spawns pdv-server itself,
+ * not a user tool) deliberately do not go through this seam.
+ */
+
+import { execFile, spawn, type ChildProcess } from "child_process";
+import { promisify } from "util";
+
+/** Re-exported so call sites can type children without importing child_process. */
+export type { ChildProcess } from "child_process";
+
+const execFileAsync = promisify(execFile);
+
+/** Options accepted by {@link serverExecFile}. */
+export interface ServerExecFileOptions {
+  /** Kill the process and reject after this many milliseconds. */
+  timeout?: number;
+  /** Working directory for the command. */
+  cwd?: string;
+  /** Full environment for the command (replaces, not merges). */
+  env?: NodeJS.ProcessEnv;
+}
+
+/** Options accepted by {@link serverSpawn}. */
+export interface ServerSpawnOptions {
+  /** Working directory for the command. */
+  cwd?: string;
+  /** Full environment for the command (replaces, not merges). */
+  env?: NodeJS.ProcessEnv;
+  /** stdio disposition; callers virtually always use ["ignore","pipe","pipe"]. */
+  stdio?: Array<"ignore" | "pipe" | "inherit">;
+  /** Kill the process after this many milliseconds. */
+  timeout?: number;
+  /** Abort signal that kills the process when fired. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Run a server-side command to completion and capture its output.
+ *
+ * Identical semantics to `promisify(child_process.execFile)`: resolves with
+ * the decoded `stdout`/`stderr` on exit 0, rejects on non-zero exit,
+ * timeout, or spawn failure with an error that carries the captured
+ * `stdout`/`stderr` fields.
+ *
+ * @param file - Executable path or command name (PATH-resolved).
+ * @param args - Argument vector.
+ * @param options - Timeout / cwd / env options.
+ * @returns The command's decoded standard streams.
+ * @throws {Error} When the command exits non-zero, times out, or cannot be
+ *   spawned; the error object additionally exposes `stdout` and `stderr`.
+ */
+export async function serverExecFile(
+  file: string,
+  args: string[],
+  options?: ServerExecFileOptions
+): Promise<{ stdout: string; stderr: string }> {
+  // Explicit utf8 (the runtime default) selects the string-typed overload
+  // of promisified execFile; behavior is unchanged.
+  return execFileAsync(file, args, { encoding: "utf8" as const, ...options });
+}
+
+/**
+ * Spawn a server-side command and return the live child process.
+ *
+ * Identical semantics to `child_process.spawn`; the caller owns stream
+ * consumption, exit handling, and any deadline/kill logic.
+ *
+ * @param file - Executable path or command name (PATH-resolved).
+ * @param args - Argument vector.
+ * @param options - cwd / env / stdio / timeout / signal options.
+ * @returns The spawned child process.
+ * @throws Never directly — spawn failures surface as an `error` event on
+ *   the returned child.
+ */
+export function serverSpawn(
+  file: string,
+  args: string[],
+  options?: ServerSpawnOptions
+): ChildProcess {
+  return spawn(file, args, options ?? {});
+}

--- a/electron/main/uv-runner.ts
+++ b/electron/main/uv-runner.ts
@@ -25,9 +25,9 @@
  * ARCHITECTURE.md §10.5.6 (the uv binary), §10.5.18 (the uv-runner module)
  */
 
-import { spawn } from "child_process";
 import * as path from "path";
 import * as fs from "fs";
+import { serverSpawn } from "./server/spawn";
 import type { PushSender } from "./server/invoke-registry";
 import { getResourcesRoot } from "./server/server-paths";
 
@@ -168,7 +168,7 @@ export function runUv(args: string[], opts: UvRunOptions = {}): Promise<UvResult
       NO_COLOR: "1",
       UV_NO_PROGRESS: "1",
     };
-    const proc = spawn(binary, args, {
+    const proc = serverSpawn(binary, args, {
       cwd: opts.cwd,
       env: opts.env ? { ...baseEnv, ...opts.env } : baseEnv,
       stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
First PR of the remote-completion series (B1–B6, plan restructured 2026-07-27). Everything remains behind the `PDV_REMOTE=1` gate.

## What this does

**Spawn seam (`main/server/spawn.ts`)** — every server-side subprocess (interpreter probes, kernel launch, uv/juliaup/Pkg, git, ps) now routes through one seam; an import guard keeps it authoritative. Pure delegation today; this is the hook where the Slurm launch path (B5) will rewrite kernel invocations without touching call sites.

**Login-environment capture (`main/server/login-env.ts`)** — a session daemon spawned over an ssh exec channel never ran a login shell, so Lmod modules, juliaup, and conda PATH entries were invisible to it and every kernel it spawned. The daemon now runs one login shell at startup — `bash -lc '. setup.sh >/dev/null 2>&1; env -0 > <file>'` — and applies the captured environment to its own `process.env`, which every spawn call site builds from.

**Design deviation from the plan's per-spawn `bash -lc … exec` wrapper, for cause:** login shells *print* (profile/Lmod chatter lands on stdout before any in-`-c` redirect applies) while interpreter probes regex their captured output for version numbers; and a login shell per spawn costs 100–500 ms across environment-detector's eight probes. One capture per daemon is chatter-immune and latency-flat. `PDV_*`/`ELECTRON_RUN_AS_NODE` are protected from profile override; a failed capture degrades to the inherited environment; the 5 s budget stays inside the attacher's 10 s socket wait.

**Per-host setup script (`main/remote/setup-script.ts`)** — master copy on the laptop at `<userData>/remote-setup/<host>.sh` (hand-editable offline; B3 adds the Settings editor + Test button), shipped atomically at `startSession` *before* the daemon can be created (it is sourced only during the startup capture). A configured script that cannot be delivered fails the session start loudly; deleting the local file un-configures the host (remote copy removed).

## Test plan

- [x] 1684 vitest green; typecheck ×3 silent; lint at the 68-problem develop baseline; knip clean
- [x] Setup-script quoting verified against the OS: the generated ship command is executed through a real `/bin/sh` with `$HOME` redirected and quoting-hostile content byte-compared
- [x] Login-env tests run real login shells (chatter, failing script, timeout, missing bash)
- [x] Fake-ssh e2e 4/4 locally, including a new end-to-end assertion: master copy → shipped byte-identical to the session dir → daemon log confirms the capture sourced it
- [x] Full local Playwright suite green on the seam refactor (1 known pre-existing flake, green in isolation)
- [ ] CI (this PR)
- No `pdv-python/` changes → dependency sweep not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQeyJFAodcNA5dEPGmsTqu